### PR TITLE
libzigc: reinstate 55 musl network C files + stdio/getc.c (fixes #259)

### DIFF
--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -530,7 +530,7 @@ const src_files = [_][]const u8{
     "musl/src/math/__math_xflowf.c",
     "musl/src/misc/getauxval.c",
     "musl/src/misc/getdomainname.c",
-    //"musl/src/network/accept4.c", // migrated to lib/c/network.zig
+    "musl/src/network/accept4.c",
     "musl/src/network/accept.c",
     "musl/src/network/bind.c",
     "musl/src/network/connect.c",
@@ -587,7 +587,7 @@ const src_files = [_][]const u8{
     "musl/src/network/proto.c",
     "musl/src/network/recv.c",
     "musl/src/network/recvfrom.c",
-    //"musl/src/network/recvmmsg.c", // migrated to lib/c/network.zig
+    "musl/src/network/recvmmsg.c",
     "musl/src/network/recvmsg.c",
     "musl/src/network/res_init.c",
     //"musl/src/network/res_mkquery.c", // migrated to lib/c/network.zig
@@ -598,7 +598,7 @@ const src_files = [_][]const u8{
     //"musl/src/network/res_send.c", // migrated to lib/c/network.zig
     "musl/src/network/res_state.c",
     "musl/src/network/send.c",
-    //"musl/src/network/sendmmsg.c", // migrated to lib/c/network.zig
+    "musl/src/network/sendmmsg.c",
     "musl/src/network/sendmsg.c",
     "musl/src/network/sendto.c",
     "musl/src/network/serv.c",
@@ -606,7 +606,7 @@ const src_files = [_][]const u8{
     "musl/src/network/shutdown.c",
     "musl/src/network/sockatmark.c",
     "musl/src/network/socket.c",
-    //"musl/src/network/socketpair.c", // migrated to lib/c/network.zig
+    "musl/src/network/socketpair.c",
     "musl/src/process/posix_spawn.c",
     "musl/src/process/posix_spawnp.c",
     "musl/src/sched/affinity.c",

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -531,81 +531,81 @@ const src_files = [_][]const u8{
     "musl/src/misc/getauxval.c",
     "musl/src/misc/getdomainname.c",
     //"musl/src/network/accept4.c", // migrated to lib/c/network.zig
-    //"musl/src/network/accept.c", // migrated to lib/c/network.zig
-    //"musl/src/network/bind.c", // migrated to lib/c/network.zig
-    //"musl/src/network/connect.c", // migrated to lib/c/network.zig
+    "musl/src/network/accept.c",
+    "musl/src/network/bind.c",
+    "musl/src/network/connect.c",
     //"musl/src/network/dn_comp.c", // migrated to lib/c/network.zig
-    //"musl/src/network/dn_expand.c", // migrated to lib/c/network.zig
-    //"musl/src/network/dn_skipname.c", // migrated to lib/c/network.zig
-    //"musl/src/network/dns_parse.c", // migrated to lib/c/network.zig
-    //"musl/src/network/ent.c", // migrated to lib/c/network.zig
-    //"musl/src/network/ether.c", // migrated to lib/c/network.zig
+    "musl/src/network/dn_expand.c",
+    "musl/src/network/dn_skipname.c",
+    "musl/src/network/dns_parse.c",
+    "musl/src/network/ent.c",
+    "musl/src/network/ether.c",
     //"musl/src/network/freeaddrinfo.c", // migrated to lib/c/network.zig
-    //"musl/src/network/gai_strerror.c", // migrated to lib/c/network.zig
+    "musl/src/network/gai_strerror.c",
     //"musl/src/network/getaddrinfo.c", // migrated to lib/c/network.zig
-    //"musl/src/network/gethostbyaddr.c", // migrated to lib/c/network.zig
+    "musl/src/network/gethostbyaddr.c",
     //"musl/src/network/gethostbyaddr_r.c", // migrated to lib/c/network.zig
-    //"musl/src/network/gethostbyname2.c", // migrated to lib/c/network.zig
+    "musl/src/network/gethostbyname2.c",
     //"musl/src/network/gethostbyname2_r.c", // migrated to lib/c/network.zig
-    //"musl/src/network/gethostbyname.c", // migrated to lib/c/network.zig
-    //"musl/src/network/gethostbyname_r.c", // migrated to lib/c/network.zig
+    "musl/src/network/gethostbyname.c",
+    "musl/src/network/gethostbyname_r.c",
     //"musl/src/network/getifaddrs.c", // migrated to lib/c/network.zig
     //"musl/src/network/getnameinfo.c", // migrated to lib/c/network.zig
-    //"musl/src/network/getpeername.c", // migrated to lib/c/network.zig
-    //"musl/src/network/getservbyname.c", // migrated to lib/c/network.zig
+    "musl/src/network/getpeername.c",
+    "musl/src/network/getservbyname.c",
     //"musl/src/network/getservbyname_r.c", // migrated to lib/c/network.zig
-    //"musl/src/network/getservbyport.c", // migrated to lib/c/network.zig
+    "musl/src/network/getservbyport.c",
     //"musl/src/network/getservbyport_r.c", // migrated to lib/c/network.zig
-    //"musl/src/network/getsockname.c", // migrated to lib/c/network.zig
-    //"musl/src/network/getsockopt.c", // migrated to lib/c/network.zig
-    //"musl/src/network/h_errno.c", // migrated to lib/c/network.zig
-    //"musl/src/network/herror.c", // migrated to lib/c/network.zig
-    //"musl/src/network/hstrerror.c", // migrated to lib/c/network.zig
-    //"musl/src/network/htonl.c", // migrated to lib/c/network.zig
-    //"musl/src/network/htons.c", // migrated to lib/c/network.zig
-    //"musl/src/network/if_freenameindex.c", // migrated to lib/c/network.zig
-    //"musl/src/network/if_indextoname.c", // migrated to lib/c/network.zig
+    "musl/src/network/getsockname.c",
+    "musl/src/network/getsockopt.c",
+    "musl/src/network/h_errno.c",
+    "musl/src/network/herror.c",
+    "musl/src/network/hstrerror.c",
+    "musl/src/network/htonl.c",
+    "musl/src/network/htons.c",
+    "musl/src/network/if_freenameindex.c",
+    "musl/src/network/if_indextoname.c",
     //"musl/src/network/if_nameindex.c", // migrated to lib/c/network.zig
-    //"musl/src/network/if_nametoindex.c", // migrated to lib/c/network.zig
-    //"musl/src/network/in6addr_any.c", // migrated to lib/c/network.zig
-    //"musl/src/network/in6addr_loopback.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_addr.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_aton.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_legacy.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_ntoa.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_ntop.c", // migrated to lib/c/network.zig
-    //"musl/src/network/inet_pton.c", // migrated to lib/c/network.zig
-    //"musl/src/network/listen.c", // migrated to lib/c/network.zig
+    "musl/src/network/if_nametoindex.c",
+    "musl/src/network/in6addr_any.c",
+    "musl/src/network/in6addr_loopback.c",
+    "musl/src/network/inet_addr.c",
+    "musl/src/network/inet_aton.c",
+    "musl/src/network/inet_legacy.c",
+    "musl/src/network/inet_ntoa.c",
+    "musl/src/network/inet_ntop.c",
+    "musl/src/network/inet_pton.c",
+    "musl/src/network/listen.c",
     //"musl/src/network/lookup_ipliteral.c", // migrated to lib/c/network.zig
     //"musl/src/network/lookup_name.c", // migrated to lib/c/network.zig
     //"musl/src/network/lookup_serv.c", // migrated to lib/c/network.zig
     //"musl/src/network/netlink.c", // migrated to lib/c/network.zig
     //"musl/src/network/netname.c", // migrated to lib/c/network.zig
     //"musl/src/network/ns_parse.c", // migrated to lib/c/network.zig
-    //"musl/src/network/ntohl.c", // migrated to lib/c/network.zig
-    //"musl/src/network/ntohs.c", // migrated to lib/c/network.zig
-    //"musl/src/network/proto.c", // migrated to lib/c/network.zig
-    //"musl/src/network/recv.c", // migrated to lib/c/network.zig
-    //"musl/src/network/recvfrom.c", // migrated to lib/c/network.zig
+    "musl/src/network/ntohl.c",
+    "musl/src/network/ntohs.c",
+    "musl/src/network/proto.c",
+    "musl/src/network/recv.c",
+    "musl/src/network/recvfrom.c",
     //"musl/src/network/recvmmsg.c", // migrated to lib/c/network.zig
-    //"musl/src/network/recvmsg.c", // migrated to lib/c/network.zig
-    //"musl/src/network/res_init.c", // migrated to lib/c/network.zig
+    "musl/src/network/recvmsg.c",
+    "musl/src/network/res_init.c",
     //"musl/src/network/res_mkquery.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_msend.c", // migrated to lib/c/network.zig
     //"musl/src/network/resolvconf.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_query.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_querydomain.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_send.c", // migrated to lib/c/network.zig
-    //"musl/src/network/res_state.c", // migrated to lib/c/network.zig
-    //"musl/src/network/send.c", // migrated to lib/c/network.zig
+    "musl/src/network/res_state.c",
+    "musl/src/network/send.c",
     //"musl/src/network/sendmmsg.c", // migrated to lib/c/network.zig
-    //"musl/src/network/sendmsg.c", // migrated to lib/c/network.zig
-    //"musl/src/network/sendto.c", // migrated to lib/c/network.zig
-    //"musl/src/network/serv.c", // migrated to lib/c/network.zig
-    //"musl/src/network/setsockopt.c", // migrated to lib/c/network.zig
-    //"musl/src/network/shutdown.c", // migrated to lib/c/network.zig
-    //"musl/src/network/sockatmark.c", // migrated to lib/c/network.zig
-    //"musl/src/network/socket.c", // migrated to lib/c/network.zig
+    "musl/src/network/sendmsg.c",
+    "musl/src/network/sendto.c",
+    "musl/src/network/serv.c",
+    "musl/src/network/setsockopt.c",
+    "musl/src/network/shutdown.c",
+    "musl/src/network/sockatmark.c",
+    "musl/src/network/socket.c",
     //"musl/src/network/socketpair.c", // migrated to lib/c/network.zig
     "musl/src/process/posix_spawn.c",
     "musl/src/process/posix_spawnp.c",
@@ -861,6 +861,7 @@ const src_files = [_][]const u8{
     "musl/src/process/fork.c",
     "musl/src/stdio/fputc.c",
     "musl/src/stdio/fwide.c",
+    "musl/src/stdio/getc.c",
     "musl/src/stdio/putc.c",
     "musl/src/stdio/putc_unlocked.c",
     "musl/src/stdio/putchar.c",


### PR DESCRIPTION
Fixes #259.

## Root cause

Commit 67880b83 ("libzigc: migrate all 77 network files to Zig") commented out all 77 `musl/src/network/*.c` entries in `src/libs/musl.zig`, but only ~33 of those symbols were actually migrated to Zig `symbol()` exports (in `lib/c/network/dns.zig` and `lib/c/network/resolver.zig`). `lib/c/network.zig` itself is an imports-only file with zero exports.

The remaining ~55 symbols (`send`, `recv`, `sendto`, `recvfrom`, `__dn_expand`, `dn_skipname`, `h_errno`, `__inet_aton`, `inet_pton`, `inet_ntop`, `if_nametoindex`, etc.) became undefined at stage4 link time on `x86_64-linux-musl`.

Separately, `musl/src/stdio/getc.c` was dropped entirely without a Zig replacement — `fgetc` and `getc_unlocked` are exported in `lib/c/stdio.zig` but plain `getc` is not.

## Fix

Surgical reinstate: for each commented `network/*.c`, cross-referenced the primary symbol(s) against every `symbol()` call in `lib/c/**` (accounting for target guards — `wasi_sources.zig` and `win32/stubs.zig` don't apply to linux-musl). Files whose symbols are actually exported in Zig stay commented (`freeaddrinfo`, `getaddrinfo`, `getnameinfo`, `getifaddrs`, `lookup_*`, `res_send`, `res_query`, `res_mkquery`, `res_msend`, `resolvconf`, `if_nameindex`, `ns_parse`, `dn_comp`). `netname.c` stays commented to avoid `gethostname`/`sethostname` duplicate-symbol collision.

Total: 55 network C files reinstated + 1 stdio file added = 56 entries changed.

## Validation

CI: https://github.com/ctaggart/zig/actions/runs/24648940235 — stage4 built in 30m and dirent tests passed on all 11 target groups (x86_64, x86, aarch64, arm, thumb, wasm32, riscv, loongarch64, s390x, powerpc).

## Follow-up (not in this PR)

Consider a CI lint that fails if a `// migrated to <file>` comment in `src/libs/musl.zig` references a file that doesn't actually export the expected symbols — would catch this class of bug before merge.
