### PR TITLE
libzigc: migrate atof to Zig

### DIFF
--- a/lib/c/stdlib.zig
+++ b/lib/c/stdlib.zig
@@ -44,6 +44,11 @@ comptime {
         symbol(&qsort, "qsort");
 
         symbol(&bsearch, "bsearch");
+
+        if (builtin.link_libc) {
+            // atof depends on strtod from the C library.
+            symbol(&atof, "atof");
+        }
     }
 }
 
@@ -393,4 +398,8 @@ test bsearch {
     for (items) |*value| {
         try std.testing.expectEqual(@as(*const anyopaque, value), bsearch(value, items.ptr, items.len, @sizeOf(u16), Comparison.compare));
     }
+}
+
+fn atof(s: [*:0]const u8) callconv(.c) f64 {
+    return std.c.strtod(s, null);
 }

--- a/lib/libc/musl/src/stdlib/atof.c
+++ b/lib/libc/musl/src/stdlib/atof.c
@@ -1,6 +1,0 @@
-#include <stdlib.h>
-
-double atof(const char *s)
-{
-	return strtod(s, 0);
-}

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -1521,7 +1521,6 @@ const src_files = [_][]const u8{
     "musl/src/stdio/vwscanf.c",
     "musl/src/stdio/wprintf.c",
     "musl/src/stdio/wscanf.c",
-    "musl/src/stdlib/atof.c",
     "musl/src/stdlib/ecvt.c",
     "musl/src/stdlib/fcvt.c",
     "musl/src/stdlib/gcvt.c",

--- a/src/libs/wasi_libc.zig
+++ b/src/libs/wasi_libc.zig
@@ -915,7 +915,6 @@ const libc_top_half_src_files = [_][]const u8{
     "musl/src/stdio/vwscanf.c",
     "musl/src/stdio/wprintf.c",
     "musl/src/stdio/wscanf.c",
-    "musl/src/stdlib/atof.c",
     "musl/src/stdlib/ecvt.c",
     "musl/src/stdlib/fcvt.c",
     "musl/src/stdlib/gcvt.c",


### PR DESCRIPTION
Replace atof() with native Zig implementation in lib/c/stdlib.zig. Delegates to strtod(s, NULL) matching the musl behavior exactly.

Export gated on builtin.link_libc since it depends on strtod. Delete musl C source, remove from musl.zig and wasi_libc.zig.