### PR TITLE
libzigc: fix type error and duplicate export from #387 (process _Fork+fork)

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -29,7 +29,7 @@ else
 /// blocks will need to each check for `builtin.link_libc` and skip exports
 /// when the exported functions have libc dependencies not provided by this
 /// compilation unit.
-pub inline fn symbol(comptime func: *const anyopaque, comptime name: []const u8) void {
+pub inline fn symbol(comptime func: anytype, comptime name: []const u8) void {
     @export(func, .{
         .name = name,
         // Normally, libc goes into a static archive, making all symbols

--- a/lib/c/process.zig
+++ b/lib/c/process.zig
@@ -197,7 +197,6 @@ comptime {
         symbol(&execlpImpl, "execlp");
         symbol(&systemImpl, "system");
         symbol(&forkImpl, "fork");
-        symbol(&dummyForkHandler, "__fork_handler");
         symbol(&dummyForkHandler, "__malloc_atfork");
         symbol(&dummyForkHandler, "__ldso_atfork");
         symbol(&dummy0, "__tl_lock");


### PR DESCRIPTION
PR #387 (process `_Fork`/`fork` migration) introduced two real compile errors that the existing PR gates could not catch:

1. **`lib/c/process.zig:205` type error** — `symbol(&dummyLockPtr, "__gettext_lockptr")` fails: *"cannot implicitly cast double pointer '*?*c_int' to anyopaque pointer '*const anyopaque'"*.

2. **`lib/c/process.zig:200` duplicate `__fork_handler` export** — `lib/c/thread.zig:337` already exports the real `__fork_handler_fn` under the same key. Two weak `@export`s of the same name produce an LLVM error: *"exported symbol collision: __fork_handler"*.

## Why these slipped through

- `zig fmt --ast-check` is purely syntactic; it does not catch type errors or export collisions.
- The Python `check-migration-claims` gate validates manifest/claim consistency, not real compilation.
- The new `pr-build` gate (issue #424) is currently stage-4-segfaulting and not enforced.

## Fix

```diff
-pub inline fn symbol(comptime func: *const anyopaque, comptime name: []const u8) void {
+pub inline fn symbol(comptime func: anytype, comptime name: []const u8) void {
```
`anytype` lets `@export` see any pointer's concrete type at comptime; the previous `*const anyopaque` parameter type rejected pointer-to-optional-pointer (`*?*c_int`) at coercion time.

```diff
-        symbol(&dummyForkHandler, "__fork_handler");
```
`thread.zig:337` already provides the real implementation under the same condition (`if (builtin.link_libc)` and `isMuslLibC()`), so the dummy is a no-op duplicate.

## Verification

Built locally with the cached release zig 0.16.0-dev.3061 + `--zig-lib-dir lib` against `libc-test` (target `aarch64-linux-musl`, filter `argv` across Debug/ReleaseFast/ReleaseSafe/ReleaseSmall): both errors are eliminated. The only remaining blocker on that path is the stale baked-in musl manifest in the prebuilt release zig (`aio.c file_hash FileNotFound`), which is a CI-plumbing concern tracked in #424 — orthogonal to this fix.

This unblocks the libzigc compile for any future PR (or the gate) that actually invokes `zig build test-libc`.