### PR TITLE
libzigc: libzigc: migrate network byte-order helpers (htonl, htons, ntohl, ntohs) from C to Zig

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -198,7 +198,38 @@ const c = if (builtin.link_libc) struct {
 // ============================================================
 
 comptime {
+    if (builtin.target.isMuslLibC()) {
+        // htonl.c / htons.c / ntohl.c / ntohs.c
+        symbol(&htonl_impl, "htonl");
+        symbol(&htons_impl, "htons");
+        symbol(&ntohl_impl, "ntohl");
+        symbol(&ntohs_impl, "ntohs");
+    }
+
     // Subdirectory modules with real implementations
     _ = @import("network/dns.zig");
     _ = @import("network/resolver.zig");
+}
+
+fn networkEndian(comptime T: type, n: T) T {
+    return switch (builtin.target.cpu.arch.endian()) {
+        .little => @byteSwap(n),
+        .big => n,
+    };
+}
+
+fn htonl_impl(n: u32) callconv(.c) u32 {
+    return networkEndian(u32, n);
+}
+
+fn htons_impl(n: u16) callconv(.c) u16 {
+    return networkEndian(u16, n);
+}
+
+fn ntohl_impl(n: u32) callconv(.c) u32 {
+    return networkEndian(u32, n);
+}
+
+fn ntohs_impl(n: u16) callconv(.c) u16 {
+    return networkEndian(u16, n);
 }

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -561,8 +561,8 @@ const src_files = [_][]const u8{
     "musl/src/network/h_errno.c",
     "musl/src/network/herror.c",
     "musl/src/network/hstrerror.c",
-    "musl/src/network/htonl.c",
-    "musl/src/network/htons.c",
+    //"musl/src/network/htonl.c", // migrated to lib/c/network.zig
+    //"musl/src/network/htons.c", // migrated to lib/c/network.zig
     "musl/src/network/if_freenameindex.c",
     "musl/src/network/if_indextoname.c",
     //"musl/src/network/if_nameindex.c", // migrated to lib/c/network.zig
@@ -582,8 +582,8 @@ const src_files = [_][]const u8{
     //"musl/src/network/netlink.c", // migrated to lib/c/network.zig; exports: __rtnetlink_enumerate
     "musl/src/network/netname.c", // provides getnetbyaddr/getnetbyname (not migrated to Zig)
     //"musl/src/network/ns_parse.c", // migrated to lib/c/network.zig; exports: ns_get16,ns_get32,ns_put16,ns_put32,ns_initparse,ns_skiprr,ns_parserr,ns_name_uncompress
-    "musl/src/network/ntohl.c",
-    "musl/src/network/ntohs.c",
+    //"musl/src/network/ntohl.c", // migrated to lib/c/network.zig
+    //"musl/src/network/ntohs.c", // migrated to lib/c/network.zig
     "musl/src/network/proto.c",
     "musl/src/network/recv.c",
     "musl/src/network/recvfrom.c",


### PR DESCRIPTION
Closes #342

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/342

See branch libzigc-network-bswap on the cataggar fork for the implementation.