### PR TITLE
libzigc: fix Zig API compat issues in shared files

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -61,6 +61,23 @@ pub fn errno(syscall_return_value: usize) c_int {
     };
 }
 
+/// Like `errno`, but for syscalls that return `isize` (ssize_t) values such as
+/// read, write, pread, pwrite, readlink, etc.
+pub fn errnoSize(syscall_return_value: usize) isize {
+    return switch (builtin.os.tag) {
+        .linux => {
+            const signed: isize = @bitCast(syscall_return_value);
+            if (signed < 0) {
+                @branchHint(.unlikely);
+                std.c._errno().* = @intCast(-signed);
+                return -1;
+            }
+            return signed;
+        },
+        else => comptime unreachable,
+    };
+}
+
 comptime {
     _ = @import("c/ctype.zig");
     _ = @import("c/fcntl.zig");

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1429,11 +1429,11 @@ pub fn write(fd: i32, buf: [*]const u8, count: usize) usize {
 }
 
 pub fn ftruncate(fd: i32, length: i64) usize {
-    if (@hasField(SYS, "ftruncate64") and usize_bits < 64) {
+    if (usize_bits < 64) {
         const length_halves = splitValue64(length);
         if (require_aligned_register_pair) {
             return syscall4(
-                .ftruncate64,
+                if (@hasField(SYS, "ftruncate64")) .ftruncate64 else .ftruncate,
                 @as(usize, @bitCast(@as(isize, fd))),
                 0,
                 length_halves[0],
@@ -1441,7 +1441,7 @@ pub fn ftruncate(fd: i32, length: i64) usize {
             );
         } else {
             return syscall3(
-                .ftruncate64,
+                if (@hasField(SYS, "ftruncate64")) .ftruncate64 else .ftruncate,
                 @as(usize, @bitCast(@as(isize, fd))),
                 length_halves[0],
                 length_halves[1],


### PR DESCRIPTION
Part of #10. Two fixes for shared libc files that cause build failures across multiple PR branches:

**1. Fix linux.ftruncate for x32 (muslx32)**

The ftruncate function failed to compile on x86_64-linux-muslx32 with a bitCast size mismatch (destination usize has 32 bits but source i64 has 64 bits). Root cause: the condition tied the value split to hasField(SYS, ftruncate64) which is false on x32. Fix: check usize_bits < 64 unconditionally, like fallocate does.

**2. Add errnoSize helper to lib/c.zig**

New helper for syscalls that return isize (ssize_t) values: read, write, pread, pwrite, readlink, etc. Multiple PR branches need this shared helper.