### PR TITLE
libzigc: libzigc: migrate fenv m68k from C to Zig

### DIFF
--- a/lib/c/fenv.zig
+++ b/lib/c/fenv.zig
@@ -1,11 +1,21 @@
 const builtin = @import("builtin");
+const std = @import("std");
 const symbol = @import("../c.zig").symbol;
 
 /// fexcept_t type matching musl's arch-specific bits/fenv.h definitions.
 const fexcept_t = switch (builtin.cpu.arch) {
     .x86_64, .x86, .mips, .mipsel, .mips64, .mips64el => c_ushort,
-    .aarch64, .aarch64_be, .riscv32, .riscv64, .loongarch64,
-    .m68k, .powerpc, .powerpcle, .powerpc64, .powerpc64le, .s390x,
+    .aarch64,
+    .aarch64_be,
+    .riscv32,
+    .riscv64,
+    .loongarch64,
+    .m68k,
+    .powerpc,
+    .powerpcle,
+    .powerpc64,
+    .powerpc64le,
+    .s390x,
     => c_uint,
     else => c_ulong,
 };
@@ -14,8 +24,14 @@ const FE_TONEAREST: c_int = 0;
 
 const FE_ALL_EXCEPT: c_int = switch (builtin.cpu.arch) {
     .x86_64, .x86, .hexagon => 0x3f,
-    .aarch64, .aarch64_be, .arm, .armeb, .thumb, .thumbeb,
-    .riscv32, .riscv64,
+    .aarch64,
+    .aarch64_be,
+    .arm,
+    .armeb,
+    .thumb,
+    .thumbeb,
+    .riscv32,
+    .riscv64,
     => 0x1f,
     .loongarch64 => 0x1f0000,
     .m68k => 0xf8,
@@ -28,8 +44,17 @@ const FE_ALL_EXCEPT: c_int = switch (builtin.cpu.arch) {
 const FE_TOWARDZERO: ?c_int = switch (builtin.cpu.arch) {
     .x86_64, .x86 => 0xc00,
     .aarch64, .aarch64_be, .arm, .armeb, .thumb, .thumbeb => @as(c_int, 0xc00000),
-    .riscv32, .riscv64, .mips, .mipsel, .mips64, .mips64el,
-    .powerpc, .powerpcle, .powerpc64, .powerpc64le, .s390x,
+    .riscv32,
+    .riscv64,
+    .mips,
+    .mipsel,
+    .mips64,
+    .mips64el,
+    .powerpc,
+    .powerpcle,
+    .powerpc64,
+    .powerpc64le,
+    .s390x,
     => 1,
     .hexagon => 0x01,
     .loongarch64 => 0x100,
@@ -41,8 +66,15 @@ const FE_UPWARD: ?c_int = switch (builtin.cpu.arch) {
     .x86_64, .x86 => 0x800,
     .aarch64, .aarch64_be, .arm, .armeb, .thumb, .thumbeb => 0x400000,
     .riscv32, .riscv64 => 3,
-    .mips, .mipsel, .mips64, .mips64el, .powerpc, .powerpcle,
-    .powerpc64, .powerpc64le, .s390x,
+    .mips,
+    .mipsel,
+    .mips64,
+    .mips64el,
+    .powerpc,
+    .powerpcle,
+    .powerpc64,
+    .powerpc64le,
+    .s390x,
     => 2,
     .hexagon => 0x03,
     .loongarch64 => 0x200,
@@ -54,8 +86,15 @@ const FE_DOWNWARD: ?c_int = switch (builtin.cpu.arch) {
     .x86_64, .x86 => 0x400,
     .aarch64, .aarch64_be, .arm, .armeb, .thumb, .thumbeb => @as(c_int, 0x800000),
     .riscv32, .riscv64 => 2,
-    .mips, .mipsel, .mips64, .mips64el, .powerpc, .powerpcle,
-    .powerpc64, .powerpc64le, .s390x,
+    .mips,
+    .mipsel,
+    .mips64,
+    .mips64el,
+    .powerpc,
+    .powerpcle,
+    .powerpc64,
+    .powerpc64le,
+    .s390x,
     => 3,
     .hexagon => 0x02,
     .loongarch64 => 0x300,
@@ -63,17 +102,36 @@ const FE_DOWNWARD: ?c_int = switch (builtin.cpu.arch) {
     else => null,
 };
 
+const have_m68k_fpu = builtin.cpu.arch == .m68k and
+    std.Target.m68k.featureSetHasAny(builtin.cpu.features, .{ .isa_68881, .isa_68882 });
+
+const fenv_t_m68k = extern struct {
+    __control_register: c_uint,
+    __status_register: c_uint,
+    __instruction_address: c_uint,
+};
+
 comptime {
     if (builtin.link_libc) {
-        // Weak generic fallbacks (from fenv.c).
-        // Overridden by arch-specific implementations at link time.
-        symbol(&feclearexcept, "feclearexcept");
-        symbol(&feraiseexcept, "feraiseexcept");
-        symbol(&fetestexcept, "fetestexcept");
-        symbol(&fegetround, "fegetround");
-        symbol(&__fesetround, "__fesetround");
-        symbol(&fegetenv, "fegetenv");
-        symbol(&fesetenv, "fesetenv");
+        if (have_m68k_fpu) {
+            symbol(&m68k_feclearexcept, "feclearexcept");
+            symbol(&m68k_feraiseexcept, "feraiseexcept");
+            symbol(&m68k_fetestexcept, "fetestexcept");
+            symbol(&m68k_fegetround, "fegetround");
+            symbol(&m68k___fesetround, "__fesetround");
+            symbol(&m68k_fegetenv, "fegetenv");
+            symbol(&m68k_fesetenv, "fesetenv");
+        } else {
+            // Weak generic fallbacks (from fenv.c).
+            // Overridden by arch-specific implementations at link time.
+            symbol(&feclearexcept, "feclearexcept");
+            symbol(&feraiseexcept, "feraiseexcept");
+            symbol(&fetestexcept, "fetestexcept");
+            symbol(&fegetround, "fegetround");
+            symbol(&__fesetround, "__fesetround");
+            symbol(&fegetenv, "fegetenv");
+            symbol(&fesetenv, "fesetenv");
+        }
 
         // Generic callers (no arch-specific overrides for these).
         symbol(&__flt_rounds, "__flt_rounds");
@@ -83,6 +141,91 @@ comptime {
         symbol(&fesetround, "fesetround");
         symbol(&feupdateenv, "feupdateenv");
     }
+}
+
+fn m68k_getsr() c_uint {
+    return asm volatile ("fmove.l %%fpsr,$0"
+        : [_] "=dm" (-> c_uint),
+    );
+}
+
+fn m68k_setsr(v: c_uint) void {
+    asm volatile ("fmove.l $0,%%fpsr"
+        :
+        : [_] "dm" (v),
+    );
+}
+
+fn m68k_getcr() c_uint {
+    return asm volatile ("fmove.l %%fpcr,$0"
+        : [_] "=dm" (-> c_uint),
+    );
+}
+
+fn m68k_setcr(v: c_uint) void {
+    asm volatile ("fmove.l $0,%%fpcr"
+        :
+        : [_] "dm" (v),
+    );
+}
+
+fn m68k_getpiar() c_uint {
+    return asm volatile ("fmove.l %%fpiar,$0"
+        : [_] "=dm" (-> c_uint),
+    );
+}
+
+fn m68k_setpiar(v: c_uint) void {
+    asm volatile ("fmove.l $0,%%fpiar"
+        :
+        : [_] "dm" (v),
+    );
+}
+
+fn m68k_feclearexcept(mask: c_int) callconv(.c) c_int {
+    if (mask & ~FE_ALL_EXCEPT != 0) return -1;
+    m68k_setsr(m68k_getsr() & ~@as(c_uint, @bitCast(mask)));
+    return 0;
+}
+
+fn m68k_feraiseexcept(mask: c_int) callconv(.c) c_int {
+    if (mask & ~FE_ALL_EXCEPT != 0) return -1;
+    m68k_setsr(m68k_getsr() | @as(c_uint, @bitCast(mask)));
+    return 0;
+}
+
+fn m68k_fetestexcept(mask: c_int) callconv(.c) c_int {
+    return @bitCast(m68k_getsr() & @as(c_uint, @bitCast(mask)));
+}
+
+fn m68k_fegetround() callconv(.c) c_int {
+    return @bitCast(m68k_getcr() & @as(c_uint, @intCast(FE_UPWARD.?)));
+}
+
+fn m68k___fesetround(r: c_int) callconv(.c) c_int {
+    const round_mask: c_uint = @intCast(FE_UPWARD.?);
+    m68k_setcr((m68k_getcr() & ~round_mask) | @as(c_uint, @bitCast(r)));
+    return 0;
+}
+
+fn m68k_fegetenv(envp: *fenv_t_m68k) callconv(.c) c_int {
+    envp.__control_register = m68k_getcr();
+    envp.__status_register = m68k_getsr();
+    envp.__instruction_address = m68k_getpiar();
+    return 0;
+}
+
+fn m68k_fesetenv(envp_arg: *const fenv_t_m68k) callconv(.c) c_int {
+    const default_env: fenv_t_m68k = .{
+        .__control_register = 0,
+        .__status_register = 0,
+        .__instruction_address = 0,
+    };
+    const envp = if (@intFromPtr(envp_arg) == std.math.maxInt(usize)) &default_env else envp_arg;
+    m68k_setcr(envp.__control_register);
+    m68k_setsr(envp.__status_register);
+    m68k_setpiar(envp.__instruction_address);
+    return 0;
 }
 
 // Weak generic fallbacks for archs without arch-specific fenv.

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -454,7 +454,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/i386/fenv.s",
     "musl/src/fenv/loongarch64/fenv.S",
     "musl/src/fenv/loongarch64/fenv-sf.c",
-    "musl/src/fenv/m68k/fenv.c",
+    //"musl/src/fenv/m68k/fenv.c", // migrated to lib/c/fenv.zig (m68k); exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/mips64/fenv.S",
     "musl/src/fenv/mips64/fenv-sf.c",
     "musl/src/fenv/mips/fenv.S",


### PR DESCRIPTION
Closes #355

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/355

See branch libzigc-fenv-m68k on the cataggar fork for the implementation.