### PR TITLE
libzigc: migrate _Exit to Zig

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -63,6 +63,7 @@ pub fn errno(syscall_return_value: usize) c_int {
 
 comptime {
     _ = @import("c/ctype.zig");
+    _ = @import("c/exit.zig");
     _ = @import("c/fcntl.zig");
     _ = @import("c/inttypes.zig");
     if (!builtin.target.isMinGW()) {

--- a/lib/c/exit.zig
+++ b/lib/c/exit.zig
@@ -1,0 +1,15 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const linux = std.os.linux;
+
+const symbol = @import("../c.zig").symbol;
+
+comptime {
+    if (builtin.target.isMuslLibC()) {
+        symbol(&_Exit, "_Exit");
+    }
+}
+
+fn _Exit(ec: c_int) callconv(.c) noreturn {
+    linux.exit_group(ec);
+}

--- a/lib/libc/musl/src/exit/_Exit.c
+++ b/lib/libc/musl/src/exit/_Exit.c
@@ -1,8 +1,0 @@
-#include <stdlib.h>
-#include "syscall.h"
-
-_Noreturn void _Exit(int ec)
-{
-	__syscall(SYS_exit_group, ec);
-	for (;;) __syscall(SYS_exit, ec);
-}

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -583,7 +583,6 @@ const src_files = [_][]const u8{
     "musl/src/exit/atexit.c",
     "musl/src/exit/at_quick_exit.c",
     "musl/src/exit/exit.c",
-    "musl/src/exit/_Exit.c",
     "musl/src/exit/quick_exit.c",
     "musl/src/fcntl/creat.c",
     "musl/src/fcntl/fcntl.c",


### PR DESCRIPTION
Migrate `_Exit` from exit category to `lib/c/exit.zig`. Calls `linux.exit_group()` directly.

Partial progress on #10 (Session 3: exit category).