### PR TITLE
libzigc: migrate timer_getoverrun, __emulate_wait4, timer_gettime to Zig (#302, #301, #300)

### DIFF
--- a/lib/c/internal.zig
+++ b/lib/c/internal.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const c = @import("../c.zig");
+const linux = std.os.linux;
 
 // syscall_ret.c — syscall return value to errno conversion
 fn syscall_retLinux(r: c_ulong) callconv(.c) c_long {
@@ -63,10 +64,70 @@ var hwcap: usize = 0;
 var progname: ?[*]u8 = null;
 var progname_full: ?[*]u8 = null;
 
+// emulate_wait4.c — wait4 emulation via SYS_waitid for arches lacking
+// SYS_wait4 (currently riscv32, loongarch32). Mirrors musl's
+// `#ifndef SYS_wait4` gate and reproduces the kernel-ABI status word that
+// wait4 would have returned by translating siginfo_t fields.
+const WEXITED: c_int = 4;
+
+fn __emulate_wait4Linux(
+    pid: c_int,
+    status: ?*c_int,
+    options: c_int,
+    kru: ?*linux.rusage,
+    cp: c_int,
+) callconv(.c) c_long {
+    _ = cp; // cancellation point not implemented; same path as non-cp
+    var info: linux.siginfo_t = undefined;
+    info.fields.common.first.piduid.pid = 0;
+
+    var p: c_int = pid;
+    const t: linux.P = if (pid < -1) blk: {
+        p = -pid;
+        break :blk .PGID;
+    } else if (pid == -1) .ALL else if (pid == 0) .PGID else .PID;
+
+    const r: isize = @bitCast(linux.syscall5(
+        .waitid,
+        @intFromEnum(t),
+        @as(usize, @bitCast(@as(isize, p))),
+        @intFromPtr(&info),
+        @as(usize, @bitCast(@as(isize, options | WEXITED))),
+        @intFromPtr(kru),
+    ));
+
+    if (r < 0) return @intCast(r);
+
+    const si_pid = info.fields.common.first.piduid.pid;
+    if (si_pid != 0) if (status) |sp| {
+        const si_status = info.fields.common.second.sigchld.status;
+        const code: linux.CLD = @enumFromInt(info.code);
+        var sw: c_int = 0;
+        switch (code) {
+            .CONTINUED => sw = 0xffff,
+            .DUMPED => sw = (si_status & 0x7f) | 0x80,
+            .EXITED => sw = (si_status & 0xff) << 8,
+            .KILLED => sw = si_status & 0x7f,
+            .STOPPED, .TRAPPED => sw = (si_status << 8) + 0x7f,
+            else => {},
+        }
+        sp.* = sw;
+    };
+
+    return @as(c_long, si_pid);
+}
+
 comptime {
     if (builtin.target.isMuslLibC()) {
         c.symbol(&syscall_retLinux, "__syscall_ret");
         c.symbol(&procfdnameLinux, "__procfdname");
+
+        // Export __emulate_wait4 only on arches where musl needs it (i.e. those
+        // lacking SYS_wait4). On other arches musl's `__sys_wait4` macro inlines
+        // a direct SYS_wait4 syscall and never calls this helper.
+        if (!@hasField(linux.SYS, "wait4")) {
+            c.symbol(&__emulate_wait4Linux, "__emulate_wait4");
+        }
 
         @export(&libc_version, .{ .name = "__libc_version", .linkage = .weak, .visibility = .hidden });
         @export(&sysinfo, .{ .name = "__sysinfo", .linkage = .weak, .visibility = .hidden });

--- a/lib/c/time.zig
+++ b/lib/c/time.zig
@@ -73,6 +73,7 @@ comptime {
         symbol(&clockLinux, "clock");
         symbol(&clock_getcpuclockidLinux, "clock_getcpuclockid");
         symbol(&timer_deleteLinux, "timer_delete");
+        symbol(&timer_getoverrunLinux, "timer_getoverrun");
     }
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
         symbol(&difftimeImpl, "difftime");
@@ -546,4 +547,16 @@ fn timer_deleteLinux(t: *opaque {}) callconv(.c) c_int {
         return 0;
     }
     return errno(linux.syscall1(.timer_delete, @intFromPtr(t)));
+}
+
+// timer_getoverrun.c
+fn timer_getoverrunLinux(t: *opaque {}) callconv(.c) c_int {
+    var sys_t: usize = @intFromPtr(t);
+    const t_int: isize = @bitCast(sys_t);
+    if (t_int < 0) {
+        const td_addr: usize = sys_t << 1;
+        const timer_id: c_int = (@as(*const c_int, @ptrFromInt(td_addr + off_timer_id))).*;
+        sys_t = @as(usize, @intCast(timer_id & std.math.maxInt(c_int)));
+    }
+    return errno(linux.syscall1(.timer_getoverrun, sys_t));
 }

--- a/lib/c/time.zig
+++ b/lib/c/time.zig
@@ -74,6 +74,7 @@ comptime {
         symbol(&clock_getcpuclockidLinux, "clock_getcpuclockid");
         symbol(&timer_deleteLinux, "timer_delete");
         symbol(&timer_getoverrunLinux, "timer_getoverrun");
+        symbol(&timer_gettimeLinux, "timer_gettime");
     }
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
         symbol(&difftimeImpl, "difftime");
@@ -559,4 +560,42 @@ fn timer_getoverrunLinux(t: *opaque {}) callconv(.c) c_int {
         sys_t = @as(usize, @intCast(timer_id & std.math.maxInt(c_int)));
     }
     return errno(linux.syscall1(.timer_getoverrun, sys_t));
+}
+
+// timer_gettime.c
+fn timer_gettimeLinux(t: *opaque {}, val: *linux.itimerspec) callconv(.c) c_int {
+    var sys_t: usize = @intFromPtr(t);
+    const t_int: isize = @bitCast(sys_t);
+    if (t_int < 0) {
+        const td_addr: usize = sys_t << 1;
+        const timer_id: c_int = (@as(*const c_int, @ptrFromInt(td_addr + off_timer_id))).*;
+        sys_t = @as(usize, @intCast(timer_id & std.math.maxInt(c_int)));
+    }
+
+    if (comptime !@hasField(linux.SYS, "timer_gettime64")) {
+        // 64-bit-time arches: timer_gettime is the kernel's natural 64-bit-time entry.
+        return errno(linux.syscall2(.timer_gettime, sys_t, @intFromPtr(val)));
+    }
+    if (comptime !@hasField(linux.SYS, "timer_gettime")) {
+        // 32-bit-time-only arches (riscv32, loongarch32): only timer_gettime64 exists.
+        return errno(linux.syscall2(.timer_gettime64, sys_t, @intFromPtr(val)));
+    }
+    // Legacy 32-bit arches with both: prefer time64, fall back to legacy on -ENOSYS.
+    const enosys: isize = -@as(isize, @intFromEnum(linux.E.NOSYS));
+    var r: isize = enosys;
+    if (@sizeOf(linux.time_t) > 4) {
+        r = @bitCast(linux.syscall2(.timer_gettime64, sys_t, @intFromPtr(val)));
+    }
+    if (r != enosys) {
+        return errno(@as(usize, @bitCast(r)));
+    }
+    var val32: [4]c_long = undefined;
+    r = @bitCast(linux.syscall2(.timer_gettime, sys_t, @intFromPtr(&val32)));
+    if (r == 0) {
+        val.it_interval.sec = @intCast(val32[0]);
+        val.it_interval.nsec = @intCast(val32[1]);
+        val.it_value.sec = @intCast(val32[2]);
+        val.it_value.nsec = @intCast(val32[3]);
+    }
+    return errno(@as(usize, @bitCast(r)));
 }

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -838,7 +838,7 @@ const src_files = [_][]const u8{
     //"musl/src/time/time.c", // migrated to lib/c/time.zig
     "musl/src/time/timer_create.c",
     //"musl/src/time/timer_delete.c", // migrated to lib/c/time.zig
-    "musl/src/time/timer_getoverrun.c",
+    //"musl/src/time/timer_getoverrun.c", // migrated to lib/c/time.zig
     "musl/src/time/timer_gettime.c",
     "musl/src/time/timer_settime.c",
     "musl/src/time/__tz.c",

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -471,7 +471,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/s390x/fenv.c",
     "musl/src/fenv/x32/fenv.s",
     "musl/src/fenv/x86_64/fenv.s",
-    "musl/src/internal/emulate_wait4.c",
+    //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig
     "musl/src/internal/floatscan.c",
     "musl/src/internal/i386/defsysinfo.s",
     "musl/src/internal/intscan.c",

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -471,7 +471,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/s390x/fenv.c",
     "musl/src/fenv/x32/fenv.s",
     "musl/src/fenv/x86_64/fenv.s",
-    //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig
+    //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig; exports: __emulate_wait4
     "musl/src/internal/floatscan.c",
     "musl/src/internal/i386/defsysinfo.s",
     "musl/src/internal/intscan.c",

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -839,7 +839,7 @@ const src_files = [_][]const u8{
     "musl/src/time/timer_create.c",
     //"musl/src/time/timer_delete.c", // migrated to lib/c/time.zig
     //"musl/src/time/timer_getoverrun.c", // migrated to lib/c/time.zig
-    "musl/src/time/timer_gettime.c",
+    //"musl/src/time/timer_gettime.c", // migrated to lib/c/time.zig
     "musl/src/time/timer_settime.c",
     "musl/src/time/__tz.c",
     "musl/src/time/wcsftime.c",


### PR DESCRIPTION
Three small libzigc migrations from `lib/libc/musl/src/` to `lib/c/`, addressing recent daily-status flagged C files.

## Commits

* **41a03740f1** — `timer_getoverrun` → `lib/c/time.zig`. Single-syscall wrapper; reuses the thread-encoded `timer_t` decode pattern from `timer_deleteLinux`. **Closes #302.**
* **ed1ba96566** — `__emulate_wait4` → `lib/c/internal.zig`. Added a `linux` import and re-implemented musl's `waitid`-based `wait4` shim used as a fallback on arches without `SYS_wait4` (riscv32, loongarch32). The `symbol()` export is gated on `!@hasField(linux.SYS, "wait4")` so it only emits where needed. **Closes #301.**
* **f259352ba6** — `timer_gettime` → `lib/c/time.zig`. Mirrors musl's three-way split based on syscall availability:
  - `timer_gettime` only: natural 64-bit-time arches (direct syscall).
  - `timer_gettime64` only: riscv32/loongarch32 (direct syscall).
  - Both available: legacy 32-bit arches — try `timer_gettime64` first, fall back to `timer_gettime` on `-ENOSYS` and unpack 4×long into the user's `itimerspec`.
  **Closes #300.**

## Effect

`src/libs/musl.zig` now comments out three more entries:
```
//"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig
//"musl/src/time/timer_getoverrun.c", // migrated to lib/c/time.zig
//"musl/src/time/timer_gettime.c", // migrated to lib/c/time.zig
```

## Verification

- `zig fmt --ast-check` is clean on both modified files.
- CI (test-libc.yml) will be dispatched on the `ai` branch with this PR's branch and the `time` and `process` filters.

Closes #302
Closes #301
Closes #300