### PR TITLE
lld: exclude libunwind symbols from dynamic export in ELF

### DIFF
--- a/src/link/Lld.zig
+++ b/src/link/Lld.zig
@@ -1183,6 +1183,13 @@ fn elfLink(lld: *Lld, arena: Allocator) !void {
             // libunwind dep
             if (comp.config.link_libunwind) {
                 try argv.append(try comp.libunwind_static_lib.?.full_object_path.toString(arena));
+                // Prevent libunwind's _Unwind_* symbols from being globally
+                // visible. Without this, the static libunwind symbols can
+                // shadow libgcc_s.so's versions, breaking C++ exception
+                // handling in mixed C++/Zig binaries linked with `zig cc`.
+                if (is_exe_or_dyn_lib) {
+                    try argv.append("--exclude-libs=libunwind.a");
+                }
             }
 
             // libc dep


### PR DESCRIPTION
## Summary

Fixes #146

When `zig cc` links a mixed C++/Zig binary, Zig's bundled static libunwind provides `_Unwind_RaiseException` and other `_Unwind_*` functions. These symbols can shadow `libgcc_s.so`'s versions during dynamic symbol resolution, breaking C++ exception handling (`throw`/`catch` segfaults) in binaries that use `libstdc++.so`.

## Root Cause Analysis

When `-lgcc_s` is passed to `zig cc`, it is [replaced](https://github.com/ctaggart/zig/blob/master/src/target.zig#L349-L355) by Zig's own static `libunwind.a` + `compiler_rt`. While libunwind is compiled with `-D_LIBUNWIND_HIDE_SYMBOLS -fvisibility=hidden`, the `_Unwind_*` symbols from the static archive can still participate in symbol interposition during ELF linking. When `libstdc++.so`'s `__cxa_throw` resolves `_Unwind_RaiseException` to the local version instead of `libgcc_s.so`'s version, it can crash because the two unwinder implementations have subtle runtime incompatibilities (different `dl_iterate_phdr` behaviors, different LSDA pointer resolution, etc.).

The bundled LLVM libunwind's C code (`lib/libunwind/src/UnwindLevel1.c`) IS fully C++-compatible — it properly implements the Itanium two-phase unwinding protocol with LSDA and personality function support. The issue is purely about symbol visibility in the linked output, not about the unwinder implementation itself.

## Change

In `src/link/Lld.zig`, when linking the static libunwind for ELF executables or shared libraries, pass `--exclude-libs=libunwind.a` to LLD. This forces all symbols from the libunwind archive to be `STB_LOCAL` in the output, preventing them from being used by shared libraries like `libstdc++.so`. Those libraries instead resolve `_Unwind_*` from `libgcc_s.so` (loaded transitively via `libstdc++.so`'s `DT_NEEDED`).

## Effect

- **Mixed C++/Zig binaries**: `libstdc++.so` uses `libgcc_s.so`'s unwinder (compatible with GCC's personality functions)
- **Pure Zig binaries**: The local libunwind is still available for Zig's own stack unwinding
- **No behavioral change** for statically-linked binaries (`--exclude-libs` only affects dynamic symbol table)