### PR TITLE
lib/c: fix sysconf and strdup crashes uncovered by ReleaseSafe stage4

### DIFF
--- a/lib/c/conf.zig
+++ b/lib/c/conf.zig
@@ -34,39 +34,356 @@ const values = [21]c_short{
     -1, // _PC_SYMLINK_MAX = 19
     1, // _PC_2_SYMLINKS = 20
 };
+// _SC_* index values (from POSIX / musl unistd.h)
+const _SC_ARG_MAX = 0;
+const _SC_CHILD_MAX = 1;
+const _SC_CLK_TCK = 2;
+const _SC_NGROUPS_MAX = 3;
+const _SC_OPEN_MAX = 4;
+const _SC_STREAM_MAX = 5;
+const _SC_TZNAME_MAX = 6;
+const _SC_JOB_CONTROL = 7;
+const _SC_SAVED_IDS = 8;
+const _SC_REALTIME_SIGNALS = 9;
+const _SC_PRIORITY_SCHEDULING = 10;
+const _SC_TIMERS = 11;
+const _SC_ASYNCHRONOUS_IO = 12;
+const _SC_PRIORITIZED_IO = 13;
+const _SC_SYNCHRONIZED_IO = 14;
+const _SC_FSYNC = 15;
+const _SC_MAPPED_FILES = 16;
+const _SC_MEMLOCK = 17;
+const _SC_MEMLOCK_RANGE = 18;
+const _SC_MEMORY_PROTECTION = 19;
+const _SC_MESSAGE_PASSING = 20;
+const _SC_SEMAPHORES = 21;
+const _SC_SHARED_MEMORY_OBJECTS = 22;
+const _SC_AIO_LISTIO_MAX = 23;
+const _SC_AIO_MAX = 24;
+const _SC_AIO_PRIO_DELTA_MAX = 25;
+const _SC_DELAYTIMER_MAX = 26;
+const _SC_MQ_OPEN_MAX = 27;
+const _SC_MQ_PRIO_MAX = 28;
+const _SC_VERSION = 29;
+const _SC_PAGE_SIZE = 30;
+const _SC_RTSIG_MAX = 31;
+const _SC_SEM_NSEMS_MAX = 32;
+const _SC_SEM_VALUE_MAX = 33;
+const _SC_SIGQUEUE_MAX = 34;
+const _SC_TIMER_MAX = 35;
+const _SC_BC_BASE_MAX = 36;
+const _SC_BC_DIM_MAX = 37;
+const _SC_BC_SCALE_MAX = 38;
+const _SC_BC_STRING_MAX = 39;
+const _SC_COLL_WEIGHTS_MAX = 40;
+const _SC_EXPR_NEST_MAX = 42;
+const _SC_LINE_MAX = 43;
+const _SC_RE_DUP_MAX = 44;
+const _SC_2_VERSION = 46;
+const _SC_2_C_BIND = 47;
+const _SC_2_C_DEV = 48;
+const _SC_2_FORT_DEV = 49;
+const _SC_2_FORT_RUN = 50;
+const _SC_2_SW_DEV = 51;
+const _SC_2_LOCALEDEF = 52;
+const _SC_IOV_MAX = 60;
+const _SC_THREADS = 67;
+const _SC_THREAD_SAFE_FUNCTIONS = 68;
+const _SC_GETGR_R_SIZE_MAX = 69;
+const _SC_GETPW_R_SIZE_MAX = 70;
+const _SC_LOGIN_NAME_MAX = 71;
+const _SC_TTY_NAME_MAX = 72;
+const _SC_THREAD_DESTRUCTOR_ITERATIONS = 73;
+const _SC_THREAD_KEYS_MAX = 74;
+const _SC_THREAD_STACK_MIN = 75;
+const _SC_THREAD_THREADS_MAX = 76;
+const _SC_THREAD_ATTR_STACKADDR = 77;
+const _SC_THREAD_ATTR_STACKSIZE = 78;
+const _SC_THREAD_PRIORITY_SCHEDULING = 79;
+const _SC_THREAD_PRIO_INHERIT = 80;
+const _SC_THREAD_PRIO_PROTECT = 81;
+const _SC_THREAD_PROCESS_SHARED = 82;
 const _SC_NPROCESSORS_CONF = 83;
 const _SC_NPROCESSORS_ONLN = 84;
 const _SC_PHYS_PAGES = 85;
 const _SC_AVPHYS_PAGES = 86;
+const _SC_ATEXIT_MAX = 87;
+const _SC_PASS_MAX = 88;
+const _SC_XOPEN_VERSION = 89;
+const _SC_XOPEN_XCU_VERSION = 90;
+const _SC_XOPEN_UNIX = 91;
+const _SC_XOPEN_CRYPT = 92;
+const _SC_XOPEN_ENH_I18N = 93;
+const _SC_XOPEN_SHM = 94;
+const _SC_2_CHAR_TERM = 95;
+const _SC_2_UPE = 97;
+const _SC_XOPEN_XPG2 = 98;
+const _SC_XOPEN_XPG3 = 99;
+const _SC_XOPEN_XPG4 = 100;
+const _SC_NZERO = 109;
+const _SC_XBS5_ILP32_OFF32 = 125;
+const _SC_XBS5_ILP32_OFFBIG = 126;
+const _SC_XBS5_LP64_OFF64 = 127;
+const _SC_XBS5_LPBIG_OFFBIG = 128;
+const _SC_XOPEN_LEGACY = 129;
+const _SC_XOPEN_REALTIME = 130;
+const _SC_XOPEN_REALTIME_THREADS = 131;
+const _SC_ADVISORY_INFO = 132;
+const _SC_BARRIERS = 133;
+const _SC_CLOCK_SELECTION = 137;
+const _SC_CPUTIME = 138;
+const _SC_THREAD_CPUTIME = 139;
+const _SC_MONOTONIC_CLOCK = 149;
+const _SC_READER_WRITER_LOCKS = 153;
+const _SC_SPIN_LOCKS = 154;
+const _SC_REGEXP = 155;
+const _SC_SHELL = 157;
+const _SC_SPAWN = 159;
+const _SC_SPORADIC_SERVER = 160;
+const _SC_THREAD_SPORADIC_SERVER = 161;
+const _SC_TIMEOUTS = 164;
+const _SC_TYPED_MEMORY_OBJECTS = 165;
+const _SC_2_PBS = 168;
+const _SC_2_PBS_ACCOUNTING = 169;
+const _SC_2_PBS_LOCATE = 170;
+const _SC_2_PBS_MESSAGE = 171;
+const _SC_2_PBS_TRACK = 172;
+const _SC_SYMLOOP_MAX = 173;
+const _SC_STREAMS = 174;
+const _SC_2_PBS_CHECKPOINT = 175;
+const _SC_V6_ILP32_OFF32 = 176;
+const _SC_V6_ILP32_OFFBIG = 177;
+const _SC_V6_LP64_OFF64 = 178;
+const _SC_V6_LPBIG_OFFBIG = 179;
+const _SC_HOST_NAME_MAX = 180;
+const _SC_TRACE = 181;
+const _SC_TRACE_EVENT_FILTER = 182;
+const _SC_TRACE_INHERIT = 183;
+const _SC_TRACE_LOG = 184;
+const _SC_IPV6 = 235;
+const _SC_RAW_SOCKETS = 236;
+const _SC_V7_ILP32_OFF32 = 237;
+const _SC_V7_ILP32_OFFBIG = 238;
+const _SC_V7_LP64_OFF64 = 239;
+const _SC_V7_LPBIG_OFFBIG = 240;
+const _SC_SS_REPL_MAX = 241;
+const _SC_TRACE_EVENT_NAME_MAX = 242;
+const _SC_TRACE_NAME_MAX = 243;
+const _SC_TRACE_SYS_MAX = 244;
+const _SC_TRACE_USER_EVENT_MAX = 245;
+const _SC_XOPEN_STREAMS = 246;
+const _SC_THREAD_ROBUST_PRIO_INHERIT = 247;
+const _SC_THREAD_ROBUST_PRIO_PROTECT = 248;
+const _SC_MINSIGSTKSZ = 249;
+const _SC_SIGSTKSZ = 250;
+const SC_TABLE_LEN = 251;
+
 const _CS_POSIX_V6_ILP32_OFF32_CFLAGS = 1116;
 const _POSIX_VERSION: c_long = 200809;
 const LONG_MAX = std.math.maxInt(c_long);
-// Encoded table values
-const VER: c_int = -256 | 1;
-const JT_ARG_MAX: c_int = -256 | 2;
-const JT_MQ_PRIO_MAX: c_int = -256 | 3;
-const JT_PAGE_SIZE: c_int = -256 | 4;
-const JT_SEM_VALUE_MAX: c_int = -256 | 5;
-const JT_NPROCESSORS: c_int = -256 | 6;
-const JT_PHYS_PAGES: c_int = -256 | 8;
-const JT_AVPHYS_PAGES: c_int = -256 | 9;
-const JT_ZERO: c_int = -256 | 10;
-const JT_DELAYTIMER_MAX: c_int = -256 | 11;
-const JT_MINSIGSTKSZ: c_int = -256 | 12;
-const JT_SIGSTKSZ: c_int = -256 | 13;
-const RLIM_NPROC: c_int = @bitCast(@as(c_uint, 0x80000000 | 6)); // RLIMIT_NPROC
-const RLIM_NOFILE: c_int = @bitCast(@as(c_uint, 0x80000000 | 7)); // RLIMIT_NOFILE
-const sz_long: c_int = @sizeOf(c_long);
-// Table size: _SC values go up to ~199 on Linux
-const TABLE_SIZE = 200;
+
+// Direct values used in the _SC_ table (from musl limits.h / arch headers)
+const TZNAME_MAX: c_short = 6;
+const COLL_WEIGHTS_MAX: c_short = 2;
+const RE_DUP_MAX: c_short = 255;
+const IOV_MAX: c_short = 1024;
+const TTY_NAME_MAX: c_short = 32;
+const PTHREAD_DESTRUCTOR_ITERATIONS: c_short = 4;
+const PTHREAD_KEYS_MAX: c_short = 128;
+const PTHREAD_STACK_MIN: c_short = 2048;
+const NZERO: c_short = 20;
+const HOST_NAME_MAX: c_short = 255;
+const SYMLOOP_MAX: c_short = 40;
+const SEM_NSEMS_MAX: c_short = 256;
+const _XOPEN_VERSION: c_short = 700;
+const _NSIG: c_short = 65;
+const _POSIX2_BC_BASE_MAX: c_short = 99;
+const _POSIX2_BC_DIM_MAX: c_short = 2048;
+const _POSIX2_BC_SCALE_MAX: c_short = 99;
+const _POSIX2_BC_STRING_MAX: c_short = 1000;
+const LOGIN_NAME_MAX: c_short = 256;
+
+// Encoded sentinels stored in the c_short table.
+//   v == 0:        EINVAL (unknown/disabled)
+//   v == -1:       not supported
+//   v >= 0:        direct value
+//   v in [-256,-1] (encoded as -256|x for x in 1..255): jump table case
+//   v in [-32768,-256) (encoded as -32768|RLIMIT_*):     RLIMIT lookup
+const VER: c_short = @bitCast(@as(u16, 0xff00 | 1));
+const JT_ARG_MAX: c_short = @bitCast(@as(u16, 0xff00 | 2));
+const JT_MQ_PRIO_MAX: c_short = @bitCast(@as(u16, 0xff00 | 3));
+const JT_PAGE_SIZE: c_short = @bitCast(@as(u16, 0xff00 | 4));
+const JT_SEM_VALUE_MAX: c_short = @bitCast(@as(u16, 0xff00 | 5));
+const JT_NPROCESSORS_CONF: c_short = @bitCast(@as(u16, 0xff00 | 6));
+const JT_NPROCESSORS_ONLN: c_short = @bitCast(@as(u16, 0xff00 | 7));
+const JT_PHYS_PAGES: c_short = @bitCast(@as(u16, 0xff00 | 8));
+const JT_AVPHYS_PAGES: c_short = @bitCast(@as(u16, 0xff00 | 9));
+const JT_ZERO: c_short = @bitCast(@as(u16, 0xff00 | 10));
+const JT_DELAYTIMER_MAX: c_short = @bitCast(@as(u16, 0xff00 | 11));
+const JT_MINSIGSTKSZ: c_short = @bitCast(@as(u16, 0xff00 | 12));
+const JT_SIGSTKSZ: c_short = @bitCast(@as(u16, 0xff00 | 13));
+// RLIMIT_* numbers (most archs; differ on MIPS family)
+const RLIMIT_NPROC: u16 = 6;
+const RLIMIT_NOFILE: u16 = 7;
+const RLIM_NPROC: c_short = @bitCast(@as(u16, 0x8000 | RLIMIT_NPROC));
+const RLIM_NOFILE: c_short = @bitCast(@as(u16, 0x8000 | RLIMIT_NOFILE));
+
+const sz_long_long_off: c_short = if (@sizeOf(c_long) == 4) 1 else -1;
+const sz_long_lp64: c_short = if (@sizeOf(c_long) == 8) 1 else -1;
+
+// Sparse table indexed by _SC_*. Defaults to 0 (= EINVAL).
+const sc_values: [SC_TABLE_LEN]c_short = blk: {
+    var t = [_]c_short{0} ** SC_TABLE_LEN;
+    t[_SC_ARG_MAX] = JT_ARG_MAX;
+    t[_SC_CHILD_MAX] = RLIM_NPROC;
+    t[_SC_CLK_TCK] = 100;
+    t[_SC_NGROUPS_MAX] = 32;
+    t[_SC_OPEN_MAX] = RLIM_NOFILE;
+    t[_SC_STREAM_MAX] = -1;
+    t[_SC_TZNAME_MAX] = TZNAME_MAX;
+    t[_SC_JOB_CONTROL] = 1;
+    t[_SC_SAVED_IDS] = 1;
+    t[_SC_REALTIME_SIGNALS] = VER;
+    t[_SC_PRIORITY_SCHEDULING] = -1;
+    t[_SC_TIMERS] = VER;
+    t[_SC_ASYNCHRONOUS_IO] = VER;
+    t[_SC_PRIORITIZED_IO] = -1;
+    t[_SC_SYNCHRONIZED_IO] = -1;
+    t[_SC_FSYNC] = VER;
+    t[_SC_MAPPED_FILES] = VER;
+    t[_SC_MEMLOCK] = VER;
+    t[_SC_MEMLOCK_RANGE] = VER;
+    t[_SC_MEMORY_PROTECTION] = VER;
+    t[_SC_MESSAGE_PASSING] = VER;
+    t[_SC_SEMAPHORES] = VER;
+    t[_SC_SHARED_MEMORY_OBJECTS] = VER;
+    t[_SC_AIO_LISTIO_MAX] = -1;
+    t[_SC_AIO_MAX] = -1;
+    t[_SC_AIO_PRIO_DELTA_MAX] = JT_ZERO;
+    t[_SC_DELAYTIMER_MAX] = JT_DELAYTIMER_MAX;
+    t[_SC_MQ_OPEN_MAX] = -1;
+    t[_SC_MQ_PRIO_MAX] = JT_MQ_PRIO_MAX;
+    t[_SC_VERSION] = VER;
+    t[_SC_PAGE_SIZE] = JT_PAGE_SIZE;
+    t[_SC_RTSIG_MAX] = _NSIG - 1 - 31 - 3;
+    t[_SC_SEM_NSEMS_MAX] = SEM_NSEMS_MAX;
+    t[_SC_SEM_VALUE_MAX] = JT_SEM_VALUE_MAX;
+    t[_SC_SIGQUEUE_MAX] = -1;
+    t[_SC_TIMER_MAX] = -1;
+    t[_SC_BC_BASE_MAX] = _POSIX2_BC_BASE_MAX;
+    t[_SC_BC_DIM_MAX] = _POSIX2_BC_DIM_MAX;
+    t[_SC_BC_SCALE_MAX] = _POSIX2_BC_SCALE_MAX;
+    t[_SC_BC_STRING_MAX] = _POSIX2_BC_STRING_MAX;
+    t[_SC_COLL_WEIGHTS_MAX] = COLL_WEIGHTS_MAX;
+    t[_SC_EXPR_NEST_MAX] = -1;
+    t[_SC_LINE_MAX] = -1;
+    t[_SC_RE_DUP_MAX] = RE_DUP_MAX;
+    t[_SC_2_VERSION] = VER;
+    t[_SC_2_C_BIND] = VER;
+    t[_SC_2_C_DEV] = -1;
+    t[_SC_2_FORT_DEV] = -1;
+    t[_SC_2_FORT_RUN] = -1;
+    t[_SC_2_SW_DEV] = -1;
+    t[_SC_2_LOCALEDEF] = -1;
+    t[_SC_IOV_MAX] = IOV_MAX;
+    t[_SC_THREADS] = VER;
+    t[_SC_THREAD_SAFE_FUNCTIONS] = VER;
+    t[_SC_GETGR_R_SIZE_MAX] = -1;
+    t[_SC_GETPW_R_SIZE_MAX] = -1;
+    t[_SC_LOGIN_NAME_MAX] = LOGIN_NAME_MAX;
+    t[_SC_TTY_NAME_MAX] = TTY_NAME_MAX;
+    t[_SC_THREAD_DESTRUCTOR_ITERATIONS] = PTHREAD_DESTRUCTOR_ITERATIONS;
+    t[_SC_THREAD_KEYS_MAX] = PTHREAD_KEYS_MAX;
+    t[_SC_THREAD_STACK_MIN] = PTHREAD_STACK_MIN;
+    t[_SC_THREAD_THREADS_MAX] = -1;
+    t[_SC_THREAD_ATTR_STACKADDR] = VER;
+    t[_SC_THREAD_ATTR_STACKSIZE] = VER;
+    t[_SC_THREAD_PRIORITY_SCHEDULING] = VER;
+    t[_SC_THREAD_PRIO_INHERIT] = -1;
+    t[_SC_THREAD_PRIO_PROTECT] = -1;
+    t[_SC_THREAD_PROCESS_SHARED] = VER;
+    t[_SC_NPROCESSORS_CONF] = JT_NPROCESSORS_CONF;
+    t[_SC_NPROCESSORS_ONLN] = JT_NPROCESSORS_ONLN;
+    t[_SC_PHYS_PAGES] = JT_PHYS_PAGES;
+    t[_SC_AVPHYS_PAGES] = JT_AVPHYS_PAGES;
+    t[_SC_ATEXIT_MAX] = -1;
+    t[_SC_PASS_MAX] = -1;
+    t[_SC_XOPEN_VERSION] = _XOPEN_VERSION;
+    t[_SC_XOPEN_XCU_VERSION] = _XOPEN_VERSION;
+    t[_SC_XOPEN_UNIX] = 1;
+    t[_SC_XOPEN_CRYPT] = -1;
+    t[_SC_XOPEN_ENH_I18N] = 1;
+    t[_SC_XOPEN_SHM] = 1;
+    t[_SC_2_CHAR_TERM] = -1;
+    t[_SC_2_UPE] = -1;
+    t[_SC_XOPEN_XPG2] = -1;
+    t[_SC_XOPEN_XPG3] = -1;
+    t[_SC_XOPEN_XPG4] = -1;
+    t[_SC_NZERO] = NZERO;
+    t[_SC_XBS5_ILP32_OFF32] = -1;
+    t[_SC_XBS5_ILP32_OFFBIG] = sz_long_long_off;
+    t[_SC_XBS5_LP64_OFF64] = sz_long_lp64;
+    t[_SC_XBS5_LPBIG_OFFBIG] = -1;
+    t[_SC_XOPEN_LEGACY] = -1;
+    t[_SC_XOPEN_REALTIME] = -1;
+    t[_SC_XOPEN_REALTIME_THREADS] = -1;
+    t[_SC_ADVISORY_INFO] = VER;
+    t[_SC_BARRIERS] = VER;
+    t[_SC_CLOCK_SELECTION] = VER;
+    t[_SC_CPUTIME] = VER;
+    t[_SC_THREAD_CPUTIME] = VER;
+    t[_SC_MONOTONIC_CLOCK] = VER;
+    t[_SC_READER_WRITER_LOCKS] = VER;
+    t[_SC_SPIN_LOCKS] = VER;
+    t[_SC_REGEXP] = 1;
+    t[_SC_SHELL] = 1;
+    t[_SC_SPAWN] = VER;
+    t[_SC_SPORADIC_SERVER] = -1;
+    t[_SC_THREAD_SPORADIC_SERVER] = -1;
+    t[_SC_TIMEOUTS] = VER;
+    t[_SC_TYPED_MEMORY_OBJECTS] = -1;
+    t[_SC_2_PBS] = -1;
+    t[_SC_2_PBS_ACCOUNTING] = -1;
+    t[_SC_2_PBS_LOCATE] = -1;
+    t[_SC_2_PBS_MESSAGE] = -1;
+    t[_SC_2_PBS_TRACK] = -1;
+    t[_SC_SYMLOOP_MAX] = SYMLOOP_MAX;
+    t[_SC_STREAMS] = JT_ZERO;
+    t[_SC_2_PBS_CHECKPOINT] = -1;
+    t[_SC_V6_ILP32_OFF32] = -1;
+    t[_SC_V6_ILP32_OFFBIG] = sz_long_long_off;
+    t[_SC_V6_LP64_OFF64] = sz_long_lp64;
+    t[_SC_V6_LPBIG_OFFBIG] = -1;
+    t[_SC_HOST_NAME_MAX] = HOST_NAME_MAX;
+    t[_SC_TRACE] = -1;
+    t[_SC_TRACE_EVENT_FILTER] = -1;
+    t[_SC_TRACE_INHERIT] = -1;
+    t[_SC_TRACE_LOG] = -1;
+    t[_SC_IPV6] = VER;
+    t[_SC_RAW_SOCKETS] = VER;
+    t[_SC_V7_ILP32_OFF32] = -1;
+    t[_SC_V7_ILP32_OFFBIG] = sz_long_long_off;
+    t[_SC_V7_LP64_OFF64] = sz_long_lp64;
+    t[_SC_V7_LPBIG_OFFBIG] = -1;
+    t[_SC_SS_REPL_MAX] = -1;
+    t[_SC_TRACE_EVENT_NAME_MAX] = -1;
+    t[_SC_TRACE_NAME_MAX] = -1;
+    t[_SC_TRACE_SYS_MAX] = -1;
+    t[_SC_TRACE_USER_EVENT_MAX] = -1;
+    t[_SC_XOPEN_STREAMS] = JT_ZERO;
+    t[_SC_THREAD_ROBUST_PRIO_INHERIT] = -1;
+    t[_SC_THREAD_ROBUST_PRIO_PROTECT] = -1;
+    t[_SC_MINSIGSTKSZ] = JT_MINSIGSTKSZ;
+    t[_SC_SIGSTKSZ] = JT_SIGSTKSZ;
+    break :blk t;
+};
 
 comptime {
     if (builtin.target.isMuslLibC()) {
         symbol(&fpathconf, "fpathconf");
         symbol(&pathconf, "pathconf");
     }
-    if (builtin.target.isWasiLibC()) {
-    }
+    if (builtin.target.isWasiLibC()) {}
     if (builtin.link_libc) {
         symbol(&get_nprocs_conf, "get_nprocs_conf");
         symbol(&get_nprocs, "get_nprocs");
@@ -118,8 +435,7 @@ fn confstr(name: c_int, buf: ?[*]u8, len: usize) callconv(.c) usize {
         if (builtin.os.tag == .linux)
             std.c._errno().* = @intFromEnum(linux.E.INVAL);
         return 0;
-    } else
-        "";
+    } else "";
 
     // Find length of s.
     var slen: usize = 0;
@@ -137,32 +453,36 @@ fn confstr(name: c_int, buf: ?[*]u8, len: usize) callconv(.c) usize {
 }
 
 fn sysconf(name: c_int) callconv(.c) c_long {
-    if (name < 0 or name >= TABLE_SIZE) {
+    if (name < 0 or name >= sc_values.len) {
         std.c._errno().* = @intFromEnum(linux.E.INVAL);
         return -1;
     }
-    const v = values[@intCast(name)];
+    const v = sc_values[@intCast(name)];
     if (v == 0) {
         std.c._errno().* = @intFromEnum(linux.E.INVAL);
         return -1;
     }
     if (v >= -1) return v;
 
-    // RLIMIT query
+    // RLIMIT query (encoded as -32768 | RLIMIT_*)
     if (v < -256) {
         var rl: linux.rlimit = undefined;
-        _ = linux.getrlimit(@enumFromInt(v & 0x3FFF), &rl);
+        const rlim_id: u32 = @as(u16, @bitCast(v)) & 0x3fff;
+        _ = linux.getrlimit(@enumFromInt(rlim_id), &rl);
         if (rl.cur == std.math.maxInt(u64)) return -1;
         return if (rl.cur > LONG_MAX) LONG_MAX else @intCast(rl.cur);
     }
 
-    // Jump table entries
-    const code: u8 = @truncate(@as(c_uint, @intCast(v)));
+    // Jump table entries (v in [-256, -1], encoded as -256 | code)
+    const code: u8 = @truncate(@as(u16, @bitCast(v)));
     return switch (code) {
         1 => _POSIX_VERSION, // VER
-        2 => 2097152, // ARG_MAX
+        2 => 131072, // ARG_MAX (matches musl include/limits.h)
         3 => 32768, // MQ_PRIO_MAX
-        4 => @intCast(std.heap.page_size_min), // PAGE_SIZE
+        4 => blk: { // PAGE_SIZE — query auxv first, fall back to comptime min
+            const auxval = linux.getauxval(std.elf.AT_PAGESZ);
+            break :blk if (auxval != 0) @intCast(auxval) else @intCast(std.heap.page_size_min);
+        },
         5 => 2147483647, // SEM_VALUE_MAX (INT_MAX)
         6, 7 => blk: { // NPROCESSORS_CONF, NPROCESSORS_ONLN
             var set: [128]u8 = .{1} ++ (.{0} ** 127);

--- a/lib/c/string.zig
+++ b/lib/c/string.zig
@@ -305,7 +305,7 @@ fn strdup_fn(s: [*:0]const u8) callconv(.c) ?[*:0]u8 {
     const l = std.mem.len(s);
     const d: [*]u8 = @ptrCast(std.c.malloc(l + 1) orelse return null);
     @memcpy(d[0 .. l + 1], s[0 .. l + 1]);
-    return d[0 .. l + 1 :0].ptr;
+    return d[0..l :0].ptr;
 }
 
 fn strndup_fn(s: [*:0]const u8, n: usize) callconv(.c) ?[*:0]u8 {
@@ -313,7 +313,7 @@ fn strndup_fn(s: [*:0]const u8, n: usize) callconv(.c) ?[*:0]u8 {
     const d: [*]u8 = @ptrCast(std.c.malloc(l + 1) orelse return null);
     @memcpy(d[0..l], s[0..l]);
     d[l] = 0;
-    return d[0 .. l + 1 :0].ptr;
+    return d[0..l :0].ptr;
 }
 
 fn wcsdup_fn(s: [*:0]const wchar_t) callconv(.c) ?[*:0]wchar_t {
@@ -321,7 +321,7 @@ fn wcsdup_fn(s: [*:0]const wchar_t) callconv(.c) ?[*:0]wchar_t {
     const byte_len = (l + 1) * @sizeOf(wchar_t);
     const d: [*]wchar_t = @ptrCast(@alignCast(@as([*]u8, @ptrCast(std.c.malloc(byte_len) orelse return null))));
     @memcpy(d[0 .. l + 1], s[0 .. l + 1]);
-    return d[0 .. l + 1 :0].ptr;
+    return d[0..l :0].ptr;
 }
 
 const strerror_c = @extern(*const fn (c_int) callconv(.c) [*:0]u8, .{ .name = "strerror" });


### PR DESCRIPTION
Two pre-existing PR #277 bugs that were latent under ReleaseFast (silent OOB
returning benign-looking garbage) but became hard crashes when the new
`pr-build` CI gate switched stage4 to ReleaseSafe. Both fired during the
very early init of any binary linking libzigc (stage4 itself + everything
it produces), making the gate unusable until they were fixed.

**Refs:** #424 (the gate is currently broken on `libc/0.16.x` for exactly
these reasons; this PR is the unblocker).

## 1. `lib/c/conf.zig` — sysconf table OOB

`sysconf` was indexing the 21-entry `_PC_*` table with `_SC_*` constants up
to 250. The very first `malloc` in C++ static init calls
`heap.defaultQueryPageSize` → `sysconf(_SC_PAGE_SIZE=30)` → `values[30]`
OOB on a `[21]c_short`.

- ReleaseFast: garbage interpreted as encoded RLIM_* → corrupt mutex
  pointer at `0x1700000000` → SIGSEGV in LLVM `ManagedStatic` init.
- ReleaseSafe: panic `index out of bounds: index 30, len 21` at
  `lib/c/conf.zig:144` — a much clearer signal.

Fix: port musl `src/conf/sysconf.c` upstream branches verbatim:

- Add 143 `_SC_*` index constants matching musl `unistd.h`
- Add musl limit constants (`TZNAME_MAX`, `IOV_MAX`, `COLL_WEIGHTS_MAX`, …)
- Build a sparse 251-entry `sc_values: [251]c_short` table at comptime
- Encode `VER` / `JT_*` / `RLIM_*` sentinels via `@bitCast(@as(u16, …))`
  → `c_short`
- `sysconf` decodes via `@bitCast` (negative `c_short` → positive `u16`)
  instead of `@intCast` (which would panic in safe mode)
- `_SC_PAGE_SIZE` queries `linux.getauxval(AT_PAGESZ)` with
  `page_size_min` fallback; `_SC_ARG_MAX = 131072` to match musl

The pre-existing 21-entry `_PC_*` `values` table is untouched and continues
to drive `fpathconf`/`pathconf`.

## 2. `lib/c/string.zig` — strdup/strndup/wcsdup sentinel mismatch

Three functions used `d[0 .. l + 1 :0].ptr` after `malloc(l + 1)` +
`memcpy(l + 1)`. In Zig, `arr[a..b :s]` requires the sentinel to live at
`arr[b]` (one past the slice end). For a length-`(l+1)` sentinel slice
from an `l+1`-byte allocation, this checks `d[l+1]`, which is past the
buffer end → OOB read.

- ReleaseFast: silent OOB read.
- ReleaseSafe: `sentinel mismatch: expected 0, found <whatever>`

Fired during every link operation when LLD's `FileToRemoveList`
`strdup`'d the temp output path — making it impossible to finish a link.

Fix: change all three to `d[0..l :0].ptr`. Same pointer, same buffer, but
the sentinel position is now `d[l]`, which is 0 because `memcpy` copied
the source's terminating NUL.

## Verification

Done with a fresh debug stage4 (`RelWithDebInfo` + `ZIG_RELEASE_SAFE=ON`):

| State | `zig version` | `zig build-exe main.zig` |
| --- | --- | --- |
| Before any fix | SIGSEGV (sysconf bug) | n/a |
| conf.zig fix only | 0.16.0 | sentinel-mismatch panic in LLD strdup |
| Both fixes | 0.16.0 | builds and runs (cold cache) |

## Known follow-up (not in this PR)

There is an intermittent `libc++abi` `mutex lock failed: No error
information` abort during cache-hit recompiles in the same debug stage4. It
does not block fresh-cache CI runs and is being tracked separately. The
`pr-build` gate uses fresh caches per workflow run, so this PR is sufficient
to make the gate functional again.