### PR TITLE
codegen: zero-init payload of null optionals in constant data

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -456,10 +456,13 @@ pub fn generateSymbol(
             } else {
                 const padding = abi_size - (math.cast(usize, payload_type.abiSize(zcu)) orelse return error.Overflow) - 1;
                 if (payload_type.hasRuntimeBits(zcu)) {
-                    const value = payload_val orelse Value.fromInterned(try pt.intern(.{
-                        .undef = payload_type.toIntern(),
-                    }));
-                    try generateSymbol(bin_file, pt, src_loc, value, w, reloc_parent);
+                    if (payload_val) |value| {
+                        try generateSymbol(bin_file, pt, src_loc, value, w, reloc_parent);
+                    } else {
+                        // Zero-initialize the payload for null optionals so that
+                        // constant data is deterministic (not 0xAA).
+                        try w.splatByteAll(0, math.cast(usize, payload_type.abiSize(zcu)) orelse return error.Overflow);
+                    }
                 }
                 try w.writeByte(@intFromBool(payload_val != null));
                 try w.splatByteAll(0, padding);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3651,10 +3651,12 @@ pub const Object = struct {
 
                 var fields: [3]Builder.Type = undefined;
                 var vals: [3]Builder.Constant = undefined;
-                vals[0] = try o.lowerValue(pt, switch (opt.val) {
-                    .none => try pt.intern(.{ .undef = payload_ty.toIntern() }),
-                    else => |payload| payload,
-                });
+                vals[0] = switch (opt.val) {
+                    // Zero-initialize the payload for null optionals so that
+                    // constant data in .rodata is deterministic (not 0xAA).
+                    .none => try o.builder.zeroInitConst(try o.lowerType(pt, payload_ty)),
+                    else => |payload| try o.lowerValue(pt, payload),
+                };
                 vals[1] = non_null_bit;
                 fields[0] = vals[0].typeOf(&o.builder);
                 fields[1] = vals[1].typeOf(&o.builder);


### PR DESCRIPTION
## Summary

Fixes #137

When lowering a null optional with struct representation (payload + flag) to constant data, the payload field was set to `undef`. For the LLVM backend, LLVM could materialize `undef` as `0xAA` bytes in `.rodata`. For the native backend, `undef` was explicitly filled with `0xAA`.

This caused issues when C code read the constant data expecting null pointers (8 bytes of zeros) but found `0xAA` bytes instead.

## Changes

**`src/codegen/llvm.zig`** — In the `.opt` case of `lowerValue`, when `opt.val == .none`, use `zeroInitConst` for the payload instead of interning an `undef` value.

**`src/codegen.zig`** — In the `generateSymbol` `.opt` case, when `payload_val` is null, zero-fill the payload bytes instead of creating an `undef` value (which gets filled with `0xAA`).

## Rationale

The payload of a null optional is semantically irrelevant (the flag byte indicates null), so using zeros is safe and produces deterministic output. This matches the existing behavior for payload-repr optionals (line 454: `splatByteAll(0, abi_size)`).