### PR TITLE
compiler: extend AAPCS64 va_arg lowering to aarch64_be

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -1038,22 +1038,14 @@ pub const VaList = switch (builtin.cpu.arch) {
     // does not lower the `va_arg` IR instruction for non-Darwin targets
     // (AArch64ISelLowering.cpp asserts `isTargetDarwin()`; see
     // https://github.com/ziglang/zig/issues/14096). For `.stage2_llvm`
-    // little-endian aarch64, `src/codegen/llvm/FuncGen.zig::airCVaArg`
-    // now implements the AAPCS64 va_arg sequence manually for integer
-    // and pointer scalars; other types are surfaced as a codegen error.
-    // `.aarch64_be` still lacks the sub-word slot adjustment for
-    // right-justified loads, so it keeps the defensive compile-error.
-    // See ctaggart/zig#251.
-    .aarch64 => switch (builtin.os.tag) {
+    // aarch64 and aarch64_be, `src/codegen/llvm/FuncGen.zig::airCVaArg`
+    // implements the AAPCS64 va_arg sequence manually for integer and
+    // pointer scalars (with right-justified slot loads on big-endian);
+    // other types are surfaced as a codegen error tracked by
+    // ctaggart/zig#282. See ctaggart/zig#251, ctaggart/zig#281.
+    .aarch64, .aarch64_be => switch (builtin.os.tag) {
         .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos, .windows => *u8,
         else => VaListAarch64,
-    },
-    .aarch64_be => switch (builtin.os.tag) {
-        .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos, .windows => *u8,
-        else => switch (builtin.zig_backend) {
-            else => VaListAarch64,
-            .stage2_llvm => @compileError("disabled due to miscompilations"),
-        },
     },
     // On x86_64 Windows/UEFI, `va_list` is a single pointer, so the
     // implementation is trivial compared to the SysV register-save-area

--- a/src/codegen/llvm/FuncGen.zig
+++ b/src/codegen/llvm/FuncGen.zig
@@ -1081,11 +1081,12 @@ fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) TodoError!Builder.Value {
         return self.wip.load(.normal, llvm_arg_ty, cur, slot_align, "");
     }
 
-    // AAPCS64 SysV (non-Darwin, non-Windows, little-endian aarch64).
+    // AAPCS64 SysV (non-Darwin, non-Windows; little- and big-endian aarch64).
     // LLVM asserts on the `va_arg` IR instruction for this target
     // ("automatic va_arg instruction only works on Darwin" —
     // AArch64ISelLowering.cpp). Lower manually, mirroring what clang
-    // emits for __builtin_va_arg. See ziglang/zig#14096, ctaggart/zig#251.
+    // emits for __builtin_va_arg. See ziglang/zig#14096, ctaggart/zig#251,
+    // ctaggart/zig#282 (big-endian + non-scalar follow-up).
     //
     // AAPCS64 va_list layout (`lib/std/builtin.zig::VaListAarch64`):
     //   +0:  __stack    (ptr)
@@ -1096,10 +1097,12 @@ fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) TodoError!Builder.Value {
     //
     // MVP scope: scalar integers and pointers of 1, 2, 4, or 8 bytes
     // consumed via the GP register save area, with spill-to-stack fallback.
-    // Larger integers (i128), floats, vectors, aggregates, and 16-byte-
-    // aligned types report a codegen TODO error — every `@cVaArg` site in
-    // libzigc fits the MVP scope.
-    const is_aapcs64 = target.cpu.arch == .aarch64 and
+    // On aarch64_be, sub-8B scalars are right-justified in their 8B slot —
+    // add `8 - arg_size` to the slot base before the load. Larger integers
+    // (i128), floats, vectors, aggregates, HFA/HVA, and 16-byte-aligned
+    // types report a codegen TODO error — every `@cVaArg` site in libzigc
+    // fits the MVP scope (see #282 for the non-scalar follow-up).
+    const is_aapcs64 = (target.cpu.arch == .aarch64 or target.cpu.arch == .aarch64_be) and
         !target.os.tag.isDarwin() and target.os.tag != .windows;
     if (is_aapcs64) {
         const arg_size = arg_ty.abiSize(zcu);
@@ -1112,10 +1115,12 @@ fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) TodoError!Builder.Value {
         if (!is_supported_scalar or arg_align.compare(.gt, .@"8")) {
             return self.todo(
                 "aarch64 AAPCS @cVaArg only supports <=8-byte integer/pointer scalars " ++
-                    "(see ziglang/zig#14096); got type '{f}'",
+                    "(see ziglang/zig#14096, ctaggart/zig#282); got type '{f}'",
                 .{arg_ty.fmt(self.pt)},
             );
         }
+        const is_be = target.cpu.arch == .aarch64_be;
+        const be_slot_offset: i64 = if (is_be and arg_size < 8) @intCast(8 - arg_size) else 0;
 
         const ptr_align: Builder.Alignment = comptime .fromByteUnits(8);
         const i32_align: Builder.Alignment = comptime .fromByteUnits(4);
@@ -1171,7 +1176,15 @@ fn airCVaArg(self: *FuncGen, inst: Air.Inst.Index) TodoError!Builder.Value {
             &.{ in_regs_block, on_stack_block },
             &self.wip,
         );
-        return self.wip.load(.normal, llvm_arg_ty, addr_phi.toValue(), arg_align.toLlvm(), "vaarg.val");
+        // On aarch64_be, sub-8B scalars are right-justified in their 8B slot.
+        const load_addr = if (be_slot_offset == 0) addr_phi.toValue() else try self.wip.gep(
+            .inbounds,
+            .i8,
+            addr_phi.toValue(),
+            &.{try o.builder.intValue(.i64, be_slot_offset)},
+            "vaarg.be_addr",
+        );
+        return self.wip.load(.normal, llvm_arg_ty, load_addr, arg_align.toLlvm(), "vaarg.val");
     }
 
     return self.wip.vaArg(list, llvm_arg_ty, "");

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -97,10 +97,6 @@ test "simple variadic function" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
     if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
     if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064
@@ -158,10 +154,6 @@ test "coerce reference to var arg" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
 
     const S = struct {
@@ -189,10 +181,6 @@ test "variadic functions" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
     if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
     if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064
@@ -241,10 +229,6 @@ test "copy VaList" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
     if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
     if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064
@@ -275,10 +259,6 @@ test "unused VaList arg" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
     if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
     if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064
@@ -304,10 +284,6 @@ test "variadic function with GP register spill (aarch64 #251)" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_llvm and !builtin.os.tag.isDarwin() and builtin.cpu.arch == .aarch64_be) {
-        // https://github.com/ziglang/zig/issues/14096 — aarch64_be still unsupported.
-        return error.SkipZigTest;
-    }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
     if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
     if (builtin.cpu.arch.isRISCV() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/25064


### PR DESCRIPTION
Follow-up to #281. Drops the defensive `@compileError` gate on
`aarch64_be` for `.stage2_llvm` and applies AAPCS64 big-endian
right-justification for sub-8B scalars in their 8B register/stack slots.

## Change

- `src/codegen/llvm/FuncGen.zig`: `is_aapcs64` now accepts both
  `.aarch64` and `.aarch64_be`. When `arg_size < 8` on `aarch64_be`,
  add `8 - arg_size` to the final slot address before the load
  (applied uniformly via one GEP after the addr phi since both the reg
  and stack paths use 8B slots).
- `lib/std/builtin.zig`: unify the `.aarch64` and `.aarch64_be` arms;
  drop the `stage2_llvm` `@compileError` for `aarch64_be`.
- `test/behavior/var_args.zig`: unskip the six `aarch64_be`
  `SkipZigTest` guards added in #281 (now covered).

## Scope

Same MVP as #281: scalar integer / bool / pointer / enum, size ≤ 8B,
alignment ≤ 8B. Every `@cVaArg` site in libzigc fits this scope.

Non-scalar types, HFA/HVA, 16-byte-aligned scalars (`__int128`), and
the VR (float/vector) register save area (`__vr_top` / `__vr_offs`)
remain **out of scope** — partial fix only. Per rubber-duck review,
a proper composite path needs ABI classification + 2-slot overflow
checks + soft/hard-float split + targeted behavior tests, none of which
have a libzigc consumer today. Tracked by the remaining items on #282.

## Validation

Dispatched `test-libc.yml` on `ai` against this branch:

| Filter | Result |
|---|---|
| `process` | ✅ 11/11 (run 24846932223) |
| `stdio` | ✅ 11/11 (run 24846932234) |

Both matrices cross-compile aarch64_be-linux-musl via libzigc with
variadic-heavy call sites (execl family, printf family) — exactly the
paths this PR touches.

`env` / `thread` / `math` runs hit pre-existing pthread-mutex
SIGABRT flakes on the 2-core GitHub-hosted aarch64 cross job (runner
thread exhaustion); retries of those same compiles within the same
job succeeded, confirming the code path itself is fine.

## References

- #281 (LE MVP, merged)
- #251 (original LE bug)
- #243 (x86_64 SysV analog)
- ziglang/zig#14096 (upstream LLVM `AArch64ISelLowering` asserts
  `isTargetDarwin()` on `va_arg`)

Partial fix for #282; the non-scalar arm stays open.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>