### PR TITLE
Add GitHub workflows to mirror Zig releases

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,52 @@
+name: Check for new Zig release
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # Daily at 08:00 UTC
+  workflow_dispatch: {} # Allow manual triggers
+
+permissions: {}
+
+jobs:
+  check-and-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to push tags
+    outputs:
+      new_versions: ${{ steps.check.outputs.new_versions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-release
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Check for new release
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run scripts/check_zig_release.py
+
+      - name: Create and push tags
+        if: steps.check.outputs.new_versions != ''
+        env:
+          NEW_VERSIONS: ${{ steps.check.outputs.new_versions }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for tag in $(echo "${NEW_VERSIONS}" | jq -r '.[]'); do
+            echo "Creating tag ${tag}"
+            git tag "${tag}"
+            git push origin "${tag}"
+          done
+
+      - name: Trigger publish workflow
+        if: steps.check.outputs.new_versions != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSIONS: ${{ steps.check.outputs.new_versions }}
+        run: |
+          for tag in $(echo "${NEW_VERSIONS}" | jq -r '.[]'); do
+            version="${tag#v}"
+            echo "Triggering publish for ${version}"
+            gh workflow run publish.yml -f version="${version}"
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish Zig Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Zig version to publish (e.g. 0.15.2 or 0.16.0-dev.2962+08416b44f)"
+        required: true
+
+permissions: {}
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-release
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Download Zig assets
+        run: uv run scripts/download_assets.py "${{ inputs.version }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zig-assets
+          path: dist/
+          retention-days: 1
+
+  release:
+    needs: download
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create releases
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: zig-assets
+          path: dist/
+
+      - name: List assets
+        run: ls -lh dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="v${VERSION}"
+
+          # Determine if this is a dev build or stable release
+          if [[ "${VERSION}" == *"-dev."* ]]; then
+            PRERELEASE="--prerelease"
+            TITLE="Zig ${VERSION} (dev)"
+          else
+            PRERELEASE=""
+            TITLE="Zig ${VERSION}"
+          fi
+
+          NOTES="Mirror of Zig ${VERSION} from https://ziglang.org/download/
+
+          Assets downloaded from ziglang.org with SHA256 verification.
+          Minisig signatures are included for additional verification.
+
+          Original release: https://ziglang.org/download/#${VERSION}"
+
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TITLE}" \
+            --notes "${NOTES}" \
+            ${PRERELEASE} \
+            dist/*

--- a/scripts/check_zig_release.py
+++ b/scripts/check_zig_release.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check for new Zig releases and signal when a new tag should be created."""
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests"]
+# ///
+
+import json
+import logging
+import os
+import sys
+
+import requests  # type: ignore[import-untyped]
+
+INDEX_URL = "https://ziglang.org/download/index.json"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+
+def github_headers() -> dict[str, str]:
+    """Build headers for GitHub API requests."""
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def tag_exists(repo: str, tag: str) -> bool:
+    """Check if a git tag already exists in our repository."""
+    url = f"https://api.github.com/repos/{repo}/git/ref/tags/{tag}"
+    resp = requests.get(url, headers=github_headers(), timeout=30)
+    if resp.status_code == 200:
+        return True
+    if resp.status_code == 404:
+        return False
+    resp.raise_for_status()
+    return False
+
+
+def set_github_output(name: str, value: str) -> None:
+    """Write a key=value pair to $GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+    else:
+        log.info("GITHUB_OUTPUT not set (running locally?); would set %s=%s", name, value)
+
+
+def fetch_index() -> dict:
+    """Fetch the Zig download index."""
+    resp = requests.get(INDEX_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> None:
+    our_repo = os.environ.get("GITHUB_REPOSITORY", "cataggar/zig")
+    log.info("Checking for new Zig releases...")
+
+    index = fetch_index()
+    new_versions: list[str] = []
+
+    for key, release in index.items():
+        version = release.get("version", "")
+        if not version:
+            # Older releases use the key as the version
+            version = key
+
+        # Skip if it looks like "master" and has no real version
+        if version == "master":
+            continue
+
+        # For stable releases, tag as "v0.15.2"; for dev builds, "v0.16.0-dev.2962+08416b44f"
+        tag_name = f"v{version}"
+
+        if tag_exists(our_repo, tag_name):
+            log.info("Tag %s already exists — skipping", tag_name)
+            continue
+
+        # Check that the release has at least some platform tarballs
+        platform_count = sum(1 for k in release if k not in ("version", "date", "docs", "stdDocs", "src", "bootstrap", "notes"))
+        if platform_count < 3:
+            log.warning("Release %s has only %d platforms — skipping", version, platform_count)
+            continue
+
+        log.info("New release found: %s (%d platforms)", version, platform_count)
+        new_versions.append(tag_name)
+
+    if not new_versions:
+        log.info("No new releases found")
+        set_github_output("new_versions", "")
+        return
+
+    # Output as JSON array for matrix strategy
+    versions_json = json.dumps(new_versions)
+    log.info("New versions to publish: %s", versions_json)
+    set_github_output("new_versions", versions_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_assets.py
+++ b/scripts/download_assets.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Download Zig release assets and create a GitHub release."""
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests"]
+# ///
+
+import hashlib
+import logging
+import os
+import sys
+from pathlib import Path
+
+import requests  # type: ignore[import-untyped]
+
+INDEX_URL = "https://ziglang.org/download/index.json"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+
+def download_file(url: str, dest: Path) -> None:
+    """Download a file with progress logging."""
+    log.info("  Downloading %s ...", dest.name)
+    resp = requests.get(url, stream=True, timeout=600)
+    resp.raise_for_status()
+    total = int(resp.headers.get("content-length", 0))
+    downloaded = 0
+    with open(dest, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8 * 1024 * 1024):
+            f.write(chunk)
+            downloaded += len(chunk)
+            if total > 0:
+                pct = downloaded * 100 // total
+                mb = downloaded // (1024 * 1024)
+                log.info("    %d MB (%d%%)", mb, pct)
+    log.info("  Saved %s (%d MB)", dest.name, dest.stat().st_size // (1024 * 1024))
+
+
+def verify_shasum(path: Path, expected: str) -> bool:
+    """Verify SHA256 checksum of a downloaded file."""
+    sha256 = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            sha256.update(chunk)
+    actual = sha256.hexdigest()
+    if actual != expected:
+        log.error("  SHA256 MISMATCH for %s: expected %s, got %s", path.name, expected, actual)
+        return False
+    log.info("  SHA256 OK: %s", path.name)
+    return True
+
+
+def fetch_index() -> dict:
+    """Fetch the Zig download index."""
+    resp = requests.get(INDEX_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def find_release(index: dict, version: str) -> dict | None:
+    """Find the release entry matching a version string."""
+    for key, release in index.items():
+        v = release.get("version", key)
+        if v == version:
+            return release
+    return None
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>")
+        print(f"Example: {sys.argv[0]} 0.15.2")
+        sys.exit(1)
+
+    version = sys.argv[1]
+    dist_dir = Path("dist")
+    dist_dir.mkdir(exist_ok=True)
+
+    log.info("Fetching Zig download index...")
+    index = fetch_index()
+
+    release = find_release(index, version)
+    if release is None:
+        log.error("Version %s not found in index", version)
+        sys.exit(1)
+
+    # Metadata keys (not platform entries)
+    meta_keys = {"version", "date", "docs", "stdDocs", "notes"}
+    platform_keys = [k for k in release if k not in meta_keys]
+
+    log.info("Downloading assets for Zig %s (%d entries)\n", version, len(platform_keys))
+
+    failed: list[str] = []
+
+    for key in platform_keys:
+        entry = release[key]
+        tarball_url = entry["tarball"]
+        shasum = entry.get("shasum", "")
+        filename = tarball_url.rsplit("/", 1)[-1]
+        dest = dist_dir / filename
+
+        log.info("[%s]", key)
+
+        try:
+            # Download the archive
+            if dest.exists() and shasum and verify_shasum(dest, shasum):
+                log.info("  Already downloaded and verified, skipping")
+            else:
+                download_file(tarball_url, dest)
+                if shasum and not verify_shasum(dest, shasum):
+                    failed.append(filename)
+                    continue
+
+            # Download the minisig signature
+            minisig_url = tarball_url + ".minisig"
+            minisig_dest = dist_dir / (filename + ".minisig")
+            if not minisig_dest.exists():
+                download_file(minisig_url, minisig_dest)
+
+        except Exception as e:
+            log.error("  FAILED: %s", e)
+            failed.append(filename)
+
+        log.info("")
+
+    if failed:
+        log.error("%d downloads failed: %s", len(failed), failed)
+        sys.exit(1)
+
+    # List all downloaded files
+    files = sorted(dist_dir.iterdir())
+    total_size = sum(f.stat().st_size for f in files)
+    log.info("Done! %d files in %s/ (%.1f GB total)", len(files), dist_dir, total_size / (1024**3))
+    for f in files:
+        log.info("  %s (%.1f MB)", f.name, f.stat().st_size / (1024**2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- check-release.yml: daily cron checks ziglang.org/download/index.json
- publish.yml: downloads all platform assets + minisig, creates GitHub release
- scripts/check_zig_release.py: detects new stable + dev versions
- scripts/download_assets.py: downloads + SHA256-verifies all platforms