### PR TITLE
libc: fix ipc.zig semop on arches without SYS_semop

### DIFF
--- a/lib/c/ipc.zig
+++ b/lib/c/ipc.zig
@@ -110,12 +110,11 @@ fn semgetLinux(key: c_int, n: c_int, fl: c_int) callconv(.c) c_int {
 }
 
 fn semopLinux(id: c_int, buf: *anyopaque, n: usize) callconv(.c) c_int {
-    return errno(linux.syscall3(
-        .semop,
-        @as(usize, @bitCast(@as(isize, id))),
-        @intFromPtr(buf),
-        n,
-    ));
+    // Matches upstream musl: semop() delegates to semtimedop() with a NULL
+    // timeout. Avoids needing a SYS_semop syscall, which is absent on several
+    // architectures (x86, sparc, m68k, mipso32, powerpc, powerpc64, s390x) —
+    // semtimedopLinux already handles per-arch syscall selection.
+    return semtimedopLinux(id, buf, n, null);
 }
 
 fn semtimedopLinux(id: c_int, buf: *anyopaque, n: usize, ts: ?*const anyopaque) callconv(.c) c_int {


### PR DESCRIPTION
Fix `zigc` build failure on architectures that lack `SYS_semop`.

## Problem

`lib/c/ipc.zig` unconditionally referenced `.semop` in its `semopLinux` syscall wrapper:

```zig
return errno(linux.syscall3(
    .semop,
    ...
));
```

But `std.os.linux.SYS` has no `.semop` field on architectures that route SysV IPC through the `SYS_ipc` multiplexer: **X86, Sparc, M68k, MipsO32, PowerPC, PowerPC64, S390x**. Compiling `zigc` for these targets fails at comptime.

## Fix

Match upstream musl's implementation and delegate `semop()` → `semtimedop(..., NULL)`. `semtimedopLinux` already selects the correct syscall per arch via `@hasField(linux.SYS, "semtimedop_time64")`, and verifying every arch in `lib/std/os/linux/syscalls.zig` shows each has at least one of `semtimedop` or `semtimedop_time64`, so this compiles universally.

Per `semtimedop(2)`: *"If timeout is NULL, then semtimedop() behaves exactly like semop()."*

## Validation matrix

Every `.ipc`-multiplexer arch now compiles:

| Arch | has .semop | has .semtimedop | has .semtimedop_time64 |
|---|---|---|---|
| X86 | ❌ | ❌ | ✅ |
| Sparc | ❌ | ❌ | ✅ |
| Sparc64 | ❌ | ✅ | ❌ |
| M68k | ❌ | ❌ | ✅ |
| MipsO32 | ❌ | ❌ | ✅ |
| PowerPC | ❌ | ❌ | ✅ |
| PowerPC64 | ❌ | ✅ | ❌ |
| S390x | ❌ | ✅ | ❌ |

## Notes

Pre-existing bug (commit `65475e372e`); not introduced by the muslx32 work in #265. Fixing it here unblocks `zigc` across these targets.
