### PR TITLE
libzigc: revert 4 broken PRs (#449 #441 #438 #434) to unbreak stage4 build

### DIFF
--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -1,7 +1,6 @@
 const builtin = @import("builtin");
 var environ_var: ?[*:null]?[*:0]u8 = null;
 const std = @import("std");
-const elf = std.elf;
 const linux = std.os.linux;
 const symbol = @import("../c.zig").symbol;
 // C library dependencies.
@@ -28,103 +27,8 @@ const tls_module = extern struct {
     @"align": usize,
     offset: usize,
 };
-
-const LocaleStruct = extern struct {
-    cat: [6]?*const anyopaque,
-};
-
-const RobustList = extern struct {
-    head: ?*volatile anyopaque,
-    off: c_long,
-    pending: ?*volatile anyopaque,
-};
-
-const PThread = extern struct {
-    self: ?*PThread,
-    dtv_or_prev: ?[*]usize,
-    prev_or_next: ?*PThread,
-    next_or_sysinfo: usize,
-    sysinfo_or_canary: usize,
-    canary: usize,
-    tid: c_int,
-    errno_val: c_int,
-    detach_state: c_int,
-    cancel: c_int,
-    canceldisable: u8,
-    cancelasync: u8,
-    tsd_flags: u8,
-    map_base: ?[*]u8,
-    map_size: usize,
-    stack: ?*anyopaque,
-    stack_size: usize,
-    guard_size: usize,
-    result: ?*anyopaque,
-    cancelbuf: ?*anyopaque,
-    tsd: ?[*]?*anyopaque,
-    robust_list: RobustList,
-    h_errno_val: c_int,
-    timer_id: c_int,
-    locale: ?*LocaleStruct,
-    killlock: [1]c_int,
-    dlerror_buf: ?[*]u8,
-    stdio_locks: ?*anyopaque,
-    tls_above_canary: usize,
-    tls_above_dtv: ?[*]usize,
-
-    fn dtvPtr(td: *PThread) *?[*]usize {
-        return if (TLS_ABOVE_TP) &td.tls_above_dtv else &td.dtv_or_prev;
-    }
-
-    fn prevPtr(td: *PThread) *?*PThread {
-        return if (TLS_ABOVE_TP) @ptrCast(&td.dtv_or_prev) else @ptrCast(&td.prev_or_next);
-    }
-
-    fn nextPtr(td: *PThread) *?*PThread {
-        return if (TLS_ABOVE_TP) @ptrCast(&td.prev_or_next) else @ptrCast(&td.next_or_sysinfo);
-    }
-
-    fn sysinfoPtr(td: *PThread) *usize {
-        return if (TLS_ABOVE_TP) &td.next_or_sysinfo else &td.sysinfo_or_canary;
-    }
-};
-
-const BuiltinTls = extern struct {
-    c: u8,
-    pt: PThread,
-    space: [16]?*anyopaque,
-};
-
-const MIN_TLS_ALIGN = @offsetOf(BuiltinTls, "pt");
-const TP_OFFSET: usize = if (builtin.cpu.arch.isMIPS() or builtin.cpu.arch.isPowerPC() or builtin.cpu.arch == .m68k) 0x7000 else 0;
-const GAP_ABOVE_TP: usize = switch (builtin.cpu.arch) {
-    .aarch64, .aarch64_be => 16,
-    .arm, .armeb, .thumb, .thumbeb => 8,
-    else => 0,
-};
-const TLS_ABOVE_TP = switch (builtin.cpu.arch) {
-    .aarch64,
-    .aarch64_be,
-    .arm,
-    .armeb,
-    .thumb,
-    .thumbeb,
-    .loongarch64,
-    .m68k,
-    .mips,
-    .mipsel,
-    .mips64,
-    .mips64el,
-    .powerpc,
-    .powerpc64,
-    .powerpc64le,
-    .riscv32,
-    .riscv64,
-    => true,
-    else => false,
-};
-var builtin_tls: [1]BuiltinTls = undefined;
-var main_tls: tls_module = undefined;
-// Partial __libc struct — fields through global_locale.
+// Partial __libc struct — only the fields we access.
+// After page_size, there's global_locale which we don't touch.
 const LibC = extern struct {
     can_do_threads: u8,
     threaded: u8,
@@ -137,15 +41,11 @@ const LibC = extern struct {
     tls_align: usize,
     tls_cnt: usize,
     page_size: usize,
-    global_locale: LocaleStruct,
 };
 extern "c" fn __set_thread_area(tp: *anyopaque) c_int;
 extern "c" fn memset(dst: *anyopaque, c: c_int, n: usize) *anyopaque;
-extern "c" fn a_crash() noreturn;
 extern "c" fn _init() void;
 extern "c" fn exit(code: c_int) noreturn;
-extern weak const _DYNAMIC: [*]const usize;
-
 const AT_PHDR = 3;
 const AT_PHENT = 4;
 const AT_PHNUM = 5;
@@ -183,121 +83,6 @@ else
 // On x86_64 (TLS below TP): self(8), dtv(8) at offset 8.
 // On aarch64 (TLS_ABOVE_TP): dtv is at end of struct after canary.
 const DTV_OFFSET: usize = @sizeOf(usize); // offset of dtv in struct pthread (after self ptr)
-
-fn __init_tp_fn(p: *anyopaque) callconv(.c) c_int {
-    const td: *PThread = @ptrCast(@alignCast(p));
-    td.self = td;
-    const tp = if (TLS_ABOVE_TP) @as(*anyopaque, @ptrFromInt(@intFromPtr(p) + @sizeOf(PThread) + TP_OFFSET)) else p;
-    const r = __set_thread_area(tp);
-    if (r < 0) return -1;
-    if (r == 0) __libc.can_do_threads = 1;
-    td.detach_state = 2; // DT_JOINABLE
-    td.tid = @bitCast(linux.syscall1(.set_tid_address, @intFromPtr(&__thread_list_lock)));
-    td.locale = &__libc.global_locale;
-    td.robust_list.head = @ptrCast(&td.robust_list.head);
-    td.sysinfoPtr().* = __sysinfo;
-    td.nextPtr().* = td;
-    td.prevPtr().* = td;
-    return 0;
-}
-
-fn __copy_tls_fn(mem_arg: [*]u8) callconv(.c) *anyopaque {
-    var mem = mem_arg;
-    var td: *PThread = undefined;
-    var dtv: [*]usize = undefined;
-
-    if (TLS_ABOVE_TP) {
-        dtv = @ptrCast(@alignCast(mem + __libc.tls_size - (@sizeOf(usize) * (__libc.tls_cnt + 1))));
-
-        mem += (0 -% (@intFromPtr(mem) + @sizeOf(PThread))) & (__libc.tls_align - 1);
-        td = @ptrCast(@alignCast(mem));
-        mem += @sizeOf(PThread);
-
-        var i: usize = 1;
-        var p = __libc.tls_head;
-        while (p) |mod| : ({
-            i += 1;
-            p = mod.next;
-        }) {
-            dtv[i] = @intFromPtr(mem + mod.offset) + DTP_OFFSET;
-            _ = memcpy(mem + mod.offset, mod.image orelse continue, mod.len);
-        }
-    } else {
-        dtv = @ptrCast(@alignCast(mem));
-
-        mem += __libc.tls_size - @sizeOf(PThread);
-        mem -= @intFromPtr(mem) & (__libc.tls_align - 1);
-        td = @ptrCast(@alignCast(mem));
-
-        var i: usize = 1;
-        var p = __libc.tls_head;
-        while (p) |mod| : ({
-            i += 1;
-            p = mod.next;
-        }) {
-            dtv[i] = @intFromPtr(mem - mod.offset) + DTP_OFFSET;
-            _ = memcpy(mem - mod.offset, mod.image orelse continue, mod.len);
-        }
-    }
-
-    dtv[0] = __libc.tls_cnt;
-    td.dtvPtr().* = dtv;
-    return td;
-}
-
-fn __init_tls_fn(aux: [*]usize) callconv(.c) void {
-    var tls_phdr: ?*elf.Phdr = null;
-    var base: usize = 0;
-
-    var p: [*]u8 = @ptrFromInt(aux[AT_PHDR]);
-    var n = aux[AT_PHNUM];
-    while (n != 0) : ({
-        n -= 1;
-        p += aux[AT_PHENT];
-    }) {
-        const phdr: *elf.Phdr = @ptrCast(@alignCast(p));
-        switch (phdr.p_type) {
-            elf.PT_PHDR => base = aux[AT_PHDR] - phdr.p_vaddr,
-            elf.PT_DYNAMIC => if (@intFromPtr(&_DYNAMIC) != 0) base = @intFromPtr(&_DYNAMIC) - phdr.p_vaddr,
-            elf.PT_TLS => tls_phdr = phdr,
-            PT_GNU_STACK => if (phdr.p_memsz > __default_stacksize) {
-                __default_stacksize = if (phdr.p_memsz < DEFAULT_STACK_MAX) @intCast(phdr.p_memsz) else DEFAULT_STACK_MAX;
-            },
-            else => {},
-        }
-    }
-
-    if (tls_phdr) |phdr| {
-        main_tls.image = @ptrFromInt(base + phdr.p_vaddr);
-        main_tls.len = phdr.p_filesz;
-        main_tls.size = phdr.p_memsz;
-        main_tls.@"align" = phdr.p_align;
-        __libc.tls_cnt = 1;
-        __libc.tls_head = &main_tls;
-    }
-
-    const image_addr = @intFromPtr(main_tls.image);
-    main_tls.size += (0 -% main_tls.size -% image_addr) & (main_tls.@"align" - 1);
-    if (TLS_ABOVE_TP) {
-        main_tls.offset = GAP_ABOVE_TP;
-        main_tls.offset += (0 -% GAP_ABOVE_TP +% image_addr) & (main_tls.@"align" - 1);
-    } else {
-        main_tls.offset = main_tls.size;
-    }
-    if (main_tls.@"align" < MIN_TLS_ALIGN) main_tls.@"align" = MIN_TLS_ALIGN;
-
-    __libc.tls_align = main_tls.@"align";
-    __libc.tls_size = (2 * @sizeOf(?*anyopaque) + @sizeOf(PThread) +
-        (if (TLS_ABOVE_TP) main_tls.offset else 0) + main_tls.size + main_tls.@"align" +
-        MIN_TLS_ALIGN - 1) & (0 -% MIN_TLS_ALIGN);
-
-    const mem: [*]u8 = if (__libc.tls_size > @sizeOf(@TypeOf(builtin_tls)))
-        @ptrFromInt(linux.mmap(null, __libc.tls_size, .{ .READ = true, .WRITE = true }, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0))
-    else
-        @ptrCast(&builtin_tls);
-
-    if (__init_tp_fn(__copy_tls_fn(mem)) < 0) a_crash();
-}
 
 fn __reset_tls_fn() callconv(.c) void {
     const tp = get_tp();
@@ -346,9 +131,6 @@ comptime {
         symbol(&__init_ssp, "__init_ssp");
         symbol(&__stack_chk_fail, "__stack_chk_fail");
         symbol(&issetugidImpl, "issetugid");
-        symbol(&__init_tp_fn, "__init_tp");
-        symbol(&__copy_tls_fn, "__copy_tls");
-        symbol(&__init_tls_fn, "__init_tls");
         symbol(&__reset_tls_fn, "__reset_tls");
         symbol(&dummy, "_init");
         symbol(&libc_start_init_fn, "__libc_start_init");

--- a/lib/c/signal.zig
+++ b/lib/c/signal.zig
@@ -7,36 +7,6 @@ const sigset_t = linux.sigset_t;
 const SigsetElement = @typeInfo(sigset_t).array.child;
 const bits_per_elem = @bitSizeOf(SigsetElement);
 const errno = @import("../c.zig").errno;
-const musl_sigset_t = [128 / @sizeOf(c_ulong)]c_ulong;
-const k_sigset_t = linux.sigset_t;
-const k_sigaction = linux.k_sigaction;
-const handler_set_len = NSIG / (8 * @sizeOf(c_ulong));
-
-var unmask_done: c_int = 0;
-var handler_set: [handler_set_len]c_ulong = @splat(0);
-var __eintr_valid_flag: c_int = 0;
-
-const LibC = extern struct {
-    can_do_threads: u8,
-    threaded: u8,
-    secure: u8,
-    need_locks: i8,
-    threads_minus_1: c_int,
-    auxv: ?[*]usize,
-    tls_head: ?*anyopaque,
-    tls_size: usize,
-    tls_align: usize,
-    tls_cnt: usize,
-    page_size: usize,
-    global_locale: [6]?*anyopaque,
-};
-
-extern var __libc: LibC;
-extern var __abort_lock: c_int;
-extern "c" fn __lock(lock: *c_int) callconv(.c) void;
-extern "c" fn __unlock(lock: *c_int) callconv(.c) void;
-extern "c" fn __restore() callconv(.c) void;
-extern "c" fn __restore_rt() callconv(.c) void;
 const all_mask = blk: {
     var mask: sigset_t = undefined;
     for (&mask) |*elem| elem.* = ~@as(SigsetElement, 0);
@@ -53,10 +23,13 @@ const app_mask = blk: {
 // Musl's struct sigaction (different from kernel's k_sigaction)
 const c_sigaction = extern struct {
     handler: ?*align(1) const fn (c_int) callconv(.c) void,
-    mask: musl_sigset_t,
+    mask: [128 / @sizeOf(c_ulong)]c_ulong,
     flags: c_int,
     restorer: ?*const fn () callconv(.c) void,
 };
+// Functions provided by the C library (sigaction.c remains as C)
+extern "c" fn sigaction(sig: c_int, act: ?*const c_sigaction, oact: ?*c_sigaction) callconv(.c) c_int;
+extern "c" fn __sigaction(sig: c_int, act: ?*const c_sigaction, oact: ?*c_sigaction) callconv(.c) c_int;
 const SA_RESTART = 0x10000000;
 extern "c" fn psignal(sig: c_int, msg: ?[*:0]const u8) callconv(.c) void;
 const FILE = extern struct {
@@ -120,11 +93,6 @@ comptime {
         symbol(&sigaltstackLinux, "sigaltstack");
         symbol(&sigprocmaskLinux, "sigprocmask");
         symbol(&sigsuspendLinux, "sigsuspend");
-        symbol(&__get_handler_set, "__get_handler_set");
-        symbol(&__libc_sigaction, "__libc_sigaction");
-        symbol(&__sigaction, "__sigaction");
-        symbol(&__sigaction, "sigaction");
-        @export(&__eintr_valid_flag, .{ .name = "__eintr_valid_flag", .linkage = .weak, .visibility = .hidden });
         symbol(&__block_all_sigs, "__block_all_sigs");
         symbol(&__block_app_sigs, "__block_app_sigs");
         symbol(&__restore_sigs, "__restore_sigs");
@@ -141,108 +109,6 @@ comptime {
         symbol(&sigsetImpl, "sigset");
         symbol(&sigqueueImpl, "sigqueue");
     }
-}
-
-fn sigsetSizeBytes(comptime T: type) usize {
-    return if (@bitSizeOf(@typeInfo(T).array.child) == 8) @sizeOf(T) else NSIG / 8;
-}
-
-fn copyToKernelSigset(dst: *k_sigset_t, src: *const musl_sigset_t) void {
-    @memset(std.mem.asBytes(dst), 0);
-    @memcpy(std.mem.asBytes(dst)[0..sigsetSizeBytes(k_sigset_t)], std.mem.sliceAsBytes(src)[0..sigsetSizeBytes(k_sigset_t)]);
-}
-
-fn copyFromKernelSigset(dst: *musl_sigset_t, src: *const k_sigset_t) void {
-    @memset(std.mem.sliceAsBytes(dst), 0);
-    @memcpy(std.mem.sliceAsBytes(dst)[0..sigsetSizeBytes(k_sigset_t)], std.mem.asBytes(src)[0..sigsetSizeBytes(k_sigset_t)]);
-}
-
-fn sigactionSigValid(sig: c_int) bool {
-    return @as(u32, @bitCast(sig -% 32)) >= 3 and @as(u32, @bitCast(sig -% 1)) < NSIG - 1;
-}
-
-fn __get_handler_set(set: *sigset_t) callconv(.c) void {
-    @memcpy(std.mem.asBytes(set)[0..@sizeOf(@TypeOf(handler_set))], std.mem.asBytes(&handler_set));
-}
-
-fn __libc_sigaction(sig: c_int, noalias sa: ?*const c_sigaction, noalias old: ?*c_sigaction) callconv(.c) c_int {
-    var ksa: k_sigaction = undefined;
-    var ksa_old: k_sigaction = undefined;
-
-    if (sa) |act| {
-        if (@intFromPtr(act.handler) > 1) {
-            const s: u32 = @bitCast(sig -% 1);
-            _ = @atomicRmw(c_ulong, &handler_set[s / (8 * @sizeOf(c_ulong))], .Or, @as(c_ulong, 1) << @intCast(s % (8 * @sizeOf(c_ulong))), .seq_cst);
-
-            // If pthread_create has not yet been called, implementation-internal
-            // signals might not yet have been unblocked. They must be unblocked
-            // before any signal handler is installed, so that the ucontext_t
-            // passed to a signal handler cannot contain an illegal sigset_t.
-            if (__libc.threaded == 0 and unmask_done == 0) {
-                _ = linux.syscall4(.rt_sigprocmask, linux.SIG.UNBLOCK, @intFromPtr(&app_mask), 0, NSIG / 8);
-                unmask_done = 1;
-            }
-
-            if (act.flags & linux.SA.RESTART == 0) {
-                @atomicStore(c_int, &__eintr_valid_flag, 1, .seq_cst);
-            }
-        }
-
-        if (comptime @hasField(k_sigaction, "restorer")) {
-            ksa = .{
-                .handler = @ptrCast(act.handler),
-                .flags = @as(c_ulong, @intCast(act.flags)) | linux.SA.RESTORER,
-                .restorer = if (act.flags & linux.SA.SIGINFO != 0) &__restore_rt else &__restore,
-                .mask = undefined,
-            };
-        } else if (comptime @typeInfo(k_sigaction).@"struct".fields[0].name[0] == 'f') {
-            ksa = .{
-                .flags = @intCast(act.flags),
-                .handler = @ptrCast(act.handler),
-                .mask = undefined,
-            };
-        } else {
-            ksa = .{
-                .handler = @ptrCast(act.handler),
-                .flags = @intCast(act.flags),
-                .mask = undefined,
-            };
-        }
-        copyToKernelSigset(&ksa.mask, &act.mask);
-    }
-
-    const rc = if (builtin.cpu.arch == .sparc or builtin.cpu.arch == .sparc64)
-        linux.syscall5(.rt_sigaction, @as(usize, @bitCast(@as(isize, sig))), if (sa != null) @intFromPtr(&ksa) else 0, if (old != null) @intFromPtr(&ksa_old) else 0, if (sa != null and @hasField(k_sigaction, "restorer")) @intFromPtr(ksa.restorer) else 0, NSIG / 8)
-    else
-        linux.syscall4(.rt_sigaction, @as(usize, @bitCast(@as(isize, sig))), if (sa != null) @intFromPtr(&ksa) else 0, if (old != null) @intFromPtr(&ksa_old) else 0, NSIG / 8);
-
-    if (old) |oldact| {
-        if (rc == 0) {
-            oldact.handler = @ptrCast(ksa_old.handler);
-            oldact.flags = @intCast(ksa_old.flags);
-            copyFromKernelSigset(&oldact.mask, &ksa_old.mask);
-        }
-    }
-    return errno(rc);
-}
-
-fn __sigaction(sig: c_int, noalias sa: ?*const c_sigaction, noalias old: ?*c_sigaction) callconv(.c) c_int {
-    if (!sigactionSigValid(sig)) {
-        std.c._errno().* = @intFromEnum(linux.E.INVAL);
-        return -1;
-    }
-
-    if (sig == @intFromEnum(linux.SIG.ABRT)) {
-        var set: sigset_t = undefined;
-        __block_all_sigs(&set);
-        __lock(&__abort_lock);
-        const rc = __libc_sigaction(sig, sa, old);
-        __unlock(&__abort_lock);
-        __restore_sigs(&set);
-        return rc;
-    }
-
-    return __libc_sigaction(sig, sa, old);
 }
 
 fn sigaddsetLinux(set: *sigset_t, sig: c_int) callconv(.c) c_int {
@@ -501,7 +367,10 @@ fn sigqueueImpl(pid: linux.pid_t, sig: c_int, value: usize) callconv(.c) c_int {
 
     var set: sigset_t = undefined;
     _ = linux.sigprocmask(linux.SIG.BLOCK, &app_mask, &set);
-    const ret = errno(linux.syscall3(.rt_sigqueueinfo, @as(usize, @bitCast(@as(isize, pid))), @as(usize, @bitCast(@as(isize, sig))), @intFromPtr(&si)));
+    const ret = errno(linux.syscall3(.rt_sigqueueinfo,
+        @as(usize, @bitCast(@as(isize, pid))),
+        @as(usize, @bitCast(@as(isize, sig))),
+        @intFromPtr(&si)));
     _ = linux.sigprocmask(linux.SIG.SETMASK, &set, null);
     return ret;
 }

--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -90,6 +90,8 @@ const SwCookie = extern struct {
 const stderr_ext = @extern(*const ?*FILE, .{ .name = "stderr" });
 const strerror_fn = @extern(*const fn (c_int) callconv(.c) [*:0]const u8, .{ .name = "strerror" });
 const vfprintf_fn = @extern(*const fn (?*FILE, [*:0]const u8, VaList) callconv(.c) c_int, .{ .name = "vfprintf" });
+const vfwprintf_fn = @extern(*const fn (?*FILE, [*:0]const wchar_t, VaList) callconv(.c) c_int, .{ .name = "vfwprintf" });
+const vfscanf_fn = @extern(*const fn (?*FILE, [*:0]const u8, VaList) callconv(.c) c_int, .{ .name = "vfscanf" });
 const vfwscanf_fn = @extern(*const fn (?*FILE, [*:0]const wchar_t, VaList) callconv(.c) c_int, .{ .name = "vfwscanf" });
 const memchr_fn = @extern(*const fn (?[*]const u8, c_int, usize) callconv(.c) ?[*]u8, .{ .name = "memchr" });
 const lseek_fn = @extern(*const fn (c_int, i64, c_int) callconv(.c) i64, .{ .name = "__lseek" });
@@ -97,17 +99,7 @@ const malloc_fn = @extern(*const fn (usize) callconv(.c) ?*anyopaque, .{ .name =
 const realloc_fn = @extern(*const fn (?*anyopaque, usize) callconv(.c) ?*anyopaque, .{ .name = "realloc" });
 const aio_close_fn = @extern(*const fn (c_int) callconv(.c) c_int, .{ .name = "__aio_close" });
 const mbtowc_fn = @extern(*const fn (?*wchar_t, ?[*]const u8, usize) callconv(.c) c_int, .{ .name = "mbtowc" });
-const btowc_fn = @extern(*const fn (c_int) callconv(.c) wint_t, .{ .name = "btowc" });
-const snprintf_fn = @extern(*const fn ([*]u8, usize, [*:0]const u8, ...) callconv(.c) c_int, .{ .name = "snprintf" });
-const fprintf_fn = @extern(*const fn (?*FILE, [*:0]const u8, ...) callconv(.c) c_int, .{ .name = "fprintf" });
-const wcsnlen_fn = @extern(*const fn ([*:0]const wchar_t, usize) callconv(.c) usize, .{ .name = "wcsnlen" });
 const wcsrtombs_fn = @extern(*const fn (?[*]u8, *?[*:0]const wchar_t, usize, ?*anyopaque) callconv(.c) usize, .{ .name = "wcsrtombs" });
-const shlim_fn = @extern(*const fn (*FILE, i64) callconv(.c) void, .{ .name = "__shlim" });
-const shgetc_fn = @extern(*const fn (*FILE) callconv(.c) c_int, .{ .name = "__shgetc" });
-const intscan_fn = @extern(*const fn (*FILE, c_uint, c_int, c_ulonglong) callconv(.c) c_ulonglong, .{ .name = "__intscan" });
-const floatscan_fn = @extern(*const fn (*FILE, c_int, c_int) callconv(.c) c_longdouble, .{ .name = "__floatscan" });
-const mbrtowc_fn = @extern(*const fn (?*wchar_t, ?[*]const u8, usize, ?*mbstate_t) callconv(.c) usize, .{ .name = "mbrtowc" });
-const mbsinit_fn = @extern(*const fn (?*const mbstate_t) callconv(.c) c_int, .{ .name = "mbsinit" });
 
 comptime {
     if (builtin.link_libc and builtin.target.isMuslLibC()) {
@@ -185,8 +177,6 @@ comptime {
         symbol(&perror_impl, "perror");
         // #243 fix enables by-value VaList; all v-prefix stdio wrappers now migrated.
         symbol(&vprintf_impl, "vprintf");
-        symbol(&vfscanf_impl, "vfscanf");
-        symbol(&vfscanf_impl, "__isoc99_vfscanf");
         symbol(&vscanf_impl, "vscanf");
         symbol(&vsprintf_impl, "vsprintf");
         symbol(&vwprintf_impl, "vwprintf");
@@ -197,7 +187,6 @@ comptime {
         symbol(&vsscanf_impl, "vsscanf");
         symbol(&vswprintf_impl, "vswprintf");
         symbol(&vswscanf_impl, "vswscanf");
-        symbol(&vfwprintf_impl, "vfwprintf");
         // Internal helpers (__fmodeflags.c, __fclose_ca.c, __fopen_rb_ca.c)
         symbol(&fmodeflags_impl, "__fmodeflags");
         symbol(&fclose_ca_impl, "__fclose_ca");
@@ -1589,368 +1578,6 @@ fn string_read(f: *FILE, buf: [*]u8, len: usize) callconv(.c) usize {
     return actual;
 }
 
-const SIZE_hh: c_int = -2;
-const SIZE_h: c_int = -1;
-const SIZE_def: c_int = 0;
-const SIZE_l: c_int = 1;
-const SIZE_L: c_int = 2;
-const SIZE_ll: c_int = 3;
-
-inline fn is_space(c: c_int) bool {
-    return switch (c) {
-        ' ', '\t', '\n', '\r', 11, 12 => true,
-        else => false,
-    };
-}
-
-inline fn is_digit(c: c_int) bool {
-    return c >= '0' and c <= '9';
-}
-
-inline fn shcnt(f: *FILE) i64 {
-    return f.shcnt + @as(i64, @intCast(@intFromPtr(f.rpos.?) - @intFromPtr(f.buf.?)));
-}
-
-inline fn shlim(f: *FILE, lim: i64) void {
-    shlim_fn(f, lim);
-}
-
-inline fn shgetc(f: *FILE) c_int {
-    if (f.rpos != f.shend) {
-        const c = f.rpos.?[0];
-        f.rpos = f.rpos.? + 1;
-        return c;
-    }
-    return shgetc_fn(f);
-}
-
-inline fn shunget(f: *FILE) void {
-    if (f.shlim >= 0) f.rpos = f.rpos.? - 1;
-}
-
-fn store_int(dest: ?*anyopaque, size: c_int, i: c_ulonglong) void {
-    const p = dest orelse return;
-    switch (size) {
-        SIZE_hh => @as(*u8, @ptrCast(@alignCast(p))).* = @truncate(i),
-        SIZE_h => @as(*c_short, @ptrCast(@alignCast(p))).* = @bitCast(@as(c_ushort, @truncate(i))),
-        SIZE_def => @as(*c_int, @ptrCast(@alignCast(p))).* = @bitCast(@as(c_uint, @truncate(i))),
-        SIZE_l => @as(*c_long, @ptrCast(@alignCast(p))).* = @bitCast(@as(c_ulong, @truncate(i))),
-        SIZE_ll => @as(*c_longlong, @ptrCast(@alignCast(p))).* = @bitCast(@as(c_ulonglong, i)),
-        else => {},
-    }
-}
-
-fn arg_n(ap: VaList, n: c_uint) ?*anyopaque {
-    var ap_src = ap;
-    var ap2 = @cVaCopy(&ap_src);
-    defer @cVaEnd(&ap2);
-    var n_remaining = n;
-    while (n_remaining > 1) : (n_remaining -= 1) _ = @cVaArg(&ap2, ?*anyopaque);
-    return @cVaArg(&ap2, ?*anyopaque);
-}
-
-fn fail_with_alloc(result: c_int, alloc: bool, s: ?[*]u8, wcs: ?[*]wchar_t) c_int {
-    if (alloc) {
-        free_fn(s);
-        free_fn(wcs);
-    }
-    return result;
-}
-
-fn input_fail_result(matches: c_int) c_int {
-    return if (matches == 0) -1 else matches;
-}
-
-/// vfscanf.c: int vfscanf(FILE *restrict f, const char *restrict fmt, va_list ap)
-fn vfscanf_impl(f_arg: ?*FILE, fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
-    const f = f_arg.?;
-    var ap_src = ap;
-    var width: c_int = undefined;
-    var size: c_int = undefined;
-    var alloc: bool = false;
-    var base: c_uint = undefined;
-    var p: [*]const u8 = fmt;
-    var c: c_int = undefined;
-    var t: c_int = undefined;
-    var s: ?[*]u8 = null;
-    var wcs: ?[*]wchar_t = null;
-    var st: mbstate_t = undefined;
-    var dest: ?*anyopaque = null;
-    var invert: c_int = 0;
-    var matches: c_int = 0;
-    var x: c_ulonglong = undefined;
-    var y: c_longdouble = undefined;
-    var pos: i64 = 0;
-    var scanset: [257]u8 = undefined;
-    var i: usize = undefined;
-    var k: usize = undefined;
-    var wc: wchar_t = undefined;
-
-    const need_unlock = flock(f);
-    defer funlock(f, need_unlock);
-
-    if (f.rpos == null) _ = toread_fn(f);
-    if (f.rpos == null) return input_fail_result(matches);
-
-    while (p[0] != 0) : (p += 1) {
-        alloc = false;
-
-        if (is_space(p[0])) {
-            while (is_space(p[1])) p += 1;
-            shlim(f, 0);
-            while (true) {
-                c = shgetc(f);
-                if (!is_space(c)) break;
-            }
-            shunget(f);
-            pos += shcnt(f);
-            continue;
-        }
-
-        if (p[0] != '%' or p[1] == '%') {
-            shlim(f, 0);
-            if (p[0] == '%') {
-                p += 1;
-                while (true) {
-                    c = shgetc(f);
-                    if (!is_space(c)) break;
-                }
-            } else {
-                c = shgetc(f);
-            }
-            if (c != p[0]) {
-                shunget(f);
-                if (c < 0) return input_fail_result(matches);
-                return matches;
-            }
-            pos += shcnt(f);
-            continue;
-        }
-
-        p += 1;
-        if (p[0] == '*') {
-            dest = null;
-            p += 1;
-        } else if (is_digit(p[0]) and p[1] == '$') {
-            dest = arg_n(ap_src, p[0] - '0');
-            p += 2;
-        } else {
-            dest = @cVaArg(&ap_src, ?*anyopaque);
-        }
-
-        width = 0;
-        while (is_digit(p[0])) : (p += 1) {
-            width = 10 * width + @as(c_int, p[0]) - '0';
-        }
-
-        if (p[0] == 'm') {
-            wcs = null;
-            s = null;
-            alloc = dest != null;
-            p += 1;
-        } else {
-            alloc = false;
-        }
-
-        size = SIZE_def;
-        const size_ch = p[0];
-        p += 1;
-        switch (size_ch) {
-            'h' => if (p[0] == 'h') {
-                p += 1;
-                size = SIZE_hh;
-            } else size = SIZE_h,
-            'l' => if (p[0] == 'l') {
-                p += 1;
-                size = SIZE_ll;
-            } else size = SIZE_l,
-            'j' => size = SIZE_ll,
-            'z', 't' => size = SIZE_l,
-            'L' => size = SIZE_L,
-            'd', 'i', 'o', 'u', 'x', 'a', 'e', 'f', 'g', 'A', 'E', 'F', 'G', 'X', 's', 'c', '[', 'S', 'C', 'p', 'n' => p -= 1,
-            else => return fail_with_alloc(matches, alloc, s, wcs),
-        }
-
-        t = p[0];
-
-        if ((t & 0x2f) == 3) {
-            t |= 32;
-            size = SIZE_l;
-        }
-
-        switch (t) {
-            'c' => if (width < 1) width = 1,
-            '[' => {},
-            'n' => {
-                store_int(dest, size, @intCast(pos));
-                continue;
-            },
-            else => {
-                shlim(f, 0);
-                while (true) {
-                    c = shgetc(f);
-                    if (!is_space(c)) break;
-                }
-                shunget(f);
-                pos += shcnt(f);
-            },
-        }
-
-        shlim(f, width);
-        if (shgetc(f) < 0) return fail_with_alloc(input_fail_result(matches), alloc, s, wcs);
-        shunget(f);
-
-        switch (t) {
-            's', 'c', '[' => {
-                if (t == 'c' or t == 's') {
-                    @memset(&scanset, 0xff);
-                    scanset[0] = 0;
-                    if (t == 's') {
-                        scanset[1 + '\t'] = 0;
-                        scanset[1 + '\n'] = 0;
-                        scanset[1 + 11] = 0;
-                        scanset[1 + 12] = 0;
-                        scanset[1 + '\r'] = 0;
-                        scanset[1 + ' '] = 0;
-                    }
-                } else {
-                    p += 1;
-                    if (p[0] == '^') {
-                        p += 1;
-                        invert = 1;
-                    } else invert = 0;
-                    @memset(&scanset, @as(u8, @intCast(invert)));
-                    scanset[0] = 0;
-                    if (p[0] == '-') {
-                        p += 1;
-                        scanset[1 + '-'] = @intCast(1 - invert);
-                    } else if (p[0] == ']') {
-                        p += 1;
-                        scanset[1 + ']'] = @intCast(1 - invert);
-                    }
-                    while (p[0] != ']') : (p += 1) {
-                        if (p[0] == 0) return fail_with_alloc(matches, alloc, s, wcs);
-                        if (p[0] == '-' and p[1] != 0 and p[1] != ']') {
-                            const start = p[-1];
-                            p += 1;
-                            var rc: c_int = start;
-                            while (rc < p[0]) : (rc += 1) scanset[@as(usize, @intCast(1 + rc))] = @intCast(1 - invert);
-                        }
-                        scanset[1 + p[0]] = @intCast(1 - invert);
-                    }
-                }
-
-                wcs = null;
-                s = null;
-                i = 0;
-                k = if (t == 'c') @as(usize, @intCast(width)) + 1 else 31;
-                if (size == SIZE_l) {
-                    if (alloc) {
-                        wcs = @ptrCast(@alignCast(malloc_fn(k * @sizeOf(wchar_t)) orelse return fail_with_alloc(input_fail_result(matches), alloc, s, wcs)));
-                    } else if (dest) |d| {
-                        wcs = @ptrCast(@alignCast(d));
-                    }
-                    st = std.mem.zeroes(mbstate_t);
-                    while (true) {
-                        c = shgetc(f);
-                        if (scanset[@as(usize, @intCast(c + 1))] == 0) break;
-                        var ch: u8 = @truncate(@as(c_uint, @bitCast(c)));
-                        switch (mbrtowc_fn(&wc, @ptrCast(&ch), 1, &st)) {
-                            @as(usize, @bitCast(@as(isize, -1))) => return fail_with_alloc(input_fail_result(matches), alloc, s, wcs),
-                            @as(usize, @bitCast(@as(isize, -2))) => continue,
-                            else => {},
-                        }
-                        if (wcs) |buf| buf[i] = wc;
-                        i += 1;
-                        if (alloc and i == k) {
-                            k += k + 1;
-                            wcs = @ptrCast(@alignCast(realloc_fn(wcs, k * @sizeOf(wchar_t)) orelse return fail_with_alloc(input_fail_result(matches), alloc, s, wcs)));
-                        }
-                    }
-                    if (mbsinit_fn(&st) == 0) return fail_with_alloc(input_fail_result(matches), alloc, s, wcs);
-                } else if (alloc) {
-                    s = @ptrCast(@alignCast(malloc_fn(k) orelse return fail_with_alloc(input_fail_result(matches), alloc, s, wcs)));
-                    while (true) {
-                        c = shgetc(f);
-                        if (scanset[@as(usize, @intCast(c + 1))] == 0) break;
-                        s.?[i] = @truncate(@as(c_uint, @bitCast(c)));
-                        i += 1;
-                        if (i == k) {
-                            k += k + 1;
-                            s = @ptrCast(@alignCast(realloc_fn(s, k) orelse return fail_with_alloc(input_fail_result(matches), alloc, s, wcs)));
-                        }
-                    }
-                } else if (dest) |d| {
-                    s = @ptrCast(@alignCast(d));
-                    while (true) {
-                        c = shgetc(f);
-                        if (scanset[@as(usize, @intCast(c + 1))] == 0) break;
-                        s.?[i] = @truncate(@as(c_uint, @bitCast(c)));
-                        i += 1;
-                    }
-                } else {
-                    while (true) {
-                        c = shgetc(f);
-                        if (scanset[@as(usize, @intCast(c + 1))] == 0) break;
-                    }
-                }
-                shunget(f);
-                const cnt = shcnt(f);
-                if (cnt == 0) return fail_with_alloc(matches, alloc, s, wcs);
-                if (t == 'c' and cnt != width) return fail_with_alloc(matches, alloc, s, wcs);
-                if (alloc) {
-                    if (size == SIZE_l) @as(*?[*]wchar_t, @ptrCast(@alignCast(dest.?))).* = wcs else @as(*?[*]u8, @ptrCast(@alignCast(dest.?))).* = s;
-                }
-                if (t != 'c') {
-                    if (wcs) |buf| buf[i] = 0;
-                    if (s) |buf| buf[i] = 0;
-                }
-            },
-            'p', 'X', 'x' => {
-                base = 16;
-                x = intscan_fn(f, base, 0, std.math.maxInt(c_ulonglong));
-                if (shcnt(f) == 0) return matches;
-                if (t == 'p') {
-                    if (dest) |d| @as(*?*anyopaque, @ptrCast(@alignCast(d))).* = @ptrFromInt(@as(usize, @intCast(x)));
-                } else store_int(dest, size, x);
-            },
-            'o' => {
-                base = 8;
-                x = intscan_fn(f, base, 0, std.math.maxInt(c_ulonglong));
-                if (shcnt(f) == 0) return matches;
-                store_int(dest, size, x);
-            },
-            'd', 'u' => {
-                base = 10;
-                x = intscan_fn(f, base, 0, std.math.maxInt(c_ulonglong));
-                if (shcnt(f) == 0) return matches;
-                store_int(dest, size, x);
-            },
-            'i' => {
-                base = 0;
-                x = intscan_fn(f, base, 0, std.math.maxInt(c_ulonglong));
-                if (shcnt(f) == 0) return matches;
-                store_int(dest, size, x);
-            },
-            'a', 'A', 'e', 'E', 'f', 'F', 'g', 'G' => {
-                y = floatscan_fn(f, size, 0);
-                if (shcnt(f) == 0) return matches;
-                if (dest) |d| switch (size) {
-                    SIZE_def => @as(*f32, @ptrCast(@alignCast(d))).* = @floatCast(y),
-                    SIZE_l => @as(*f64, @ptrCast(@alignCast(d))).* = @floatCast(y),
-                    SIZE_L => @as(*c_longdouble, @ptrCast(@alignCast(d))).* = y,
-                    else => {},
-                };
-            },
-            else => return fail_with_alloc(matches, alloc, s, wcs),
-        }
-
-        pos += shcnt(f);
-        if (dest != null) matches += 1;
-    }
-    return matches;
-}
-
 /// vsscanf.c: int vsscanf(const char *restrict s, const char *restrict fmt, va_list ap)
 fn vsscanf_impl(s: [*:0]const u8, fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
     var f = std.mem.zeroes(FILE);
@@ -1958,7 +1585,7 @@ fn vsscanf_impl(s: [*:0]const u8, fmt: [*:0]const u8, ap: VaList) callconv(.c) c
     f.cookie = @ptrCast(@constCast(s));
     f.read_fn = &string_read;
     f.lock = -1;
-    return vfscanf_impl(@ptrCast(&f), fmt, ap);
+    return vfscanf_fn(@ptrCast(&f), fmt, ap);
 }
 
 fn sw_write(f: *FILE, s: [*]const u8, l: usize) callconv(.c) usize {
@@ -2012,7 +1639,7 @@ fn vswprintf_impl(s: [*]wchar_t, n: usize, fmt: [*:0]const wchar_t, ap: VaList) 
     f.buf_size = buf.len;
     f.cookie = @ptrCast(&c);
     if (n == 0) return -1;
-    const r = vfwprintf_impl(@ptrCast(&f), fmt, ap);
+    const r = vfwprintf_fn(@ptrCast(&f), fmt, ap);
     _ = sw_write(&f, @ptrCast(&f), 0);
     return if (r >= @as(c_int, @intCast(n))) @as(c_int, -1) else r;
 }
@@ -2054,7 +1681,7 @@ fn vswscanf_impl(s: [*:0]const wchar_t, fmt: [*:0]const wchar_t, ap: VaList) cal
 /// swscanf.c: int swscanf(const wchar_t *restrict s, const wchar_t *restrict fmt, ...)
 /// vwprintf.c: int vwprintf(const wchar_t *restrict fmt, va_list ap)
 fn vwprintf_impl(fmt: [*:0]const wchar_t, ap: VaList) callconv(.c) c_int {
-    return vfwprintf_impl(stdout_ext.*, fmt, ap);
+    return vfwprintf_fn(stdout_ext.*, fmt, ap);
 }
 
 /// vwscanf.c: int vwscanf(const wchar_t *restrict fmt, va_list ap)
@@ -2069,7 +1696,7 @@ fn vprintf_impl(fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
 
 /// vscanf.c: int vscanf(const char *restrict fmt, va_list ap)
 fn vscanf_impl(fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
-    return vfscanf_impl(stdin_ext.*, fmt, ap);
+    return vfscanf_fn(stdin_ext.*, fmt, ap);
 }
 
 // --- Variadic entry points (#243 fix enables forwarding VaList by value to C) ---
@@ -2120,14 +1747,14 @@ fn asprintf_impl(s: *?[*]u8, fmt: [*:0]const u8, ...) callconv(.c) c_int {
 fn wprintf_impl(fmt: [*:0]const wchar_t, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfwprintf_impl(stdout_ext.*, fmt, ap);
+    return vfwprintf_fn(stdout_ext.*, fmt, ap);
 }
 
 /// fwprintf.c
 fn fwprintf_impl(f: ?*FILE, fmt: [*:0]const wchar_t, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfwprintf_impl(f, fmt, ap);
+    return vfwprintf_fn(f, fmt, ap);
 }
 
 /// swprintf.c
@@ -2141,14 +1768,14 @@ fn swprintf_impl(s: [*]wchar_t, n: usize, fmt: [*:0]const wchar_t, ...) callconv
 fn scanf_impl(fmt: [*:0]const u8, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfscanf_impl(stdin_ext.*, fmt, ap);
+    return vfscanf_fn(stdin_ext.*, fmt, ap);
 }
 
 /// fscanf.c (also aliased as __isoc99_fscanf)
 fn fscanf_impl(f: ?*FILE, fmt: [*:0]const u8, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfscanf_impl(f, fmt, ap);
+    return vfscanf_fn(f, fmt, ap);
 }
 
 /// sscanf.c (also aliased as __isoc99_sscanf)

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -446,7 +446,7 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
 }
 
 const src_files = [_][]const u8{
-    //"musl/src/env/__init_tls.c", // migrated to lib/c/env.zig
+    "musl/src/env/__init_tls.c",
     "musl/src/fenv/aarch64/fenv.s",
     //"musl/src/fenv/arm/fenv.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/arm/fenv-hf.S",
@@ -663,7 +663,7 @@ const src_files = [_][]const u8{
     "musl/src/signal/riscv64/sigsetjmp.s",
     "musl/src/signal/s390x/restore.s",
     "musl/src/signal/s390x/sigsetjmp.s",
-    //"musl/src/signal/sigaction.c", // migrated to lib/c/signal.zig
+    "musl/src/signal/sigaction.c",
     "musl/src/signal/x32/restore.s",
     "musl/src/signal/x32/sigsetjmp.s",
     "musl/src/signal/x86_64/restore.s",
@@ -728,7 +728,7 @@ const src_files = [_][]const u8{
     // "musl/src/stdio/vasprintf.c", // migrated to Zig (vasprintf_impl)
     // "musl/src/stdio/vdprintf.c", // migrated to Zig (vdprintf_impl)
     "musl/src/stdio/vfprintf.c",
-    //"musl/src/stdio/vfscanf.c", // migrated to lib/c/stdio.zig
+    "musl/src/stdio/vfscanf.c",
     "musl/src/stdio/vfwprintf.c",
     "musl/src/stdio/vfwscanf.c",
     // "musl/src/stdio/vprintf.c", // migrated to Zig (vprintf_impl), positive test for #243 fix


### PR DESCRIPTION
The autopilot driver landed 4 PRs that introduced compile errors caught by `zig fmt --ast-check`. Because `pr-build` is currently advisory (#429 pthread flakiness) and the only required gate is the Python migration-claims check, the broken code merged anyway. Stage4 won't build at `d32a9ce662`, so post-merge-libc has been failing at "Build stage4" for every push since.

## Reverted PRs

| PR | Issue | File:line | Error |
|---|---|---|---|
| #449 | #321 stdio vfscanf | `lib/c/stdio.zig:1759` | invalid LHS in switch arm |
| #441 | #341 env __init_tls | `lib/c/env.zig:147` | `extern weak const` — invalid Zig syntax |
| #438 | #332 signal sigaction | `lib/c/signal.zig:415,432,481` | undeclared `sigaction` (defined as `__sigaction`) |
| #434 | #322 stdio vfwprintf | `lib/c/stdio.zig:200,2015,2057,2123,2130` | undeclared `vfwprintf_impl` |

`pr-build`'s ast-check step _did_ flag all 4, but the gate was advisory.

## Why now

Five most recent post-merge-libc runs all failed at the **"Build stage4"** step:

| run | sha | failed at |
|---|---|---|
| 25522768392 | d32a9ce6 | Build stage4 |
| 25517710234 | be924adc | Build stage4 |
| 25515484382 | 27ac13ea | Build stage4 |
| 25512146819 | b1564ae1 | Build stage4 |
| 25511014122 | 9d384a7a | Build stage4 |

The libc-test matrix never even started — there's nothing wrong with the tests right now, just the code.

## Verified locally

- `zig fmt --ast-check` on every `lib/c/*.zig`: clean
- `python3 scripts/check_musl_migration.py`: OK (185 entries, 1495 symbols)

## Follow-ups

- Promote `ast-check` + `build stage4 aarch64` to a required CI gate (separate PR; tracked in a follow-up issue).
- Re-attempt the original migrations (#321 #322 #332 #341) once the real gate is in place.

Closes-related: #321, #322, #332, #341 (reopens conceptually — original issues remain open after these reverts)