### PR TITLE
libzigc: libzigc: migrate internal floatscan from C to Zig

### DIFF
--- a/lib/c/internal.zig
+++ b/lib/c/internal.zig
@@ -64,6 +64,283 @@ var hwcap: usize = 0;
 var progname: ?[*]u8 = null;
 var progname_full: ?[*]u8 = null;
 
+const off_t = c_longlong;
+const EINVAL = 22;
+const ERANGE = 34;
+
+// floatscan.c — scanner for strtod/scanf-family floating point conversion.
+// This matches musl's FILE layout closely enough to interoperate with the
+// existing shgetc helpers and with the string pseudo-FILEs used by strtod.
+const InternalFile = extern struct {
+    flags: c_uint,
+    rpos: ?[*]u8,
+    rend: ?[*]u8,
+    close_fn: ?*anyopaque,
+    wend: ?[*]u8,
+    wpos: ?[*]u8,
+    mustbezero_1: ?[*]u8,
+    wbase: ?[*]u8,
+    read_fn: ?*anyopaque,
+    write_fn: ?*anyopaque,
+    seek_fn: ?*anyopaque,
+    buf: ?[*]u8,
+    buf_size: usize,
+    prev: ?*anyopaque,
+    next: ?*anyopaque,
+    fd: c_int,
+    pipe_pid: c_int,
+    lockcount: c_long,
+    mode: c_int,
+    lock: c_int,
+    lbf: c_int,
+    cookie: ?*anyopaque,
+    off: off_t,
+    getln_buf: ?[*]u8,
+    mustbezero_2: ?*anyopaque,
+    shend: ?[*]u8,
+    shlim_val: off_t,
+    shcnt_val: off_t,
+    prev_locked: ?*anyopaque,
+    next_locked: ?*anyopaque,
+    locale: ?*anyopaque,
+};
+
+extern "c" fn __shgetc(f: *InternalFile) c_int;
+
+fn shgetc(f: *InternalFile) c_int {
+    if (f.rpos != f.shend) {
+        const p = f.rpos.?;
+        const ch: c_int = p[0];
+        f.rpos = p + 1;
+        return ch;
+    }
+    return __shgetc(f);
+}
+
+fn shunget(f: *InternalFile) void {
+    if (f.shlim_val >= 0) f.rpos = f.rpos.? - 1;
+}
+
+fn shlim(f: *InternalFile, lim: off_t) void {
+    f.shlim_val = lim;
+    f.shcnt_val = @as(off_t, @intCast(@intFromPtr(f.buf.?) - @intFromPtr(f.rpos.?)));
+    if (lim != 0 and @as(off_t, @intCast(@intFromPtr(f.rend.?) - @intFromPtr(f.rpos.?))) > lim)
+        f.shend = f.rpos.? + @as(usize, @intCast(lim))
+    else
+        f.shend = f.rend;
+}
+
+fn setErrno(e: c_int) void {
+    std.c._errno().* = e;
+}
+
+fn asciiLower(ch: c_int) c_int {
+    return ch | 32;
+}
+
+fn isDigit(ch: c_int) bool {
+    return ch >= '0' and ch <= '9';
+}
+
+fn isHexDigit(ch: c_int) bool {
+    const lower = asciiLower(ch);
+    return isDigit(ch) or (lower >= 'a' and lower <= 'f');
+}
+
+fn isNanChar(ch: c_int) bool {
+    const lower = asciiLower(ch);
+    return isDigit(ch) or (lower >= 'a' and lower <= 'z') or ch == '_';
+}
+
+fn isSpace(ch: c_int) bool {
+    return std.ascii.isWhitespace(@truncate(@as(c_uint, @bitCast(ch))));
+}
+
+fn appendFloatScan(buf: *[4096]u8, len: *usize, ch: c_int) void {
+    if (len.* < buf.len) {
+        buf[len.*] = @intCast(ch);
+        len.* += 1;
+    }
+}
+
+fn popFloatScan(len: *usize) void {
+    if (len.* != 0) len.* -= 1;
+}
+
+fn invalidFloatScan(f: *InternalFile) c_longdouble {
+    setErrno(EINVAL);
+    shlim(f, 0);
+    return 0;
+}
+
+fn parseScannedFloat(comptime T: type, s: []const u8, saw_nonzero: bool) c_longdouble {
+    const parsed = std.fmt.parseFloat(T, s) catch {
+        setErrno(EINVAL);
+        return 0;
+    };
+    if (!std.math.isFinite(parsed)) {
+        setErrno(ERANGE);
+    } else if (parsed == 0 and saw_nonzero) {
+        setErrno(ERANGE);
+    }
+    return @floatCast(parsed);
+}
+
+fn finishScannedFloat(s: []const u8, prec: c_int, saw_nonzero: bool) c_longdouble {
+    return switch (prec) {
+        0 => parseScannedFloat(f32, s, saw_nonzero),
+        1 => parseScannedFloat(f64, s, saw_nonzero),
+        2 => parseScannedFloat(c_longdouble, s, saw_nonzero),
+        else => 0,
+    };
+}
+
+fn scanExponentSuffix(f: *InternalFile, buf: *[4096]u8, len: *usize, marker: c_int) void {
+    appendFloatScan(buf, len, marker);
+    var ch = shgetc(f);
+    var had_sign = false;
+    if (ch == '+' or ch == '-') {
+        had_sign = true;
+        appendFloatScan(buf, len, ch);
+        ch = shgetc(f);
+    }
+    if (!isDigit(ch)) {
+        shunget(f);
+        if (had_sign) {
+            shunget(f);
+            popFloatScan(len);
+        }
+        popFloatScan(len);
+        return;
+    }
+    while (isDigit(ch)) : (ch = shgetc(f)) appendFloatScan(buf, len, ch);
+    if (ch >= 0) shunget(f);
+}
+
+fn scanInfTail(f: *InternalFile, buf: *[4096]u8, len: *usize) void {
+    const tail = "inity";
+    var consumed: usize = 0;
+    for (tail) |want| {
+        const ch = shgetc(f);
+        if (asciiLower(ch) != want) {
+            if (ch >= 0) shunget(f);
+            while (consumed != 0) : (consumed -= 1) {
+                shunget(f);
+                popFloatScan(len);
+            }
+            return;
+        }
+        appendFloatScan(buf, len, ch);
+        consumed += 1;
+    }
+}
+
+fn floatscan(f: *InternalFile, prec: c_int, pok: c_int) callconv(.c) c_longdouble {
+    _ = pok;
+    var buf: [4096]u8 = undefined;
+    var len: usize = 0;
+    var saw_nonzero = false;
+
+    var ch = shgetc(f);
+    while (isSpace(ch)) ch = shgetc(f);
+
+    if (ch == '+' or ch == '-') {
+        appendFloatScan(&buf, &len, ch);
+        ch = shgetc(f);
+    }
+
+    if (asciiLower(ch) == 'i') {
+        appendFloatScan(&buf, &len, ch);
+        const n = shgetc(f);
+        const fch = shgetc(f);
+        if (asciiLower(n) != 'n' or asciiLower(fch) != 'f') {
+            if (fch >= 0) shunget(f);
+            if (n >= 0) shunget(f);
+            return invalidFloatScan(f);
+        }
+        appendFloatScan(&buf, &len, n);
+        appendFloatScan(&buf, &len, fch);
+        scanInfTail(f, &buf, &len);
+        return finishScannedFloat(buf[0..len], prec, true);
+    }
+
+    if (asciiLower(ch) == 'n') {
+        appendFloatScan(&buf, &len, ch);
+        const a = shgetc(f);
+        const n = shgetc(f);
+        if (asciiLower(a) != 'a' or asciiLower(n) != 'n') {
+            if (n >= 0) shunget(f);
+            if (a >= 0) shunget(f);
+            return invalidFloatScan(f);
+        }
+        appendFloatScan(&buf, &len, a);
+        appendFloatScan(&buf, &len, n);
+        ch = shgetc(f);
+        if (ch == '(') {
+            appendFloatScan(&buf, &len, ch);
+            while (true) {
+                ch = shgetc(f);
+                if (isNanChar(ch)) appendFloatScan(&buf, &len, ch) else break;
+            }
+            if (ch == ')') appendFloatScan(&buf, &len, ch) else if (ch >= 0) shunget(f);
+        } else if (ch >= 0) shunget(f);
+        return finishScannedFloat(buf[0..len], prec, true);
+    }
+
+    var gotdig = false;
+    if (ch == '0') {
+        appendFloatScan(&buf, &len, ch);
+        gotdig = true;
+        ch = shgetc(f);
+        if (asciiLower(ch) == 'x') {
+            appendFloatScan(&buf, &len, ch);
+            var gothex = false;
+            ch = shgetc(f);
+            while (isHexDigit(ch)) : (ch = shgetc(f)) {
+                gothex = true;
+                if (ch != '0') saw_nonzero = true;
+                appendFloatScan(&buf, &len, ch);
+            }
+            if (ch == '.') {
+                appendFloatScan(&buf, &len, ch);
+                ch = shgetc(f);
+                while (isHexDigit(ch)) : (ch = shgetc(f)) {
+                    gothex = true;
+                    if (ch != '0') saw_nonzero = true;
+                    appendFloatScan(&buf, &len, ch);
+                }
+            }
+            if (!gothex) {
+                if (ch >= 0) shunget(f);
+                shunget(f);
+                popFloatScan(&len);
+                return finishScannedFloat(buf[0..len], prec, false);
+            }
+            if (asciiLower(ch) == 'p') scanExponentSuffix(f, &buf, &len, ch) else if (ch >= 0) shunget(f);
+            return finishScannedFloat(buf[0..len], prec, saw_nonzero);
+        }
+    }
+
+    while (isDigit(ch)) : (ch = shgetc(f)) {
+        gotdig = true;
+        if (ch != '0') saw_nonzero = true;
+        appendFloatScan(&buf, &len, ch);
+    }
+    if (ch == '.') {
+        appendFloatScan(&buf, &len, ch);
+        ch = shgetc(f);
+        while (isDigit(ch)) : (ch = shgetc(f)) {
+            gotdig = true;
+            if (ch != '0') saw_nonzero = true;
+            appendFloatScan(&buf, &len, ch);
+        }
+    }
+
+    if (!gotdig) return invalidFloatScan(f);
+    if (asciiLower(ch) == 'e') scanExponentSuffix(f, &buf, &len, ch) else if (ch >= 0) shunget(f);
+    return finishScannedFloat(buf[0..len], prec, saw_nonzero);
+}
+
 // emulate_wait4.c — wait4 emulation via SYS_waitid for arches lacking
 // SYS_wait4 (currently riscv32, loongarch32). Mirrors musl's
 // `#ifndef SYS_wait4` gate and reproduces the kernel-ABI status word that
@@ -121,6 +398,7 @@ comptime {
     if (builtin.target.isMuslLibC()) {
         c.symbol(&syscall_retLinux, "__syscall_ret");
         c.symbol(&procfdnameLinux, "__procfdname");
+        c.symbol(&floatscan, "__floatscan");
 
         // Export __emulate_wait4 only on arches where musl needs it (i.e. those
         // lacking SYS_wait4). On other arches musl's `__sys_wait4` macro inlines

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -472,7 +472,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/x32/fenv.s",
     "musl/src/fenv/x86_64/fenv.s",
     //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig; exports: __emulate_wait4
-    "musl/src/internal/floatscan.c",
+    //"musl/src/internal/floatscan.c", // migrated to lib/c/internal.zig; exports: __floatscan
     "musl/src/internal/i386/defsysinfo.s",
     "musl/src/internal/intscan.c",
     "musl/src/internal/shgetc.c",


### PR DESCRIPTION
Closes #325

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/325

See branch libzigc-internal-floatscan on the cataggar fork for the implementation.