### PR TITLE
ci: allow x86_64 musl failures + diagnose runner limits

### DIFF
--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -175,8 +175,34 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         run: git clone --depth 1 https://github.com/ctaggart/libc-test.git "$HOME/libc-test"
 
+      - name: Diagnose runner limits (x86_64)
+        if: steps.filter.outputs.skip != 'true' && matrix.name == 'x86_64'
+        run: |
+          echo "=== ulimits ==="
+          ulimit -a
+          echo "=== /proc/self/limits ==="
+          cat /proc/self/limits
+          echo "=== cgroup pids.max ==="
+          cat /sys/fs/cgroup/pids.max 2>/dev/null || echo "n/a"
+          echo "=== cgroup memory.max ==="
+          cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "n/a"
+          echo "=== nproc ==="
+          nproc
+          echo "=== free -m ==="
+          free -m
+          echo "=== vm.overcommit_memory ==="
+          cat /proc/sys/vm/overcommit_memory
+          echo "=== kernel.threads-max ==="
+          cat /proc/sys/kernel/threads-max
+
       - name: Run libc-test (${{ matrix.name }})
         if: steps.filter.outputs.skip != 'true'
+        # x86_64 native musl compile is known-flaky on ubuntu-latest runners:
+        # zig's musl-linked clang spawns too many std::thread instances and
+        # trips "thread constructor failed: Resource temporarily unavailable".
+        # Tracked in ctaggart/zig issue (see CI mitigation issue).
+        # Affects both x86_64-linux-musl AND x86_64-linux-muslx32 equally.
+        continue-on-error: ${{ matrix.name == 'x86_64' }}
         run: |
           # Raise thread/process limits to avoid "thread constructor failed:
           # Resource temporarily unavailable" during parallel musl sub-compiles.


### PR DESCRIPTION
Mitigates #269.

The `x86_64` matrix job in `.github/workflows/test-libc.yml` is flaky on `ubuntu-latest` runners — zig''s musl-linked clang trips `libc++abi: thread constructor failed: Resource temporarily unavailable` when compiling musl C sources. Affects both `x86_64-linux-musl` and `x86_64-linux-muslx32` equally (it is **not** muslx32-specific).

Changes:
- Mark the x86_64 matrix entry `continue-on-error: true` so flakiness doesn''t block the workflow.
- Add a new "Diagnose runner limits (x86_64)" step that dumps `ulimit -a`, `/proc/self/limits`, cgroup `pids.max` / `memory.max`, `nproc`, `free -m`, `vm.overcommit_memory`, `kernel.threads-max` — gives us forensic data on every run so we can pinpoint which limit is hit and iterate toward a real fix.

This is a temporary mitigation; see #269 for candidate real fixes (`-fno-integrated-cc1`, larger runner, glibc-built stage4, etc.).
