### PR TITLE
libcxx: add char_traits<unsigned char> specialization

### DIFF
--- a/lib/libcxx/include/__string/char_traits.h
+++ b/lib/libcxx/include/__string/char_traits.h
@@ -274,6 +274,32 @@ struct char_traits<char8_t> : __char_traits_base<char8_t, unsigned int, static_c
 
 #endif // _LIBCPP_HAS_CHAR8_T
 
+// char_traits<unsigned char>
+//
+// Extension: provide char_traits<unsigned char> for compatibility with code
+// that uses std::basic_string<unsigned char> (e.g. cpprestsdk/Casablanca).
+// libstdc++ supports this via a generic char_traits base template; libc++
+// removed its generic template but we add this targeted specialization so
+// that zig c++ can compile codebases that depend on this pattern.
+
+template <>
+struct char_traits<unsigned char>
+    : __char_traits_base<unsigned char, unsigned int, static_cast<unsigned int>(EOF)> {
+  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 int
+  compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT {
+    return std::__constexpr_memcmp(__s1, __s2, __element_count(__n));
+  }
+
+  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __str) _NOEXCEPT {
+    return std::__constexpr_strlen(__str);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 const char_type*
+  find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT {
+    return std::__constexpr_memchr(__s, __a, __n);
+  }
+};
+
 template <>
 struct char_traits<char16_t> : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int


### PR DESCRIPTION
## Summary

Adds `std::char_traits<unsigned char>` as a Zig extension to the bundled libc++ headers, enabling `std::basic_string<unsigned char>` to compile with `zig c++`.

Related to #146 — this is a prerequisite for compiling large C++ codebases with an all-LLVM stack (`zig c++` with libc++ instead of libstdc++).

## Background

Upstream libc++ [deliberately removed](https://reviews.llvm.org/D138307) the generic `char_traits` base template in LLVM 19. The C++ standard only requires specializations for `char`, `wchar_t`, `char8_t`, `char16_t`, and `char32_t`. However, real-world C++ code uses `std::basic_string<unsigned char>` — notably [Microsoft's cpprestsdk](https://github.com/microsoft/cpprestsdk) (C++ REST SDK / Casablanca), which is widely used in Azure/monitoring applications.

libstdc++ (GCC) still supports this via its generic `char_traits` template. Without this specialization, any C++ codebase that uses `std::basic_string<unsigned char>` cannot compile with `zig c++`.

## Change

Added a `char_traits<unsigned char>` specialization in `lib/libcxx/include/__string/char_traits.h`, following the exact same pattern as the existing `char_traits<char8_t>` specialization (since `char8_t` is `unsigned char` under the hood in C++20, but is a distinct type).

The specialization:
- Inherits from `__char_traits_base<unsigned char, unsigned int, EOF>`
- Provides `compare`, `length`, `find` using the same `__constexpr_mem*` helpers
- Available in all C++ standard modes (not gated on C++20)
- Does not conflict with `char_traits<char8_t>` (they are distinct types)

## Impact

Enables `zig c++` to compile C++ code that uses:
- `std::basic_string<unsigned char>` (cpprestsdk streams)
- `std::basic_string<uint8_t>` (byte string handling)

This unblocks compiling mixed C++/Zig codebases with an all-LLVM stack, which is the proper fix for the C++ exception handling issues described in #146.