### PR TITLE
libzigc: libzigc: migrate thread __set_thread_area (arm), __tls_get_addr from C to Zig

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -124,6 +124,7 @@ const PtCb = extern struct {
 const PR_SET_NAME: usize = 15;
 const PR_GET_NAME: usize = 16;
 const AT_FDCWD: usize = @bitCast(@as(isize, -100));
+const AT_PLATFORM: usize = 15;
 const O_CLOEXEC: usize = 0o2000000;
 const thrd_success: c_int = 0;
 const thrd_error: c_int = 2;


### PR DESCRIPTION
Closes #334

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/334

See branch libzigc-thread-tls on the cataggar fork for the implementation.