### PR TITLE
libzigc: libzigc: migrate getauxval, getdomainname from C to Zig

### DIFF
--- a/lib/c/misc.zig
+++ b/lib/c/misc.zig
@@ -250,6 +250,8 @@ comptime {
         symbol(&getresgidLinux, "getresgid");
         symbol(&setdomainnameLinux, "setdomainname");
         symbol(&gethostid, "gethostid");
+        symbol(&__getauxval, "__getauxval");
+        symbol(&__getauxval, "getauxval");
         symbol(&getdomainnameLinux, "getdomainname");
         symbol(&getrlimitLinux, "getrlimit");
         symbol(&setrlimitLinux, "setrlimit");
@@ -331,6 +333,35 @@ fn setdomainnameLinux(name: [*]const u8, len: usize) callconv(.c) c_int {
 }
 
 fn gethostid() callconv(.c) c_long {
+    return 0;
+}
+
+const LibC = extern struct {
+    can_do_threads: u8,
+    threaded: u8,
+    secure: u8,
+    need_locks: i8,
+    threads_minus_1: c_int,
+    auxv: ?[*]usize,
+    tls_head: ?*anyopaque,
+    tls_size: usize,
+    tls_align: usize,
+    tls_cnt: usize,
+    page_size: usize,
+};
+extern var __libc: LibC;
+
+fn __getauxval(item: c_ulong) callconv(.c) c_ulong {
+    if (item == std.elf.AT_SECURE) return __libc.secure;
+
+    var auxv = __libc.auxv orelse {
+        std.c._errno().* = @intFromEnum(linux.E.NOENT);
+        return 0;
+    };
+    while (auxv[0] != 0) : (auxv += 2) {
+        if (auxv[0] == item) return @intCast(auxv[1]);
+    }
+    std.c._errno().* = @intFromEnum(linux.E.NOENT);
     return 0;
 }
 

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -528,8 +528,8 @@ const src_files = [_][]const u8{
     //"musl/src/math/__math_uflowf.c", // migrated to lib/c/math.zig
     //"musl/src/math/__math_xflow.c", // migrated to lib/c/math.zig
     //"musl/src/math/__math_xflowf.c", // migrated to lib/c/math.zig
-    "musl/src/misc/getauxval.c",
-    "musl/src/misc/getdomainname.c",
+    //"musl/src/misc/getauxval.c", // migrated to lib/c/misc.zig
+    //"musl/src/misc/getdomainname.c", // migrated to lib/c/misc.zig
     "musl/src/network/accept4.c",
     "musl/src/network/accept.c",
     "musl/src/network/bind.c",


### PR DESCRIPTION
Closes #307

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/307

See branch libzigc-issue-307 on the cataggar fork for the implementation.