### PR TITLE
libzigc: migrate 14 thread C files to Zig (destroy, concurrency, equal)

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -81,6 +81,7 @@ comptime {
     _ = @import("c/sys/reboot.zig");
     _ = @import("c/sys/utsname.zig");
 
+    _ = @import("c/thread.zig");
     _ = @import("c/unistd.zig");
     _ = @import("c/wchar.zig");
 }

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -1,0 +1,119 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const symbol = @import("../c.zig").symbol;
+
+const E = std.os.linux.E;
+
+comptime {
+    if (builtin.target.isMuslLibC()) {
+        // Destroy functions (all return 0, releasing no resources)
+        symbol(&pthread_attr_destroy, "pthread_attr_destroy");
+        symbol(&pthread_mutexattr_destroy, "pthread_mutexattr_destroy");
+        symbol(&pthread_condattr_destroy, "pthread_condattr_destroy");
+        symbol(&pthread_rwlockattr_destroy, "pthread_rwlockattr_destroy");
+        symbol(&pthread_barrierattr_destroy, "pthread_barrierattr_destroy");
+        symbol(&pthread_spin_destroy, "pthread_spin_destroy");
+        symbol(&pthread_rwlock_destroy, "pthread_rwlock_destroy");
+        symbol(&sem_destroy, "sem_destroy");
+
+        // Concurrency stubs (no-ops on Linux, which always uses 1:1 threading)
+        symbol(&pthread_getconcurrency, "pthread_getconcurrency");
+        symbol(&pthread_setconcurrency, "pthread_setconcurrency");
+
+        // Priority ceiling not supported by musl
+        symbol(&pthread_mutex_getprioceiling, "pthread_mutex_getprioceiling");
+
+        // C11 thread destroy stubs (no-ops for private objects)
+        symbol(&cnd_destroy, "cnd_destroy");
+        symbol(&mtx_destroy, "mtx_destroy");
+
+        // Thread comparison
+        symbol(&pthread_equal, "pthread_equal");
+        symbol(&pthread_equal, "thrd_equal");
+    }
+}
+
+// All pthread/semaphore destroy functions return 0 because musl's
+// implementations hold no dynamically-allocated resources.
+
+fn pthread_attr_destroy(a: ?*anyopaque) callconv(.c) c_int {
+    _ = a;
+    return 0;
+}
+
+fn pthread_mutexattr_destroy(a: ?*anyopaque) callconv(.c) c_int {
+    _ = a;
+    return 0;
+}
+
+fn pthread_condattr_destroy(a: ?*anyopaque) callconv(.c) c_int {
+    _ = a;
+    return 0;
+}
+
+fn pthread_rwlockattr_destroy(a: ?*anyopaque) callconv(.c) c_int {
+    _ = a;
+    return 0;
+}
+
+fn pthread_barrierattr_destroy(a: ?*anyopaque) callconv(.c) c_int {
+    _ = a;
+    return 0;
+}
+
+fn pthread_spin_destroy(s: ?*anyopaque) callconv(.c) c_int {
+    _ = s;
+    return 0;
+}
+
+fn pthread_rwlock_destroy(rw: ?*anyopaque) callconv(.c) c_int {
+    _ = rw;
+    return 0;
+}
+
+fn sem_destroy(sem: ?*anyopaque) callconv(.c) c_int {
+    _ = sem;
+    return 0;
+}
+
+// Linux always uses 1:1 threading; concurrency hints are no-ops.
+
+fn pthread_getconcurrency() callconv(.c) c_int {
+    return 0;
+}
+
+fn pthread_setconcurrency(val: c_int) callconv(.c) c_int {
+    if (val < 0) return eint(.INVAL);
+    if (val > 0) return eint(.AGAIN);
+    return 0;
+}
+
+// Priority ceiling is not supported by musl.
+
+fn pthread_mutex_getprioceiling(m: ?*const anyopaque, ceiling: ?*c_int) callconv(.c) c_int {
+    _ = m;
+    _ = ceiling;
+    return eint(.INVAL);
+}
+
+// C11 thread destroy stubs.
+
+fn cnd_destroy(c: ?*anyopaque) callconv(.c) void {
+    _ = c;
+}
+
+fn mtx_destroy(mtx: ?*anyopaque) callconv(.c) void {
+    _ = mtx;
+}
+
+// Thread identity comparison.
+
+fn pthread_equal(a: std.c.pthread_t, b: std.c.pthread_t) callconv(.c) c_int {
+    return @intCast(@intFromBool(a == b));
+}
+
+/// Convert a Linux errno enum value to a positive c_int for direct return
+/// from POSIX thread functions (which return error numbers, not -1).
+fn eint(e: E) c_int {
+    return @intCast(@intFromEnum(e));
+}

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -1568,7 +1568,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/call_once.c",
     "musl/src/thread/clone.c",
     "musl/src/thread/cnd_broadcast.c",
-    "musl/src/thread/cnd_destroy.c",
+    //"musl/src/thread/cnd_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/cnd_init.c",
     "musl/src/thread/cnd_signal.c",
     "musl/src/thread/cnd_timedwait.c",
@@ -1601,7 +1601,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/mipsn32/__unmapself.s",
     "musl/src/thread/mips/syscall_cp.s",
     "musl/src/thread/mips/__unmapself.s",
-    "musl/src/thread/mtx_destroy.c",
+    //"musl/src/thread/mtx_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/mtx_init.c",
     "musl/src/thread/mtx_lock.c",
     "musl/src/thread/mtx_timedlock.c",
@@ -1616,7 +1616,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/powerpc/syscall_cp.s",
     "musl/src/thread/powerpc/__unmapself.s",
     "musl/src/thread/pthread_atfork.c",
-    "musl/src/thread/pthread_attr_destroy.c",
+    //"musl/src/thread/pthread_attr_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_attr_get.c",
     "musl/src/thread/pthread_attr_init.c",
     "musl/src/thread/pthread_attr_setdetachstate.c",
@@ -1627,7 +1627,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_attr_setscope.c",
     "musl/src/thread/pthread_attr_setstack.c",
     "musl/src/thread/pthread_attr_setstacksize.c",
-    "musl/src/thread/pthread_barrierattr_destroy.c",
+    //"musl/src/thread/pthread_barrierattr_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_barrierattr_init.c",
     "musl/src/thread/pthread_barrierattr_setpshared.c",
     "musl/src/thread/pthread_barrier_destroy.c",
@@ -1635,7 +1635,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_barrier_wait.c",
     "musl/src/thread/pthread_cancel.c",
     "musl/src/thread/pthread_cleanup_push.c",
-    "musl/src/thread/pthread_condattr_destroy.c",
+    //"musl/src/thread/pthread_condattr_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_condattr_init.c",
     "musl/src/thread/pthread_condattr_setclock.c",
     "musl/src/thread/pthread_condattr_setpshared.c",
@@ -1647,9 +1647,9 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_cond_wait.c",
     "musl/src/thread/pthread_create.c",
     "musl/src/thread/pthread_detach.c",
-    "musl/src/thread/pthread_equal.c",
+    //"musl/src/thread/pthread_equal.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_getattr_np.c",
-    "musl/src/thread/pthread_getconcurrency.c",
+    //"musl/src/thread/pthread_getconcurrency.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_getcpuclockid.c",
     "musl/src/thread/pthread_getname_np.c",
     "musl/src/thread/pthread_getschedparam.c",
@@ -1657,7 +1657,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_join.c",
     "musl/src/thread/pthread_key_create.c",
     "musl/src/thread/pthread_kill.c",
-    "musl/src/thread/pthread_mutexattr_destroy.c",
+    //"musl/src/thread/pthread_mutexattr_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutexattr_init.c",
     "musl/src/thread/pthread_mutexattr_setprotocol.c",
     "musl/src/thread/pthread_mutexattr_setpshared.c",
@@ -1665,7 +1665,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_mutexattr_settype.c",
     "musl/src/thread/pthread_mutex_consistent.c",
     "musl/src/thread/pthread_mutex_destroy.c",
-    "musl/src/thread/pthread_mutex_getprioceiling.c",
+    //"musl/src/thread/pthread_mutex_getprioceiling.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutex_init.c",
     "musl/src/thread/pthread_mutex_lock.c",
     "musl/src/thread/pthread_mutex_setprioceiling.c",
@@ -1673,10 +1673,10 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_mutex_trylock.c",
     "musl/src/thread/pthread_mutex_unlock.c",
     "musl/src/thread/pthread_once.c",
-    "musl/src/thread/pthread_rwlockattr_destroy.c",
+    //"musl/src/thread/pthread_rwlockattr_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_rwlockattr_init.c",
     "musl/src/thread/pthread_rwlockattr_setpshared.c",
-    "musl/src/thread/pthread_rwlock_destroy.c",
+    //"musl/src/thread/pthread_rwlock_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_rwlock_init.c",
     "musl/src/thread/pthread_rwlock_rdlock.c",
     "musl/src/thread/pthread_rwlock_timedrdlock.c",
@@ -1689,13 +1689,13 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_setattr_default_np.c",
     "musl/src/thread/pthread_setcancelstate.c",
     "musl/src/thread/pthread_setcanceltype.c",
-    "musl/src/thread/pthread_setconcurrency.c",
+    //"musl/src/thread/pthread_setconcurrency.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_setname_np.c",
     "musl/src/thread/pthread_setschedparam.c",
     "musl/src/thread/pthread_setschedprio.c",
     "musl/src/thread/pthread_setspecific.c",
     "musl/src/thread/pthread_sigmask.c",
-    "musl/src/thread/pthread_spin_destroy.c",
+    //"musl/src/thread/pthread_spin_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_spin_init.c",
     "musl/src/thread/pthread_spin_lock.c",
     "musl/src/thread/pthread_spin_trylock.c",
@@ -1714,7 +1714,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/s390x/syscall_cp.s",
     "musl/src/thread/s390x/__tls_get_offset.s",
     "musl/src/thread/s390x/__unmapself.s",
-    "musl/src/thread/sem_destroy.c",
+    //"musl/src/thread/sem_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/sem_getvalue.c",
     "musl/src/thread/sem_init.c",
     "musl/src/thread/sem_open.c",


### PR DESCRIPTION
Migrate the simplest thread functions from musl C to `lib/c/thread.zig`:

**Destroy functions** (all return 0, no resources to release):
- pthread_attr_destroy, pthread_mutexattr_destroy, pthread_condattr_destroy
- pthread_rwlockattr_destroy, pthread_barrierattr_destroy
- pthread_spin_destroy, pthread_rwlock_destroy, sem_destroy

**C11 thread destroy stubs** (no-ops):
- cnd_destroy, mtx_destroy

**Concurrency stubs** (Linux uses 1:1 threading):
- pthread_getconcurrency (always returns 0)
- pthread_setconcurrency (validates input)

**Other trivial functions:**
- pthread_mutex_getprioceiling (always EINVAL, not supported)
- pthread_equal / thrd_equal (pointer comparison)

Part of #10 - thread category (14 of 131 C files)