### PR TITLE
compiler: lower AAPCS64 va_arg in LLVM backend (fixes #251)

### DIFF
--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -198,7 +198,6 @@ comptime {
         symbol(&stdio_write_impl, "__stdio_write");
         symbol(&stdout_write_impl, "__stdout_write");
 
-        // vasprintf, vdprintf kept as C (see #243)
         symbol(&getdelim_impl, "getdelim");
 
         // Variadic entry points forwarding to v* implementations (unblocked by #243 fix).

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -1034,7 +1034,21 @@ pub const VaList = switch (builtin.cpu.arch) {
     .wasm64,
     .xcore,
     => *anyopaque,
-    .aarch64, .aarch64_be => switch (builtin.os.tag) {
+    // AAPCS64 SysV (non-Darwin / non-Windows). LLVM's AArch64 backend
+    // does not lower the `va_arg` IR instruction for non-Darwin targets
+    // (AArch64ISelLowering.cpp asserts `isTargetDarwin()`; see
+    // https://github.com/ziglang/zig/issues/14096). For `.stage2_llvm`
+    // little-endian aarch64, `src/codegen/llvm/FuncGen.zig::airCVaArg`
+    // now implements the AAPCS64 va_arg sequence manually for integer
+    // and pointer scalars; other types are surfaced as a codegen error.
+    // `.aarch64_be` still lacks the sub-word slot adjustment for
+    // right-justified loads, so it keeps the defensive compile-error.
+    // See ctaggart/zig#251.
+    .aarch64 => switch (builtin.os.tag) {
+        .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos, .windows => *u8,
+        else => VaListAarch64,
+    },
+    .aarch64_be => switch (builtin.os.tag) {
         .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos, .windows => *u8,
         else => switch (builtin.zig_backend) {
             else => VaListAarch64,

--- a/src/codegen/llvm/FuncGen.zig
+++ b/src/codegen/llvm/FuncGen.zig
@@ -1042,7 +1042,7 @@ fn airRetLoad(self: *FuncGen, inst: Air.Inst.Index) Allocator.Error!void {
     return;
 }
 
-fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) Allocator.Error!Builder.Value {
+fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) TodoError!Builder.Value {
     const o = self.object;
     const zcu = o.zcu;
     const target = zcu.getTarget();
@@ -1079,6 +1079,99 @@ fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) Allocator.Error!Builder.Value
             return self.wip.load(.normal, llvm_arg_ty, arg_ptr, arg_ty.abiAlignment(zcu).toLlvm(), "");
         }
         return self.wip.load(.normal, llvm_arg_ty, cur, slot_align, "");
+    }
+
+    // AAPCS64 SysV (non-Darwin, non-Windows, little-endian aarch64).
+    // LLVM asserts on the `va_arg` IR instruction for this target
+    // ("automatic va_arg instruction only works on Darwin" —
+    // AArch64ISelLowering.cpp). Lower manually, mirroring what clang
+    // emits for __builtin_va_arg. See ziglang/zig#14096, ctaggart/zig#251.
+    //
+    // AAPCS64 va_list layout (`lib/std/builtin.zig::VaListAarch64`):
+    //   +0:  __stack    (ptr)
+    //   +8:  __gr_top   (ptr)
+    //   +16: __vr_top   (ptr)
+    //   +24: __gr_offs  (i32, negative or 0; <0 means room remains in GP regs)
+    //   +28: __vr_offs  (i32, negative or 0; <0 means room remains in VR regs)
+    //
+    // MVP scope: scalar integers and pointers of 1, 2, 4, or 8 bytes
+    // consumed via the GP register save area, with spill-to-stack fallback.
+    // Larger integers (i128), floats, vectors, aggregates, and 16-byte-
+    // aligned types report a codegen TODO error — every `@cVaArg` site in
+    // libzigc fits the MVP scope.
+    const is_aapcs64 = target.cpu.arch == .aarch64 and
+        !target.os.tag.isDarwin() and target.os.tag != .windows;
+    if (is_aapcs64) {
+        const arg_size = arg_ty.abiSize(zcu);
+        const arg_align = arg_ty.abiAlignment(zcu);
+        const is_supported_scalar = switch (arg_ty.zigTypeTag(zcu)) {
+            .int, .bool, .pointer, .@"enum" => arg_size <= 8,
+            .optional => arg_ty.isPtrLikeOptional(zcu),
+            else => false,
+        };
+        if (!is_supported_scalar or arg_align.compare(.gt, .@"8")) {
+            return self.todo(
+                "aarch64 AAPCS @cVaArg only supports <=8-byte integer/pointer scalars " ++
+                    "(see ziglang/zig#14096); got type '{f}'",
+                .{arg_ty.fmt(self.pt)},
+            );
+        }
+
+        const ptr_align: Builder.Alignment = comptime .fromByteUnits(8);
+        const i32_align: Builder.Alignment = comptime .fromByteUnits(4);
+
+        // gr_offs_ptr = &ap->__gr_offs  (offset 24)
+        const gr_offs_ptr = try self.wip.gep(
+            .inbounds,
+            .i8,
+            list,
+            &.{try o.builder.intValue(.i32, 24)},
+            "vaarg.gr_offs_ptr",
+        );
+        const gr_offs = try self.wip.load(.normal, .i32, gr_offs_ptr, i32_align, "vaarg.gr_offs");
+        const zero_i32 = try o.builder.intValue(.i32, 0);
+        const in_regs = try self.wip.icmp(.slt, gr_offs, zero_i32, "vaarg.in_regs");
+
+        const in_regs_block = try self.wip.block(1, "VaArgInRegs");
+        const on_stack_block = try self.wip.block(1, "VaArgOnStack");
+        const done_block = try self.wip.block(2, "VaArgDone");
+
+        _ = try self.wip.brCond(in_regs, in_regs_block, on_stack_block, .none);
+
+        // in_regs:  reg_addr = __gr_top + sext(__gr_offs);  __gr_offs += 8
+        self.wip.cursor = .{ .block = in_regs_block };
+        const gr_top_ptr = try self.wip.gep(
+            .inbounds,
+            .i8,
+            list,
+            &.{try o.builder.intValue(.i32, 8)},
+            "vaarg.gr_top_ptr",
+        );
+        const gr_top = try self.wip.load(.normal, .ptr, gr_top_ptr, ptr_align, "vaarg.gr_top");
+        const gr_offs_i64 = try self.wip.cast(.sext, gr_offs, .i64, "vaarg.gr_offs64");
+        const reg_addr = try self.wip.gep(.inbounds, .i8, gr_top, &.{gr_offs_i64}, "vaarg.reg_addr");
+        const eight_i32 = try o.builder.intValue(.i32, 8);
+        const new_gr_offs = try self.wip.bin(.add, gr_offs, eight_i32, "vaarg.new_gr_offs");
+        _ = try self.wip.store(.normal, new_gr_offs, gr_offs_ptr, i32_align);
+        _ = try self.wip.br(done_block);
+
+        // on_stack:  stack_addr = ap->__stack;  ap->__stack += 8
+        self.wip.cursor = .{ .block = on_stack_block };
+        const stack_addr = try self.wip.load(.normal, .ptr, list, ptr_align, "vaarg.stack");
+        const eight_i64 = try o.builder.intValue(.i64, 8);
+        const new_stack = try self.wip.gep(.inbounds, .i8, stack_addr, &.{eight_i64}, "vaarg.new_stack");
+        _ = try self.wip.store(.normal, new_stack, list, ptr_align);
+        _ = try self.wip.br(done_block);
+
+        // done: addr = phi(reg_addr from regs, stack_addr from stack)
+        self.wip.cursor = .{ .block = done_block };
+        const addr_phi = try self.wip.phi(.ptr, "vaarg.addr");
+        addr_phi.finish(
+            &.{ reg_addr, stack_addr },
+            &.{ in_regs_block, on_stack_block },
+            &self.wip,
+        );
+        return self.wip.load(.normal, llvm_arg_ty, addr_phi.toValue(), arg_align.toLlvm(), "vaarg.val");
     }
 
     return self.wip.vaArg(list, llvm_arg_ty, "");

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -97,8 +97,8 @@ test "simple variadic function" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch.isAARCH64()) {
-        // https://github.com/ziglang/zig/issues/14096
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
         return error.SkipZigTest;
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
@@ -158,8 +158,8 @@ test "coerce reference to var arg" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch.isAARCH64()) {
-        // https://github.com/ziglang/zig/issues/14096
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
         return error.SkipZigTest;
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
@@ -189,8 +189,8 @@ test "variadic functions" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch.isAARCH64()) {
-        // https://github.com/ziglang/zig/issues/14096
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
         return error.SkipZigTest;
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
@@ -241,8 +241,8 @@ test "copy VaList" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch.isAARCH64()) {
-        // https://github.com/ziglang/zig/issues/14096
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
         return error.SkipZigTest;
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
@@ -275,8 +275,8 @@ test "unused VaList arg" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch.isAARCH64()) {
-        // https://github.com/ziglang/zig/issues/14096
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
         return error.SkipZigTest;
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
@@ -296,6 +296,50 @@ test "unused VaList arg" {
     };
     const x = S.thirdArg(0, @as(c_int, 1), @as(c_int, 2));
     try std.testing.expectEqual(@as(c_int, 2), x);
+}
+
+test "variadic function with GP register spill (aarch64 #251)" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
+        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
+        return error.SkipZigTest;
+    }
+    if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
+    if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
+    if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064
+
+    // AAPCS64 has 8 GP argument registers (x0-x7). With `count` consuming x0,
+    // passing 10 variadic c_long forces the last ~3 values to spill onto the
+    // stack, exercising both the in-regs and on-stack paths in the manually
+    // lowered va_arg (see ctaggart/zig#251).
+    const S = struct {
+        fn sum(count: c_int, ...) callconv(.c) c_long {
+            var ap = @cVaStart();
+            defer @cVaEnd(&ap);
+            var i: c_int = 0;
+            var acc: c_long = 0;
+            while (i < count) : (i += 1) acc += @cVaArg(&ap, c_long);
+            return acc;
+        }
+    };
+    const total = S.sum(
+        10,
+        @as(c_long, 1),
+        @as(c_long, 2),
+        @as(c_long, 3),
+        @as(c_long, 4),
+        @as(c_long, 5),
+        @as(c_long, 6),
+        @as(c_long, 7),
+        @as(c_long, 8),
+        @as(c_long, 9),
+        @as(c_long, 10),
+    );
+    try std.testing.expectEqual(@as(c_long, 55), total);
 }
 
 test "floating point VaList args" {


### PR DESCRIPTION
Fixes #251.

## Summary

Adds a Tier-3 carve-out in `src/codegen/llvm/FuncGen.zig` to manually
lower AAPCS64 `va_arg` in the LLVM backend, parallel to the `nextSystemV`
fix for x86_64 SysV (#243). Removes the defensive `@compileError` gate
in `lib/std/builtin.zig` for little-endian aarch64 non-Darwin non-Windows,
and unskips 4 gated behavior tests.

This unblocks all aarch64 variadic libzigc callsites (16+ `@cVaArg` usages
across process.zig, stdio.zig, misc.zig, ipc.zig, mq.zig, wasi_cloudlibc.zig).

## Scope

MVP: scalar integer/bool/pointer/enum ≤ 8 bytes with alignment ≤ 8.
This covers every current libzigc `@cVaArg` callsite. Larger types and
aarch64_be surface codegen TODO errors (follow-up).

## Background

Upstream LLVM `AArch64ISelLowering` asserts `isTargetDarwin()` on va_arg
IR (ziglang/zig#14096). The defensive `@compileError` gate in
`lib/std/builtin.zig` dates to commit 9bb1104e37 (Dec 2022). This PR
sidesteps upstream LLVM by emitting the AAPCS64 va_arg sequence ourselves
(reads `__gr_offs`, picks `__gr_top + sext(__gr_offs)` vs `__stack`,
advances, phis the two addresses, loads the argument).

Sibling/prior work:
- #243 — x86_64 SysV va_list ABI fix (Tier-3 carve-out in `nextSystemV`)
- #247 — removed x86_64-windows defensive gate separately

## Validation

CI (test-libc.yml, branch=ai, fix branch checked out):
- run 24829266000 `test-filter=process` — aarch64: ✅ success (10/10 targets green)
- run 24829273652 `test-filter=stdio` — aarch64: ✅ success (10/10 targets green)

Files changed: 4, +163/-13.
- `lib/c/stdio.zig`: -1 (stale #243 comment)
- `lib/std/builtin.zig`: +16/-1 (remove gate for LE aarch64 non-Darwin non-Windows; aarch64_be stays gated)
- `src/codegen/llvm/FuncGen.zig`: +95 (manual AAPCS64 va_arg lowering)
- `test/behavior/var_args.zig`: +64/-10 (unskip 4 aarch64 stage2_llvm gates + add 10-c_long register-spill test)