### PR TITLE
libzigc: type ULLONG_MAX/UINT_MAX in internal.zig (fix LHS-of-shift)

### DIFF
--- a/lib/c/internal.zig
+++ b/lib/c/internal.zig
@@ -5,8 +5,8 @@ const linux = std.os.linux;
 
 const off_t = c_longlong;
 const EOF = -1;
-const ULLONG_MAX = std.math.maxInt(c_ulonglong);
-const UINT_MAX = std.math.maxInt(c_uint);
+const ULLONG_MAX: c_ulonglong = std.math.maxInt(c_ulonglong);
+const UINT_MAX: c_uint = std.math.maxInt(c_uint);
 
 /// Musl internal FILE struct layout (struct _IO_FILE from stdio_impl.h).
 /// Field order MUST match musl's struct _IO_FILE exactly.


### PR DESCRIPTION
PR #437 introduced `(ULLONG_MAX >> bs)` at `lib/c/internal.zig:435` where `ULLONG_MAX` was a `comptime_int` (returned by `std.math.maxInt(c_ulonglong)`) and `bs` is a runtime `u3`. Zig requires LHS of shift to be either a fixed-width integer type or RHS to be comptime-known, so this fails:

```
lib/c/internal.zig:435:59: error: LHS of shift must be a fixed-width integer type, or RHS must be comptime-known
        while (digitVal(c_ch) < base and y <= (ULLONG_MAX >> bs)) : (c_ch = shgetc(f)) {
                                               ~~~~~~~~~~~^~~~~
referenced by:
    comptime: lib/c/internal.zig:715:19  (c.symbol(&intscan, "__intscan"))
    comptime: lib/c.zig:144:21
```

The error only surfaces when `intscan` is referenced at comptime via `c.symbol(&intscan, "__intscan")`, which is why simple test snippets without that comptime-force chain don't trip it.

PR #437's `pr-build` was FAILURE at the time it merged, but `pr-build` was advisory back then. With #453 making `pr-build` required, this kind of merge can't happen again — but #437 had already landed, hence the lingering breakage.

## Fix

Type both `ULLONG_MAX` and `UINT_MAX` as their `c` equivalents:

```zig
const ULLONG_MAX: c_ulonglong = std.math.maxInt(c_ulonglong);
const UINT_MAX:   c_uint      = std.math.maxInt(c_uint);
```

This makes the LHS fixed-width so the shift type-checks. `UINT_MAX` is typed for symmetry; it's currently only used with `/` which already accepted `comptime_int` LHS, so no behavioral change there.

## Verified

- `zig fmt --ast-check lib/c/internal.zig`: clean
- Mini repro with `dev.3061+9b1eaad13` zig + comptime force chain (`comptime { _ = &fn_using_shift; }`): builds successfully after the fix; reproduces the original error before the fix.

## Why post-merge-libc has been red

post-merge-libc on every push since #437 has failed at "Build stage4" because the stage3→stage4 cross-compile for `x86_64-linux-musl` analyzes `lib/c/internal.zig` at comptime. Run 25541502743 (sha `67e41425`, the revert PR head) failed for exactly this reason — even after we'd reverted the 4 broken PRs from yesterday's incident.