### PR TITLE
ci: revert x86_64 continue-on-error + runner-limits diagnostic

### DIFF
--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -175,34 +175,8 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         run: git clone --depth 1 https://github.com/ctaggart/libc-test.git "$HOME/libc-test"
 
-      - name: Diagnose runner limits (x86_64)
-        if: steps.filter.outputs.skip != 'true' && matrix.name == 'x86_64'
-        run: |
-          echo "=== ulimits ==="
-          ulimit -a
-          echo "=== /proc/self/limits ==="
-          cat /proc/self/limits
-          echo "=== cgroup pids.max ==="
-          cat /sys/fs/cgroup/pids.max 2>/dev/null || echo "n/a"
-          echo "=== cgroup memory.max ==="
-          cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "n/a"
-          echo "=== nproc ==="
-          nproc
-          echo "=== free -m ==="
-          free -m
-          echo "=== vm.overcommit_memory ==="
-          cat /proc/sys/vm/overcommit_memory
-          echo "=== kernel.threads-max ==="
-          cat /proc/sys/kernel/threads-max
-
       - name: Run libc-test (${{ matrix.name }})
         if: steps.filter.outputs.skip != 'true'
-        # x86_64 native musl compile is known-flaky on ubuntu-latest runners:
-        # zig's musl-linked clang spawns too many std::thread instances and
-        # trips "thread constructor failed: Resource temporarily unavailable".
-        # Tracked in ctaggart/zig issue (see CI mitigation issue).
-        # Affects both x86_64-linux-musl AND x86_64-linux-muslx32 equally.
-        continue-on-error: ${{ matrix.name == 'x86_64' }}
         run: |
           # Raise thread/process limits to avoid "thread constructor failed:
           # Resource temporarily unavailable" during parallel musl sub-compiles.


### PR DESCRIPTION
Root cause of the `thread constructor failed: Resource temporarily unavailable` flake on the x86_64 matrix job was the weak `__clone` stub in `lib/c/thread.zig` (fixed in #274, which closed #273 and #269), **not** `RLIMIT_NPROC` exhaustion on GitHub-hosted runners.

With both tracking issues now closed, the defensive mitigation added in ab6f05d734 only serves to mask real failures:

- Remove `continue-on-error: ${{ matrix.name == 'x86_64' }}` from the "Run libc-test" step
- Remove the "Diagnose runner limits (x86_64)" step that dumped ulimits/cgroup info for post-mortem

Pure deletion, inverse of ab6f05d734 (26 lines removed, 0 added).
