### PR TITLE
libzigc: migrate setsid to Zig

### DIFF
--- a/lib/c/unistd.zig
+++ b/lib/c/unistd.zig
@@ -47,6 +47,8 @@ comptime {
         symbol(&unlinkatLinux, "unlinkat");
 
         symbol(&execveLinux, "execve");
+
+        symbol(&setsidLinux, "setsid");
     }
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
         symbol(&swab, "swab");
@@ -191,6 +193,10 @@ fn unlinkatLinux(fd: c_int, path: [*:0]const c_char, flags: c_int) callconv(.c) 
 
 fn execveLinux(path: [*:0]const c_char, argv: [*:null]const ?[*:0]c_char, envp: [*:null]const ?[*:0]c_char) callconv(.c) c_int {
     return errno(linux.execve(@ptrCast(path), @ptrCast(argv), @ptrCast(envp)));
+}
+
+fn setsidLinux() callconv(.c) linux.pid_t {
+    return errno(linux.setsid());
 }
 
 fn swab(noalias src_ptr: *const anyopaque, noalias dest_ptr: *anyopaque, n: isize) callconv(.c) void {

--- a/lib/libc/musl/src/unistd/setsid.c
+++ b/lib/libc/musl/src/unistd/setsid.c
@@ -1,7 +1,0 @@
-#include <unistd.h>
-#include "syscall.h"
-
-pid_t setsid(void)
-{
-	return syscall(SYS_setsid);
-}

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -1824,7 +1824,6 @@ const src_files = [_][]const u8{
     "musl/src/unistd/setresgid.c",
     "musl/src/unistd/setresuid.c",
     "musl/src/unistd/setreuid.c",
-    "musl/src/unistd/setsid.c",
     "musl/src/unistd/setuid.c",
     "musl/src/unistd/setxid.c",
     "musl/src/unistd/sleep.c",


### PR DESCRIPTION
Replace setsid() with native Zig implementation in lib/c/unistd.zig. Single syscall wrapper following the established errno(linux.setsid()) pattern.

Delete musl C source, remove from musl.zig.