### PR TITLE
libzigc: add migration-claim lint for src/libs/musl.zig

### DIFF
--- a/.github/workflows/lint-libc-migration.yml
+++ b/.github/workflows/lint-libc-migration.yml
@@ -1,0 +1,30 @@
+name: lint-libc-migration
+
+on:
+  push:
+    branches:
+      - libc/0.16.x
+      - libc/**
+    paths:
+      - src/libs/musl.zig
+      - lib/c/**
+      - scripts/check_musl_migration.py
+      - .github/workflows/lint-libc-migration.yml
+  pull_request:
+    paths:
+      - src/libs/musl.zig
+      - lib/c/**
+      - scripts/check_musl_migration.py
+      - .github/workflows/lint-libc-migration.yml
+  workflow_dispatch:
+
+jobs:
+  check-migration-claims:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check musl.zig "migrated to" claims
+        run: python3 scripts/check_musl_migration.py

--- a/scripts/check_musl_migration.py
+++ b/scripts/check_musl_migration.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Lint commented-out 'migrated to' entries in src/libs/musl.zig.
+
+For each line of the form:
+
+    //"musl/src/<dir>/<name>.c", // migrated to lib/c/<file>.zig
+
+this script verifies that the primary symbol (derived from the C filename)
+is exported via a `symbol(..., "NAME")` call somewhere under lib/c/ that is
+reachable for non-WASI, non-Windows targets. If not, CI fails — the
+"migrated" claim is bogus and the commented line must either be uncommented
+or annotated with an explicit exports override.
+
+Override syntax (same line, after the migrated-to clause):
+
+    //"musl/src/stdio/ext2.c", // migrated to lib/c/stdio.zig; exports: __fbufsize,__fpending,...
+
+Exit codes: 0 clean, 1 findings, 2 internal error.
+"""
+from __future__ import annotations
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MUSL_ZIG = REPO / "src" / "libs" / "musl.zig"
+LIB_C = REPO / "lib" / "c"
+
+# Files that only export for wasi or win32 targets — do NOT count as
+# "migrated" for linux-musl / general purposes.
+EXCLUDED_FILES = {
+    "wasi_sources.zig",
+    "wasi_cloudlibc.zig",
+    "wasi_thread_stub.zig",
+}
+EXCLUDED_DIRS = {"win32"}
+
+SYMBOL_RE = re.compile(r'symbol\([^)]*?"([A-Za-z_][A-Za-z0-9_]*)"')
+MIGRATED_RE = re.compile(
+    r'^\s*//\s*"(musl/src/[^"]+\.c)"\s*,\s*//\s*migrated to\s+([^\s;]+)'
+    r'(?:\s*;\s*exports:\s*([^\n]+))?'
+)
+
+
+def collect_exported_symbols() -> set[str]:
+    symbols: set[str] = set()
+    for path in LIB_C.rglob("*.zig"):
+        rel_parts = path.relative_to(LIB_C).parts
+        if path.name in EXCLUDED_FILES:
+            continue
+        if any(p in EXCLUDED_DIRS for p in rel_parts[:-1]):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+            continue
+        for m in SYMBOL_RE.finditer(text):
+            symbols.add(m.group(1))
+    return symbols
+
+
+def main() -> int:
+    if not MUSL_ZIG.is_file():
+        print(f"error: {MUSL_ZIG} not found", file=sys.stderr)
+        return 2
+    if not LIB_C.is_dir():
+        print(f"error: {LIB_C} not found", file=sys.stderr)
+        return 2
+
+    exported = collect_exported_symbols()
+    if not exported:
+        print("error: no symbol() calls found under lib/c", file=sys.stderr)
+        return 2
+
+    findings: list[str] = []
+    checked = 0
+    text = MUSL_ZIG.read_text(encoding="utf-8", errors="replace").splitlines()
+    for lineno, line in enumerate(text, start=1):
+        m = MIGRATED_RE.match(line)
+        if not m:
+            continue
+        checked += 1
+        c_rel = m.group(1)
+        target_zig = m.group(2)
+        override = m.group(3)
+        stem = pathlib.PurePosixPath(c_rel).stem  # "musl/src/a/b.c" -> "b"
+        if override:
+            expected = [s.strip() for s in override.split(",") if s.strip()]
+        else:
+            expected = [stem]
+        missing = [s for s in expected if s not in exported]
+        if missing:
+            findings.append(
+                f"{MUSL_ZIG.relative_to(REPO).as_posix()}:{lineno}: "
+                f'"{c_rel}" claims "migrated to {target_zig}" but '
+                f"symbol(s) {missing} are not exported anywhere under lib/c "
+                f"(excluding wasi_*.zig and win32/). "
+                "Either uncomment the C file, or annotate the line with "
+                "`; exports: <name1>,<name2>,...` to document the real "
+                "export names."
+            )
+
+    if findings:
+        print(
+            f"musl.zig migration lint: {len(findings)} problem(s) "
+            f"out of {checked} 'migrated to' entries checked "
+            f"({len(exported)} symbols found under lib/c):",
+            file=sys.stderr,
+        )
+        for f in findings:
+            print(f, file=sys.stderr)
+        return 1
+
+    print(
+        f"musl.zig migration lint: OK "
+        f"({checked} 'migrated to' entries, {len(exported)} symbols under lib/c)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -481,7 +481,7 @@ const src_files = [_][]const u8{
     "musl/src/ldso/aarch64/tlsdesc.s",
     "musl/src/ldso/arm/dlsym.s",
     "musl/src/ldso/arm/dlsym_time64.S",
-    //"musl/src/ldso/arm/find_exidx.c", // migrated to lib/c/ldso.zig
+    //"musl/src/ldso/arm/find_exidx.c", // migrated to lib/c/ldso.zig; exports: __gnu_Unwind_Find_exidx
     "musl/src/ldso/arm/tlsdesc.S",
     //"musl/src/ldso/dladdr.c", // migrated to lib/c/ldso.zig
     //"musl/src/ldso/dlclose.c", // migrated to lib/c/ldso.zig
@@ -506,7 +506,7 @@ const src_files = [_][]const u8{
     "musl/src/ldso/riscv64/dlsym.s",
     "musl/src/ldso/riscv64/tlsdesc.s",
     "musl/src/ldso/s390x/dlsym.s",
-    //"musl/src/ldso/tlsdesc.c", // migrated to lib/c/ldso.zig
+    //"musl/src/ldso/tlsdesc.c", // migrated to lib/c/ldso.zig; exports: __tlsdesc_static
     "musl/src/ldso/x32/dlsym.s",
     "musl/src/ldso/x86_64/dlsym.s",
     "musl/src/ldso/x86_64/tlsdesc.s",
@@ -576,12 +576,12 @@ const src_files = [_][]const u8{
     "musl/src/network/inet_ntop.c",
     "musl/src/network/inet_pton.c",
     "musl/src/network/listen.c",
-    //"musl/src/network/lookup_ipliteral.c", // migrated to lib/c/network.zig
-    //"musl/src/network/lookup_name.c", // migrated to lib/c/network.zig
-    //"musl/src/network/lookup_serv.c", // migrated to lib/c/network.zig
-    //"musl/src/network/netlink.c", // migrated to lib/c/network.zig
-    //"musl/src/network/netname.c", // migrated to lib/c/network.zig
-    //"musl/src/network/ns_parse.c", // migrated to lib/c/network.zig
+    //"musl/src/network/lookup_ipliteral.c", // migrated to lib/c/network.zig; exports: __lookup_ipliteral
+    //"musl/src/network/lookup_name.c", // migrated to lib/c/network.zig; exports: __lookup_name
+    //"musl/src/network/lookup_serv.c", // migrated to lib/c/network.zig; exports: __lookup_serv
+    //"musl/src/network/netlink.c", // migrated to lib/c/network.zig; exports: __rtnetlink_enumerate
+    "musl/src/network/netname.c", // provides getnetbyaddr/getnetbyname (not migrated to Zig)
+    //"musl/src/network/ns_parse.c", // migrated to lib/c/network.zig; exports: ns_get16,ns_get32,ns_put16,ns_put32,ns_initparse,ns_skiprr,ns_parserr,ns_name_uncompress
     "musl/src/network/ntohl.c",
     "musl/src/network/ntohs.c",
     "musl/src/network/proto.c",
@@ -591,8 +591,8 @@ const src_files = [_][]const u8{
     "musl/src/network/recvmsg.c",
     "musl/src/network/res_init.c",
     //"musl/src/network/res_mkquery.c", // migrated to lib/c/network.zig
-    //"musl/src/network/res_msend.c", // migrated to lib/c/network.zig
-    //"musl/src/network/resolvconf.c", // migrated to lib/c/network.zig
+    //"musl/src/network/res_msend.c", // migrated to lib/c/network.zig; exports: __res_msend,__res_msend_rc
+    //"musl/src/network/resolvconf.c", // migrated to lib/c/network.zig; exports: __get_resolv_conf
     //"musl/src/network/res_query.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_querydomain.c", // migrated to lib/c/network.zig
     //"musl/src/network/res_send.c", // migrated to lib/c/network.zig
@@ -668,8 +668,8 @@ const src_files = [_][]const u8{
     "musl/src/signal/x32/sigsetjmp.s",
     "musl/src/signal/x86_64/restore.s",
     "musl/src/signal/x86_64/sigsetjmp.s",
-    //"musl/src/stdio/ext2.c", // migrated to lib/c/stdio.zig
-    //"musl/src/stdio/ext.c", // migrated to lib/c/stdio.zig
+    //"musl/src/stdio/ext2.c", // migrated to lib/c/stdio.zig; exports: __freadahead,__freadptrinc,__fseterr
+    //"musl/src/stdio/ext.c", // migrated to lib/c/stdio.zig; exports: _flushlbf,__fsetlocking,__fwriting,__freading,__freadable,__fwritable,__flbf,__fbufsize,__fpending,__fpurge
     "musl/src/stdio/fclose.c",
     //"musl/src/stdio/__fclose_ca.c", // migrated to lib/c/stdio.zig
     "musl/src/stdio/__fdopen.c",
@@ -759,7 +759,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/i386/syscall_cp.s",
     "musl/src/thread/i386/tls.s",
     "musl/src/thread/i386/__unmapself.s",
-    //"musl/src/thread/lock_ptc.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/lock_ptc.c", // migrated to lib/c/thread.zig; exports: __inhibit_ptc,__acquire_ptc,__release_ptc
     "musl/src/thread/loongarch64/clone.s",
     "musl/src/thread/loongarch64/__set_thread_area.s",
     "musl/src/thread/loongarch64/syscall_cp.s",
@@ -792,7 +792,7 @@ const src_files = [_][]const u8{
     "musl/src/thread/powerpc/__unmapself.s",
     "musl/src/thread/pthread_atfork.c",
     //"musl/src/thread/pthread_attr_destroy.c", // migrated to lib/c/thread.zig
-    //"musl/src/thread/pthread_attr_get.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/pthread_attr_get.c", // migrated to lib/c/thread.zig; exports: pthread_attr_getdetachstate,pthread_attr_getguardsize,pthread_attr_getinheritsched,pthread_attr_getschedparam,pthread_attr_getschedpolicy,pthread_attr_getscope,pthread_attr_getstack,pthread_attr_getstacksize,pthread_barrierattr_getpshared,pthread_condattr_getclock,pthread_condattr_getpshared,pthread_mutexattr_getprotocol,pthread_mutexattr_getpshared,pthread_mutexattr_getrobust,pthread_mutexattr_gettype
     "musl/src/thread/riscv32/clone.s",
     "musl/src/thread/riscv32/__set_thread_area.s",
     "musl/src/thread/riscv32/syscall_cp.s",
@@ -816,7 +816,7 @@ const src_files = [_][]const u8{
     //"musl/src/thread/tss_create.c", // migrated to lib/c/thread.zig
     //"musl/src/thread/tss_delete.c", // migrated to lib/c/thread.zig
     "musl/src/thread/__unmapself.c",
-    //"musl/src/thread/vmlock.c", // migrated to lib/c/thread.zig
+    //"musl/src/thread/vmlock.c", // migrated to lib/c/thread.zig; exports: __vm_wait,__vm_lock,__vm_unlock
     //"musl/src/thread/__wait.c", // migrated to lib/c/thread.zig
     "musl/src/thread/x32/clone.s",
     "musl/src/thread/x32/__set_thread_area.s",


### PR DESCRIPTION
Adds a CI lint that verifies every ` //"musl/src/....c", // migrated to <file>.zig ` comment in `src/libs/musl.zig` actually points at real Zig exports. Prevents the class of incomplete-migration bug that caused #259.

## How it works

`scripts/check_musl_migration.py`:

1. Collects every `symbol(&..., "NAME")` call under `lib/c/**/*.zig`, **excluding** target-specific files that don't apply to linux-musl: `wasi_sources.zig`, `wasi_cloudlibc.zig`, `wasi_thread_stub.zig`, and everything under `lib/c/win32/`.

2. Parses every `//"musl/src/.../foo.c", // migrated to <file>.zig` line in `src/libs/musl.zig`.

3. For each, expects the symbol named after the C-file stem (`foo`) to be in the collected symbol set. Annotations override the default:
   `// migrated to lib/c/stdio.zig; exports: __fbufsize,__fpending,...`

4. Fails if any expected symbol is missing.

## CI

New workflow `.github/workflows/lint-libc-migration.yml` runs on push / PR that touches `src/libs/musl.zig`, `lib/c/**`, the script, or the workflow. Takes ~1 second. Uses `ubuntu-latest` + `python 3.11`.

## Collateral findings

Running the lint against the current tree surfaced:

- **`netname.c` was not actually migrated.** Its symbols `getnetbyaddr` and `getnetbyname` have no Zig implementation. Reinstated the C file. (Low-impact: these are obsolete `/etc/networks`-database functions that nothing in CI links against, but they were silently missing.)

- **14 other `// migrated to` comments annotated** with explicit `; exports: ...` clauses because the filename stem differs from the exported symbol names. Examples:
  - `ext.c` → `_flushlbf,__fsetlocking,__fwriting,__freading,__freadable,__fwritable,__flbf,__fbufsize,__fpending,__fpurge`
  - `pthread_attr_get.c` → 15 `pthread_{attr,cond,mutex,barrier}attr_get*` accessors
  - `netlink.c` → `__rtnetlink_enumerate`
  - `find_exidx.c` → `__gnu_Unwind_Find_exidx`

After these edits the lint is clean: 114 entries checked, 1394 symbols found, zero findings.

## Local run

```
\$ python3 scripts/check_musl_migration.py
musl.zig migration lint: OK (114 'migrated to' entries, 1394 symbols under lib/c).
```

## Why now

Suggested as a follow-up in the #261 PR body. Builds on the root-cause analysis that #261 established: the only reliable way to tell whether a C→Zig migration is complete is to check that the claimed Zig export set exists — filename-based migration comments are easy to write and easy to get wrong.

Related: #259, #261, #229.
