### PR TITLE
libzigc: migrate 7 more thread C files to Zig (spin locks, sync init)

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -73,6 +73,17 @@ comptime {
         symbol(&pthread_attr_setschedpolicy, "pthread_attr_setschedpolicy");
         symbol(&pthread_attr_setstack, "pthread_attr_setstack");
         symbol(&pthread_attr_setstacksize, "pthread_attr_setstacksize");
+
+        // Spin lock operations (atomics)
+        symbol(&pthread_spin_lock, "pthread_spin_lock");
+        symbol(&pthread_spin_trylock, "pthread_spin_trylock");
+        symbol(&pthread_spin_unlock, "pthread_spin_unlock");
+
+        // Mutex, rwlock, cond, barrier init
+        symbol(&pthread_mutex_init, "pthread_mutex_init");
+        symbol(&pthread_rwlock_init, "pthread_rwlock_init");
+        symbol(&pthread_cond_init, "pthread_cond_init");
+        symbol(&pthread_barrier_init, "pthread_barrier_init");
     }
 }
 
@@ -414,6 +425,85 @@ fn pthread_attr_setstacksize(a: *pthread_attr_t, size: usize) callconv(.c) c_int
     if (size -% PTHREAD_STACK_MIN > std.math.maxInt(usize) / 4) return eint(.INVAL);
     a._a_stackaddr = 0;
     a._a_stacksize = size;
+    return 0;
+}
+
+// --- Spin lock operations ---
+
+fn pthread_spin_lock(s: *c_int) callconv(.c) c_int {
+    while (@atomicLoad(c_int, s, .monotonic) != 0 or
+        @cmpxchgWeak(c_int, s, 0, eint(.BUSY), .seq_cst, .seq_cst) != null)
+    {
+        std.atomic.spinLoopHint();
+    }
+    return 0;
+}
+
+fn pthread_spin_trylock(s: *c_int) callconv(.c) c_int {
+    return @cmpxchgStrong(c_int, s, 0, eint(.BUSY), .seq_cst, .seq_cst) orelse 0;
+}
+
+fn pthread_spin_unlock(s: *c_int) callconv(.c) c_int {
+    @atomicStore(c_int, s, 0, .seq_cst);
+    return 0;
+}
+
+// --- Synchronization object init ---
+
+const mutex_size = if (@sizeOf(c_ulong) == 8) @as(usize, 40) else 24;
+const pthread_mutex_impl = extern struct {
+    _m_type: c_int = 0,
+    _padding: [mutex_size - @sizeOf(c_int)]u8 = [_]u8{0} ** (mutex_size - @sizeOf(c_int)),
+};
+
+fn pthread_mutex_init(m: *pthread_mutex_impl, a: ?*const pthread_mutexattr_t) callconv(.c) c_int {
+    m.* = .{};
+    if (a) |attr| m._m_type = @bitCast(attr.__attr);
+    return 0;
+}
+
+const rwlock_size = if (@sizeOf(c_ulong) == 8) @as(usize, 56) else 32;
+const pthread_rwlock_impl = extern struct {
+    _rw_lock: c_int = 0,
+    _rw_waiters: c_int = 0,
+    _rw_shared: c_int = 0,
+    _padding: [rwlock_size - 3 * @sizeOf(c_int)]u8 = [_]u8{0} ** (rwlock_size - 3 * @sizeOf(c_int)),
+};
+
+fn pthread_rwlock_init(rw: *pthread_rwlock_impl, a: ?*const pthread_rwlockattr_t) callconv(.c) c_int {
+    rw.* = .{};
+    if (a) |attr| rw._rw_shared = @bitCast(attr.__attr[0] * @as(c_uint, 128));
+    return 0;
+}
+
+const pthread_cond_impl = extern struct {
+    _c_shared: usize = 0,
+    _pad1: [16 - @sizeOf(usize)]u8 = [_]u8{0} ** (16 - @sizeOf(usize)),
+    _c_clock: c_int = 0,
+    _pad2: [48 - 16 - @sizeOf(c_int)]u8 = [_]u8{0} ** (48 - 16 - @sizeOf(c_int)),
+};
+
+fn pthread_cond_init(c: *pthread_cond_impl, a: ?*const pthread_condattr_t) callconv(.c) c_int {
+    c.* = .{};
+    if (a) |attr| {
+        c._c_clock = @bitCast(attr.__attr & 0x7fffffff);
+        if (attr.__attr >> 31 != 0) c._c_shared = std.math.maxInt(usize);
+    }
+    return 0;
+}
+
+const barrier_size = if (@sizeOf(c_ulong) == 8) @as(usize, 32) else 20;
+const pthread_barrier_impl = extern struct {
+    _b_lock: c_int = 0,
+    _b_waiters: c_int = 0,
+    _b_limit: c_int = 0,
+    _padding: [barrier_size - 3 * @sizeOf(c_int)]u8 = [_]u8{0} ** (barrier_size - 3 * @sizeOf(c_int)),
+};
+
+fn pthread_barrier_init(b: *pthread_barrier_impl, a: ?*const pthread_barrierattr_t, count: c_uint) callconv(.c) c_int {
+    if (count -% 1 > 0x7FFFFFFE) return eint(.INVAL);
+    b.* = .{};
+    b._b_limit = @bitCast((count -% 1) | if (a) |attr| attr.__attr else 0);
     return 0;
 }
 

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -1631,7 +1631,7 @@ const src_files = [_][]const u8{
     //"musl/src/thread/pthread_barrierattr_init.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/pthread_barrierattr_setpshared.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_barrier_destroy.c",
-    "musl/src/thread/pthread_barrier_init.c",
+    //"musl/src/thread/pthread_barrier_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_barrier_wait.c",
     "musl/src/thread/pthread_cancel.c",
     "musl/src/thread/pthread_cleanup_push.c",
@@ -1641,7 +1641,7 @@ const src_files = [_][]const u8{
     //"musl/src/thread/pthread_condattr_setpshared.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_cond_broadcast.c",
     "musl/src/thread/pthread_cond_destroy.c",
-    "musl/src/thread/pthread_cond_init.c",
+    //"musl/src/thread/pthread_cond_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_cond_signal.c",
     "musl/src/thread/pthread_cond_timedwait.c",
     "musl/src/thread/pthread_cond_wait.c",
@@ -1666,7 +1666,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_mutex_consistent.c",
     "musl/src/thread/pthread_mutex_destroy.c",
     //"musl/src/thread/pthread_mutex_getprioceiling.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_mutex_init.c",
+    //"musl/src/thread/pthread_mutex_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_mutex_lock.c",
     "musl/src/thread/pthread_mutex_setprioceiling.c",
     "musl/src/thread/pthread_mutex_timedlock.c",
@@ -1677,7 +1677,7 @@ const src_files = [_][]const u8{
     //"musl/src/thread/pthread_rwlockattr_init.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/pthread_rwlockattr_setpshared.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/pthread_rwlock_destroy.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_rwlock_init.c",
+    //"musl/src/thread/pthread_rwlock_init.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_rwlock_rdlock.c",
     "musl/src/thread/pthread_rwlock_timedrdlock.c",
     "musl/src/thread/pthread_rwlock_timedwrlock.c",
@@ -1697,9 +1697,9 @@ const src_files = [_][]const u8{
     "musl/src/thread/pthread_sigmask.c",
     //"musl/src/thread/pthread_spin_destroy.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/pthread_spin_init.c", // migrated to lib/c/thread.zig
-    "musl/src/thread/pthread_spin_lock.c",
-    "musl/src/thread/pthread_spin_trylock.c",
-    "musl/src/thread/pthread_spin_unlock.c",
+    //"musl/src/thread/pthread_spin_lock.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_spin_trylock.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_spin_unlock.c", // migrated to lib/c/thread.zig
     "musl/src/thread/pthread_testcancel.c",
     "musl/src/thread/riscv32/clone.s",
     "musl/src/thread/riscv32/__set_thread_area.s",


### PR DESCRIPTION
Migrate spin lock operations and synchronization object init to `lib/c/thread.zig`:

**Spin lock operations** (using Zig atomics):
- pthread_spin_lock (CAS loop with spin hint)
- pthread_spin_trylock (single CAS)
- pthread_spin_unlock (atomic store)

**Sync object init:**
- pthread_mutex_init, pthread_rwlock_init
- pthread_cond_init, pthread_barrier_init

Defines Zig types matching musl internal layouts for mutex, rwlock, cond, barrier.

Stacks on #151. Part of #10 - thread category (41 of 131 C files)