### PR TITLE
libzigc: migrate 12 more thread C files to Zig (attr init/set)

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -30,6 +30,22 @@ comptime {
         // Thread comparison
         symbol(&pthread_equal, "pthread_equal");
         symbol(&pthread_equal, "thrd_equal");
+
+        // Attribute init functions (zero-initialize)
+        symbol(&pthread_mutexattr_init, "pthread_mutexattr_init");
+        symbol(&pthread_condattr_init, "pthread_condattr_init");
+        symbol(&pthread_rwlockattr_init, "pthread_rwlockattr_init");
+        symbol(&pthread_barrierattr_init, "pthread_barrierattr_init");
+        symbol(&pthread_spin_init, "pthread_spin_init");
+
+        // Attribute set functions
+        symbol(&pthread_mutexattr_settype, "pthread_mutexattr_settype");
+        symbol(&pthread_mutexattr_setpshared, "pthread_mutexattr_setpshared");
+        symbol(&pthread_condattr_setclock, "pthread_condattr_setclock");
+        symbol(&pthread_condattr_setpshared, "pthread_condattr_setpshared");
+        symbol(&pthread_rwlockattr_setpshared, "pthread_rwlockattr_setpshared");
+        symbol(&pthread_barrierattr_setpshared, "pthread_barrierattr_setpshared");
+        symbol(&pthread_attr_setscope, "pthread_attr_setscope");
     }
 }
 
@@ -116,4 +132,104 @@ fn pthread_equal(a: std.c.pthread_t, b: std.c.pthread_t) callconv(.c) c_int {
 /// from POSIX thread functions (which return error numbers, not -1).
 fn eint(e: E) c_int {
     return @intCast(@intFromEnum(e));
+}
+
+// --- Musl internal type definitions ---
+// These match the musl libc type layouts exactly.
+
+/// `typedef struct { unsigned __attr; } pthread_mutexattr_t;`
+const pthread_mutexattr_t = extern struct { __attr: c_uint = 0 };
+
+/// `typedef struct { unsigned __attr; } pthread_condattr_t;`
+const pthread_condattr_t = extern struct { __attr: c_uint = 0 };
+
+/// `typedef struct { unsigned __attr; } pthread_barrierattr_t;`
+const pthread_barrierattr_t = extern struct { __attr: c_uint = 0 };
+
+/// `typedef struct { unsigned __attr[2]; } pthread_rwlockattr_t;`
+const pthread_rwlockattr_t = extern struct { __attr: [2]c_uint = .{ 0, 0 } };
+
+// --- Attribute init functions ---
+
+fn pthread_mutexattr_init(a: *pthread_mutexattr_t) callconv(.c) c_int {
+    a.* = .{};
+    return 0;
+}
+
+fn pthread_condattr_init(a: *pthread_condattr_t) callconv(.c) c_int {
+    a.* = .{};
+    return 0;
+}
+
+fn pthread_rwlockattr_init(a: *pthread_rwlockattr_t) callconv(.c) c_int {
+    a.* = .{};
+    return 0;
+}
+
+fn pthread_barrierattr_init(a: *pthread_barrierattr_t) callconv(.c) c_int {
+    a.* = .{};
+    return 0;
+}
+
+fn pthread_spin_init(s: *c_int, shared: c_int) callconv(.c) c_int {
+    _ = shared;
+    s.* = 0;
+    return 0;
+}
+
+// --- Attribute set functions ---
+
+fn pthread_mutexattr_settype(a: *pthread_mutexattr_t, @"type": c_int) callconv(.c) c_int {
+    const t: c_uint = @bitCast(@"type");
+    if (t > 2) return eint(.INVAL);
+    a.__attr = (a.__attr & ~@as(c_uint, 3)) | t;
+    return 0;
+}
+
+fn pthread_mutexattr_setpshared(a: *pthread_mutexattr_t, pshared: c_int) callconv(.c) c_int {
+    const ps: c_uint = @bitCast(pshared);
+    if (ps > 1) return eint(.INVAL);
+    a.__attr &= ~@as(c_uint, 128);
+    a.__attr |= ps << 7;
+    return 0;
+}
+
+fn pthread_condattr_setclock(a: *pthread_condattr_t, clk: c_int) callconv(.c) c_int {
+    if (clk < 0) return eint(.INVAL);
+    const clk_u: c_uint = @intCast(clk);
+    if (clk_u -% 2 < 2) return eint(.INVAL);
+    a.__attr &= 0x80000000;
+    a.__attr |= clk_u;
+    return 0;
+}
+
+fn pthread_condattr_setpshared(a: *pthread_condattr_t, pshared: c_int) callconv(.c) c_int {
+    const ps: c_uint = @bitCast(pshared);
+    if (ps > 1) return eint(.INVAL);
+    a.__attr &= 0x7fffffff;
+    a.__attr |= ps << 31;
+    return 0;
+}
+
+fn pthread_rwlockattr_setpshared(a: *pthread_rwlockattr_t, pshared: c_int) callconv(.c) c_int {
+    const ps: c_uint = @bitCast(pshared);
+    if (ps > 1) return eint(.INVAL);
+    a.__attr[0] = ps;
+    return 0;
+}
+
+fn pthread_barrierattr_setpshared(a: *pthread_barrierattr_t, pshared: c_int) callconv(.c) c_int {
+    const ps: c_uint = @bitCast(pshared);
+    if (ps > 1) return eint(.INVAL);
+    a.__attr = if (pshared != 0) 0x80000000 else 0;
+    return 0;
+}
+
+fn pthread_attr_setscope(a: ?*anyopaque, scope: c_int) callconv(.c) c_int {
+    _ = a;
+    return switch (scope) {
+        0 => 0, // PTHREAD_SCOPE_SYSTEM
+        1 => eint(.OPNOTSUPP), // PTHREAD_SCOPE_PROCESS
+        else => eint(.INVAL),
+    };
 }

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -1624,21 +1624,21 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_attr_setinheritsched.c",
     "musl/src/thread/pthread_attr_setschedparam.c",
     "musl/src/thread/pthread_attr_setschedpolicy.c",
-    "musl/src/thread/pthread_attr_setscope.c",
+    //"musl/src/thread/pthread_attr_setscope.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_attr_setstack.c",
     "musl/src/thread/pthread_attr_setstacksize.c",
     //"musl/src/thread/pthread_barrierattr_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_barrierattr_init.c",
-    "musl/src/thread/pthread_barrierattr_setpshared.c",
+    //"musl/src/thread/pthread_barrierattr_init.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_barrierattr_setpshared.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_barrier_destroy.c",
     "musl/src/thread/pthread_barrier_init.c",
     "musl/src/thread/pthread_barrier_wait.c",
     "musl/src/thread/pthread_cancel.c",
     "musl/src/thread/pthread_cleanup_push.c",
     //"musl/src/thread/pthread_condattr_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_condattr_init.c",
-    "musl/src/thread/pthread_condattr_setclock.c",
-    "musl/src/thread/pthread_condattr_setpshared.c",
+    //"musl/src/thread/pthread_condattr_init.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_condattr_setclock.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_condattr_setpshared.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_cond_broadcast.c",
     "musl/src/thread/pthread_cond_destroy.c",
     "musl/src/thread/pthread_cond_init.c",
@@ -1658,11 +1658,11 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_key_create.c",
     "musl/src/thread/pthread_kill.c",
     //"musl/src/thread/pthread_mutexattr_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_mutexattr_init.c",
+    //"musl/src/thread/pthread_mutexattr_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutexattr_setprotocol.c",
-    "musl/src/thread/pthread_mutexattr_setpshared.c",
+    //"musl/src/thread/pthread_mutexattr_setpshared.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutexattr_setrobust.c",
-    "musl/src/thread/pthread_mutexattr_settype.c",
+    //"musl/src/thread/pthread_mutexattr_settype.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutex_consistent.c",
     "musl/src/thread/pthread_mutex_destroy.c",
     //"musl/src/thread/pthread_mutex_getprioceiling.c", // migrated to lib/c/thread.zig
@@ -1674,8 +1674,8 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_mutex_unlock.c",
     "musl/src/thread/pthread_once.c",
     //"musl/src/thread/pthread_rwlockattr_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_rwlockattr_init.c",
-    "musl/src/thread/pthread_rwlockattr_setpshared.c",
+    //"musl/src/thread/pthread_rwlockattr_init.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_rwlockattr_setpshared.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/pthread_rwlock_destroy.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_rwlock_init.c",
     "musl/src/thread/pthread_rwlock_rdlock.c",
@@ -1696,7 +1696,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_setspecific.c",
     "musl/src/thread/pthread_sigmask.c",
     //"musl/src/thread/pthread_spin_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_spin_init.c",
+    //"musl/src/thread/pthread_spin_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_spin_lock.c",
     "musl/src/thread/pthread_spin_trylock.c",
     "musl/src/thread/pthread_spin_unlock.c",


### PR DESCRIPTION
Migrate simple attribute init and set functions to `lib/c/thread.zig`:

**Init functions** (zero-initialize attribute structs):
- pthread_mutexattr_init, pthread_condattr_init
- pthread_rwlockattr_init, pthread_barrierattr_init
- pthread_spin_init

**Set functions** (validate and update attribute fields):
- pthread_mutexattr_settype, pthread_mutexattr_setpshared
- pthread_condattr_setclock, pthread_condattr_setpshared
- pthread_rwlockattr_setpshared, pthread_barrierattr_setpshared
- pthread_attr_setscope

Defines Zig types matching musl internal attribute layouts.

Stacks on #149. Part of #10 - thread category (26 of 131 C files)