### PR TITLE
ci: add PR-time aarch64-native gate + post-merge full-matrix gate for libzigc

### DIFF
--- a/.github/workflows/post-merge-libc.yml
+++ b/.github/workflows/post-merge-libc.yml
@@ -1,0 +1,85 @@
+name: post-merge-libc
+
+on:
+  push:
+    branches:
+      - libc/0.16.x
+    paths:
+      - lib/**
+      - src/**
+      - build.zig
+      - build.zig.zon
+      - CMakeLists.txt
+      - cmake/**
+      - .github/workflows/test-libc.yml
+      - .github/workflows/post-merge-libc.yml
+
+permissions:
+  contents: read
+  issues: write
+
+# Coalesce: if many auto-merges land in quick succession, only test the
+# latest revision. Older runs are cancelled to avoid burning CI on stale
+# heads. The eventual HEAD always gets tested.
+concurrency:
+  group: post-merge-libc
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: full test-libc on libc/0.16.x HEAD
+    uses: ./.github/workflows/test-libc.yml
+    with:
+      branch: ${{ github.sha }}
+      test-filter: ""
+      targets: all
+
+  on-failure:
+    name: notify on test failure
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: libc/0.16.x
+          fetch-depth: 1
+
+      - name: Open failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          short_sha="${HEAD_SHA:0:12}"
+          subject="$(git log -1 --pretty=%s "$HEAD_SHA")"
+          author="$(git log -1 --pretty=%an "$HEAD_SHA")"
+          merge_pr="$(printf '%s' "$subject" | sed -nE 's/.*\(#([0-9]+)\)$/\1/p')"
+
+          title="post-merge test-libc failure on libc/0.16.x @ ${short_sha}"
+          body=$(cat <<EOF
+          The full \`test-libc\` matrix failed against \`libc/0.16.x\` after a merge.
+
+          - Commit: [\`${short_sha}\`](${{ github.server_url }}/${{ github.repository }}/commit/${HEAD_SHA})
+          - Subject: \`${subject}\`
+          - Author: ${author}
+          - Workflow run: ${RUN_URL}
+          ${merge_pr:+- Likely-introduced-by PR: #${merge_pr}}
+
+          Manual revert may be required:
+
+          \`\`\`
+          git fetch origin libc/0.16.x
+          git checkout libc/0.16.x
+          git revert -m 1 ${HEAD_SHA}
+          git push origin libc/0.16.x
+          \`\`\`
+
+          (Reopen / triage as needed. The branch was **not** auto-reverted.)
+          EOF
+          )
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$title" \
+            --body "$body"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,240 @@
+name: pr-build
+
+# PR gate for libzigc migration PRs. Runs aarch64-native build + libc-test
+# on the self-hosted Azure VM runner so feedback is fast (~5-15 min vs
+# ~30-90 min for the full GitHub-hosted QEMU matrix). The full multi-target
+# matrix runs post-merge on libc/0.16.x via post-merge-libc.yml.
+#
+# Trust model: this workflow runs PR-controlled code on a persistent
+# self-hosted runner. The `if:` guard on the build job restricts execution
+# to PRs whose head is the canonical repo or the trusted cataggar fork
+# (the libzigc bot fork). Untrusted forks fall through to a no-op job that
+# still reports a successful pr-build check, keeping the auto-merge path
+# unblocked for legitimate same-owner PRs while not exposing the runner.
+on:
+  pull_request:
+    branches:
+      - libc/0.16.x
+      - libc/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ZIG_VERSION: "0.16.0-dev.3061+9b1eaad13"
+  LLVM_VERSION: "21.1.8"
+  TARGET: aarch64-linux-musl
+  MCPU: baseline
+  CACHE_ROOT: /runner/_cache/pr-build
+
+jobs:
+  trust-check:
+    name: pr-build trust check
+    runs-on: ubuntu-latest
+    outputs:
+      trusted: ${{ steps.gate.outputs.trusted }}
+    steps:
+      - id: gate
+        env:
+          HEAD: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "head: $HEAD"
+          echo "base: $BASE"
+          case "$HEAD" in
+              ctaggart/zig|cataggar/zig)
+                  echo "trusted=true" >> "$GITHUB_OUTPUT"
+                  ;;
+              *)
+                  if [ "$HEAD" = "$BASE" ]; then
+                      echo "trusted=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "trusted=false" >> "$GITHUB_OUTPUT"
+                      echo "::warning::Untrusted PR head '$HEAD'; skipping aarch64-native build."
+                  fi
+                  ;;
+          esac
+
+  build:
+    name: pr-build
+    needs: trust-check
+    if: needs.trust-check.outputs.trusted == 'true'
+    runs-on: [self-hosted, Linux, ARM64, nvme]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare cache root
+        run: mkdir -p "$CACHE_ROOT"
+
+      - name: Setup release Zig (aarch64) + LLVM prefix (cached, atomic)
+        run: |
+          set -euo pipefail
+          zig_marker="$CACHE_ROOT/zig-aarch64-linux-${ZIG_VERSION}/.complete"
+          llvm_marker="$CACHE_ROOT/llvm-zig-${LLVM_VERSION}-aarch64-linux/.complete"
+
+          fetch_extract() {
+              local url="$1" final="$2" marker="$3"
+              if [ -f "$marker" ]; then
+                  return 0
+              fi
+              local staging
+              staging="$(mktemp -d -p "$CACHE_ROOT" .stage-XXXXXX)"
+              echo "Fetching $url"
+              curl --fail --show-error --location --silent \
+                  --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors \
+                  "$url" | xz -d | tar x -C "$staging"
+              # Tarball top-level dir name = basename of $final
+              local top
+              top="$(basename "$final")"
+              if [ ! -d "$staging/$top" ]; then
+                  echo "ERROR: tarball did not contain expected top-level dir '$top'" >&2
+                  ls -la "$staging" >&2
+                  rm -rf "$staging"
+                  exit 1
+              fi
+              # Atomic publish: rm any stale partial, then mv staging into place.
+              rm -rf "$final"
+              mv "$staging/$top" "$final"
+              rm -rf "$staging"
+              touch "$marker"
+          }
+
+          fetch_extract \
+              "https://github.com/ctaggart/zig/releases/download/v${ZIG_VERSION}/zig-aarch64-linux-${ZIG_VERSION}.tar.xz" \
+              "$CACHE_ROOT/zig-aarch64-linux-${ZIG_VERSION}" \
+              "$zig_marker"
+          fetch_extract \
+              "https://github.com/ctaggart/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-zig-${LLVM_VERSION}-aarch64-linux.tar.xz" \
+              "$CACHE_ROOT/llvm-zig-${LLVM_VERSION}-aarch64-linux" \
+              "$llvm_marker"
+
+          echo "$CACHE_ROOT/zig-aarch64-linux-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          echo "LLVM_PREFIX=$CACHE_ROOT/llvm-zig-${LLVM_VERSION}-aarch64-linux" >> "$GITHUB_ENV"
+
+      - name: zig version
+        run: zig version
+
+      - name: zig fmt --check (lib/c, src/libs/musl.zig)
+        run: zig fmt --check lib/c src/libs/musl.zig
+
+      - name: zig fmt --ast-check on changed lib/c files
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only --diff-filter=AM \
+              "origin/${{ github.base_ref }}...HEAD" -- 'lib/c/**.zig' || true)
+          if [ -z "$changed" ]; then
+              echo "No changed lib/c/**.zig files; skipping ast-check."
+              exit 0
+          fi
+          echo "Running zig fmt --ast-check on:"
+          printf '  %s\n' $changed
+          zig fmt --ast-check $changed
+
+      - name: check_musl_migration.py
+        run: |
+          set -euo pipefail
+          if [ -f scripts/check_musl_migration.py ]; then
+              python3 scripts/check_musl_migration.py
+          else
+              echo "scripts/check_musl_migration.py not present; skipping."
+          fi
+
+      - name: Compute stage4 cache key
+        id: stage4key
+        run: |
+          set -euo pipefail
+          # Hash everything that affects the stage4 build:
+          #   - compiler sources (src/)
+          #   - build script + manifest (build.zig, build.zig.zon)
+          #   - CMake driver + helpers (CMakeLists.txt, cmake/**)
+          # Plus runner/arch + tool versions + target/mcpu in the key prefix
+          # so changes to any of those bust the cache.
+          src_hash=$(find src build.zig build.zig.zon CMakeLists.txt cmake \
+                  -type f -print0 2>/dev/null | sort -z \
+                  | xargs -0 sha256sum 2>/dev/null \
+                  | sha256sum | cut -d' ' -f1 | head -c 16)
+          key="${{ runner.os }}-${{ runner.arch }}-zig${ZIG_VERSION}-llvm${LLVM_VERSION}-${TARGET}-${MCPU}-${src_hash}"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          echo "stage4 cache key: $key"
+
+      - name: Build stage4 zig (key=${{ steps.stage4key.outputs.key }})
+        run: |
+          set -euo pipefail
+          STAGE4="$CACHE_ROOT/stage4-${{ steps.stage4key.outputs.key }}"
+          marker="$STAGE4/.complete"
+          if [ -f "$marker" ] && [ -x "$STAGE4/bin/zig" ] && \
+             "$STAGE4/bin/zig" version >/dev/null 2>&1; then
+              echo "stage4 cache hit: $STAGE4"
+          else
+              echo "stage4 cache miss; building..."
+              # Build into a staging dir and atomically move on success so
+              # cancelled builds never leave a half-installed cache entry.
+              staging="$(mktemp -d -p "$CACHE_ROOT" .stage4-XXXXXX)"
+              export CC="zig cc -target ${TARGET} -mcpu=${MCPU}"
+              export CXX="zig c++ -target ${TARGET} -mcpu=${MCPU}"
+              cmake -S . -B build -G Ninja \
+                  -DCMAKE_INSTALL_PREFIX="$staging" \
+                  -DCMAKE_PREFIX_PATH="$LLVM_PREFIX" \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DZIG_TARGET_TRIPLE="${TARGET}" \
+                  -DZIG_TARGET_MCPU="${MCPU}" \
+                  -DZIG_STATIC=ON \
+                  -DZIG_NO_LIB=ON \
+                  -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=FALSE \
+                  -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=FALSE
+              unset CC CXX
+              ninja -C build install
+              "$staging/bin/zig" version
+              rm -rf build
+              # Publish atomically.
+              rm -rf "$STAGE4"
+              mv "$staging" "$STAGE4"
+              touch "$marker"
+              echo "stage4 published to $STAGE4"
+          fi
+          echo "STAGE4=$STAGE4" >> "$GITHUB_ENV"
+
+      - name: Update libc-test checkout (log SHA for forensics)
+        run: |
+          set -euo pipefail
+          if [ ! -d "$CACHE_ROOT/libc-test/.git" ]; then
+              git clone --depth 1 https://github.com/ctaggart/libc-test.git \
+                  "$CACHE_ROOT/libc-test"
+          else
+              git -C "$CACHE_ROOT/libc-test" fetch --quiet --depth 1 origin master
+              git -C "$CACHE_ROOT/libc-test" reset --hard --quiet origin/master
+          fi
+          libc_test_sha=$(git -C "$CACHE_ROOT/libc-test" rev-parse HEAD)
+          echo "libc-test commit: $libc_test_sha"
+          echo "LIBC_TEST_SHA=$libc_test_sha" >> "$GITHUB_ENV"
+
+      - name: Run libc-test (aarch64-linux-musl, native)
+        run: |
+          set -euo pipefail
+          ulimit -u 65535 || true
+          ulimit -n 65535 || true
+          echo "stage4: $STAGE4"
+          echo "libc-test SHA: $LIBC_TEST_SHA"
+          "$STAGE4/bin/zig" build test-libc \
+              --zig-lib-dir lib \
+              -Dlibc-test-path="$CACHE_ROOT/libc-test" \
+              -Dtest-target-filter="${TARGET}" \
+              -Dtest-filter="" \
+              -j2 \
+              --summary failures
+
+      - name: Prune old stage4 caches (keep 4 most recent)
+        if: always()
+        run: |
+          set -euo pipefail
+          cd "$CACHE_ROOT"
+          ls -1dt stage4-* 2>/dev/null | tail -n +5 | xargs -r rm -rf
+          echo "stage4 caches retained:"
+          ls -1dt stage4-* 2>/dev/null || true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -121,9 +121,6 @@ jobs:
       - name: zig version
         run: zig version
 
-      - name: zig fmt --check (lib/c, src/libs/musl.zig)
-        run: zig fmt --check lib/c src/libs/musl.zig
-
       - name: zig fmt --ast-check on changed lib/c files
         run: |
           set -euo pipefail
@@ -235,6 +232,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "$CACHE_ROOT"
-          ls -1dt stage4-* 2>/dev/null | tail -n +5 | xargs -r rm -rf
+          ls -1dt stage4-* 2>/dev/null | tail -n +5 | xargs -r rm -rf || true
           echo "stage4 caches retained:"
           ls -1dt stage4-* 2>/dev/null || true

--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -16,6 +16,22 @@ on:
         required: false
         default: 'all'
         type: string
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to test'
+        required: true
+        type: string
+      test-filter:
+        description: 'Test filter (empty for all tests)'
+        required: false
+        default: ''
+        type: string
+      targets:
+        description: 'Target groups to test (comma-separated, or "all")'
+        required: false
+        default: 'all'
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds two new workflows and a small additive change to test-libc.yml.

## Why
Today the only PR check is `check-migration-claims`, a Python manifest lint that verifies `"migrated to lib/c/x.zig"` comments in `src/libs/musl.zig` point at files that exist. It does not compile, link, or test anything. Migration PRs with broken Zig can satisfy it and auto-merge.

The full `test-libc.yml` matrix exists but is `workflow_dispatch`-only and runs ~30-90 min across 10 QEMU targets on hosted runners — too heavy for per-PR gating of a 57-issue migration backlog.

## What
**pr-build.yml** — Per-PR gate, runs on the existing self-hosted aarch64 runner (armvm-runner-1, 16-core Neoverse-N2 + NVMe). aarch64-linux-musl native build + libc-test, ~5-15 min per PR. Uses /runner/_cache/pr-build with stage4 caching by hash of src/ + cmake/** + tool versions, atomic mv-on-success extraction, retried downloads, and a trust-check job that restricts the heavy build to PRs from ctaggart/zig or cataggar/zig — untrusted forks get the build job skipped (and therefore blocked from auto-merge by branch protection).

**post-merge-libc.yml** — Triggers on push to libc/0.16.x for build- or test-affecting paths. Calls test-libc.yml via workflow_call with branch=${{ github.sha }} (exact SHA so the matrix cannot drift to a newer revision mid-run) and full targets/empty filter. On failure, opens an issue with commit/PR attribution and a manual revert recipe. concurrency: group=post-merge-libc, cancel-in-progress=true so a burst of auto-merges only re-runs for the eventual HEAD.

**test-libc.yml** — Adds a workflow_call trigger alongside the existing workflow_dispatch. Inputs unchanged. No behavioral change for workflow_dispatch users.

## Follow-up after this merges
Add pr-build to libc/0.16.x branch protection's required checks alongside check-migration-claims.

Closes nothing (this is infrastructure, not a backlog issue).