### PR TITLE
libzigc: migrate 7 ldso stub functions from C to Zig

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -65,6 +65,7 @@ comptime {
     _ = @import("c/ctype.zig");
     _ = @import("c/fcntl.zig");
     _ = @import("c/inttypes.zig");
+    _ = @import("c/ldso.zig");
     if (!builtin.target.isMinGW()) {
         _ = @import("c/malloc.zig");
     }

--- a/lib/c/ldso.zig
+++ b/lib/c/ldso.zig
@@ -1,0 +1,77 @@
+const builtin = @import("builtin");
+const symbol = @import("../c.zig").symbol;
+
+comptime {
+    if (builtin.target.isMuslLibC()) {
+        // Self-contained stubs (no C library dependencies).
+        symbol(&dladdr, "dladdr");
+        symbol(&__tlsdesc_static, "__tlsdesc_static");
+        symbol(&__tlsdesc_static, "__tlsdesc_dynamic");
+
+        // Functions with C library dependencies (dlerror.c provides
+        // __dl_seterr and __dl_invalid_handle).
+        if (builtin.link_libc) {
+            symbol(&dlclose, "dlclose");
+            symbol(&dlinfo, "dlinfo");
+            symbol(&dlopen, "dlopen");
+            symbol(&dlsym, "dlsym");
+            symbol(&__dlsym_stub, "__dlsym");
+            if (@sizeOf(c_long) < 8) {
+                symbol(&__dlsym_stub, "__dlsym_redir_time64");
+            }
+        }
+    }
+}
+
+const RTLD_DI_LINKMAP = 2;
+
+// Self-contained stubs that return stub values. The dynamic linker
+// overrides these with real implementations when present.
+
+fn dladdr(addr: ?*const anyopaque, info: ?*anyopaque) callconv(.c) c_int {
+    _ = addr;
+    _ = info;
+    return 0;
+}
+
+fn __tlsdesc_static() callconv(.c) isize {
+    return 0;
+}
+
+// Functions depending on C library symbols from dlerror.c.
+
+extern fn __dl_seterr([*:0]const u8, ...) callconv(.c) void;
+extern fn __dl_invalid_handle(?*anyopaque) callconv(.c) c_int;
+
+fn dlclose(p: ?*anyopaque) callconv(.c) c_int {
+    return __dl_invalid_handle(p);
+}
+
+fn dlinfo(dso: ?*anyopaque, req: c_int, res: ?*anyopaque) callconv(.c) c_int {
+    if (__dl_invalid_handle(dso) != 0) return -1;
+    if (req != RTLD_DI_LINKMAP) {
+        __dl_seterr("Unsupported request %d", req);
+        return -1;
+    }
+    const ptr: *?*anyopaque = @ptrCast(@alignCast(res));
+    ptr.* = dso;
+    return 0;
+}
+
+fn dlopen(file: ?[*:0]const u8, mode: c_int) callconv(.c) ?*anyopaque {
+    _ = file;
+    _ = mode;
+    __dl_seterr("Dynamic loading not supported");
+    return null;
+}
+
+fn dlsym(p: ?*anyopaque, s: ?[*:0]const u8) callconv(.c) ?*anyopaque {
+    return __dlsym_stub(p, s, null);
+}
+
+fn __dlsym_stub(p: ?*anyopaque, s: ?[*:0]const u8, ra: ?*anyopaque) callconv(.c) ?*anyopaque {
+    _ = p;
+    _ = ra;
+    __dl_seterr("Symbol not found: %s", s);
+    return null;
+}

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -650,14 +650,14 @@ const src_files = [_][]const u8{
     "musl/src/ldso/arm/dlsym_time64.S",
     "musl/src/ldso/arm/find_exidx.c",
     "musl/src/ldso/arm/tlsdesc.S",
-    "musl/src/ldso/dladdr.c",
-    "musl/src/ldso/dlclose.c",
+    //"musl/src/ldso/dladdr.c", // migrated to lib/c/ldso.zig
+    //"musl/src/ldso/dlclose.c", // migrated to lib/c/ldso.zig
     "musl/src/ldso/dlerror.c",
-    "musl/src/ldso/dlinfo.c",
+    //"musl/src/ldso/dlinfo.c", // migrated to lib/c/ldso.zig
     "musl/src/ldso/dl_iterate_phdr.c",
-    "musl/src/ldso/dlopen.c",
-    "musl/src/ldso/__dlsym.c",
-    "musl/src/ldso/dlsym.c",
+    //"musl/src/ldso/dlopen.c", // migrated to lib/c/ldso.zig
+    //"musl/src/ldso/__dlsym.c", // migrated to lib/c/ldso.zig
+    //"musl/src/ldso/dlsym.c", // migrated to lib/c/ldso.zig
     "musl/src/ldso/i386/dlsym.s",
     "musl/src/ldso/i386/dlsym_time64.S",
     "musl/src/ldso/i386/tlsdesc.s",
@@ -676,7 +676,7 @@ const src_files = [_][]const u8{
     "musl/src/ldso/riscv64/dlsym.s",
     "musl/src/ldso/riscv64/tlsdesc.s",
     "musl/src/ldso/s390x/dlsym.s",
-    "musl/src/ldso/tlsdesc.c",
+    //"musl/src/ldso/tlsdesc.c", // migrated to lib/c/ldso.zig
     "musl/src/ldso/x32/dlsym.s",
     "musl/src/ldso/x86_64/dlsym.s",
     "musl/src/ldso/x86_64/tlsdesc.s",


### PR DESCRIPTION
Migrate 7 of 10 musl ldso C files to lib/c/ldso.zig.

**Migrated (trivial stubs):**
- `dladdr.c` — stub returning 0
- `dlclose.c` — calls `__dl_invalid_handle`
- `dlinfo.c` — validates handle, checks `RTLD_DI_LINKMAP`
- `dlopen.c` — stub with error message
- `dlsym.c` — delegates to `__dlsym`
- `__dlsym.c` — stub with error message (includes time64 redirect)
- `tlsdesc.c` — returns 0, weak alias for `__tlsdesc_dynamic`

These are weak stubs overridden by the dynamic linker when present. Functions depending on `__dl_seterr`/`__dl_invalid_handle` from `dlerror.c` are gated behind `builtin.link_libc`.

**Remaining (complex, for future PRs):**
- `dlerror.c` — pthread internals, atomics, malloc, vsnprintf
- `dl_iterate_phdr.c` — ELF structures, auxv, TLS
- `arm/find_exidx.c` — ARM-specific ELF unwinding

Part of #10