### PR TITLE
lib/c/thread: remove weak __clone stub that shadows musl asm

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -279,7 +279,6 @@ comptime {
         symbol(&pthread_testcancel_fn, "__pthread_testcancel");
         symbol(&sem_trywait_fn, "sem_trywait");
         symbol(&sem_post_fn, "sem_post");
-        symbol(&__clone_fn, "__clone");
         symbol(&__default_stacksize, "__default_stacksize");
         symbol(&__default_guardsize, "__default_guardsize");
     }
@@ -1456,10 +1455,6 @@ fn vm_unlock_fn() callconv(.c) void {
     {
         wake(@ptrCast(&vmlock[0]), -1, 1);
     }
-}
-
-fn __clone_fn(_: ?*const fn (?*anyopaque) callconv(.c) c_int, _: ?*anyopaque, _: c_int, _: ?*anyopaque) callconv(.c) c_int {
-    return -@as(c_int, @intCast(@intFromEnum(E.NOSYS)));
 }
 
 fn futexWait(addr: *volatile c_int, val: c_int, priv_flag: bool) void {


### PR DESCRIPTION
Remove the weak `__clone` stub in `lib/c/thread.zig` so musl's arch-specific `clone.s` is the sole definition at static-link time.

## Problem

Self-built zig (stage4) aborts on every threaded subprocess — e.g. `zig cc hello.c` → `zig ld.lld`:

```
libc++abi: terminating due to uncaught exception of type std::__1::system_error:
  thread constructor failed: Resource temporarily unavailable
```

Strace shows `pthread_create` does its mmap/mprotect/sigprocmask dance but **no `clone` syscall is ever issued** between the `SIG_BLOCK` and `SIG_SETMASK` calls.

## Root cause

`lib/c/thread.zig` defined:

```zig
symbol(&__clone_fn, "__clone");

fn __clone_fn(_: ?*const fn (?*anyopaque) callconv(.c) c_int, _: ?*anyopaque, _: c_int, _: ?*anyopaque) callconv(.c) c_int {
    return -@as(c_int, @intCast(@intFromEnum(E.NOSYS)));
}
```

`symbol()` exports with `.linkage = .weak`. But because the stub lives in a regular `.o` — not a `.a` archive — the linker accepts it as satisfying the reference and never pulls `clone.o` out of `libmusl.a`. The stub wins at link time, and musl's `pthread_create` translates every `__clone` failure to `EAGAIN`.

Full analysis in #273, including 2×2 isolation matrix proving the bug is binary-baked (independent of `ZIG_LIB_DIR`) and strace evidence (546 syscalls, zero of them `clone`).

## Fix

Delete the stub and the export registration. Musl's `lib/libc/musl/src/thread/x86_64/clone.s` (and siblings for other archs) then becomes the only `__clone` in the link.

Fixes #273