### PR TITLE
ci: only raise nproc/nofile when current soft is below threshold

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -307,8 +307,13 @@ jobs:
         timeout-minutes: 30
         run: |
           set -euo pipefail
-          ulimit -u 65535 || true
-          ulimit -n 65535 || true
+          # Only raise nproc/nofile if current soft is below threshold. Avoids
+          # noisy "cannot modify limit" errors on GH-hosted runners and
+          # avoids lowering already-high soft caps on self-hosted runners.
+          if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
+          if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
+          echo "ulimit -u: $(ulimit -u)"
+          echo "ulimit -n: $(ulimit -n)"
           echo "stage4: $STAGE4"
           echo "libc-test SHA: $LIBC_TEST_SHA"
           "$STAGE4/bin/zig" build test-libc \

--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -196,9 +196,15 @@ jobs:
         run: |
           # Raise thread/process limits to avoid "thread constructor failed:
           # Resource temporarily unavailable" during parallel musl sub-compiles.
-          ulimit -u 65535 || true
-          ulimit -n 65535 || true
+          # Only raise when current is below threshold, to avoid:
+          #   * the noisy "Operation not permitted" error on GH-hosted runners
+          #     where the user's hard nproc is already 63,838 (>= our needs);
+          #   * actively lowering soft nproc on self-hosted runners that have
+          #     much higher caps configured.
+          if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
+          if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
           echo "ulimit -u: $(ulimit -u)"
+          echo "ulimit -n: $(ulimit -n)"
 
           # Use -j1 for thread/pthread tests to avoid runner thread exhaustion
           FILTER="${{ inputs.test-filter }}"


### PR DESCRIPTION
The current call sites do unconditional `ulimit -u 65535 || true`:

* On **GH-hosted** runners (post-merge-libc x86_64 + matrix arches), the user's hard nproc is **63,838** by host policy; raising to 65,535 fails with `ulimit: max user processes: cannot modify limit: Operation not permitted`. The error is swallowed by `|| true` but still pollutes workflow logs.

* On **self-hosted** runners (this VM, used by pr-build aarch64), the soft nproc is already **254,473** (LimitNPROC default in systemd); `ulimit -u 65535` would actively lower the soft cap from 254K to 65K.

Replace each call with a guard that only raises when current is below 32,768 (more than enough for libc-test's `-j2` parallelism). Both runner classes already exceed that cap and will skip the raise.

Same treatment for `ulimit -n` (open files).

Verified:

```
$ ulimit -u   # this VM
254473
$ # gh-hosted from quoted log
ulimit: max user processes: cannot modify limit: Operation not permitted
ulimit -u: 63838
```