### PR TITLE
libzigc: libzigc: migrate stdio default streams from C to Zig

### DIFF
--- a/lib/c/exit.zig
+++ b/lib/c/exit.zig
@@ -32,8 +32,7 @@ extern "c" fn __block_all_sigs(set: ?*anyopaque) void;
 var __abort_lock: c_int = 0;
 
 comptime {
-    if (builtin.target.isMuslLibC()) {
-    }
+    if (builtin.target.isMuslLibC()) {}
     if (builtin.link_libc) {
         symbol(&quick_exit, "quick_exit");
         symbol(&__funcs_on_quick_exit, "__funcs_on_quick_exit");
@@ -45,7 +44,7 @@ comptime {
         symbol(&qe_lock, "__at_quick_exit_lockptr");
         symbol(&ae_lock, "__atexit_lockptr");
         symbol(&abortImpl, "abort");
-        symbol(&dummy, "__stdio_exit");
+        if (!builtin.target.isMuslLibC()) symbol(&dummy, "__stdio_exit");
         symbol(&libc_exit_fini, "__libc_exit_fini");
         symbol(&_ExitImpl, "_Exit");
         @export(&__abort_lock, .{ .name = "__abort_lock" });
@@ -200,4 +199,6 @@ fn exitImpl(code: c_int) callconv(.c) noreturn {
     _ExitImpl(code);
 }
 
-comptime { if (builtin.target.isMuslLibC()) symbol(&_finiStub, "_fini"); }
+comptime {
+    if (builtin.target.isMuslLibC()) symbol(&_finiStub, "_fini");
+}

--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -46,6 +46,7 @@ const _IOLBF = 1;
 const _IONBF = 2;
 const BUFSIZ = 1024;
 const EOF = -1;
+const F_PERM: c_uint = 1;
 // Extern references to musl C functions that are still compiled from C sources.
 const setvbuf_fn = @extern(*const fn (?*FILE, ?[*]u8, c_int, usize) callconv(.c) c_int, .{ .name = "setvbuf" });
 const getdelim_fn = @extern(*const fn (?*[*]u8, ?*usize, c_int, ?*FILE) callconv(.c) ssize_t, .{ .name = "getdelim" });
@@ -53,8 +54,6 @@ const fgetwc_fn = @extern(*const fn (?*FILE) callconv(.c) wint_t, .{ .name = "fg
 const fputwc_fn = @extern(*const fn (wchar_t, ?*FILE) callconv(.c) wint_t, .{ .name = "fputwc" });
 const fread_fn = @extern(*const fn (*anyopaque, usize, usize, ?*FILE) callconv(.c) usize, .{ .name = "fread" });
 const fwrite_fn = @extern(*const fn (*const anyopaque, usize, usize, ?*FILE) callconv(.c) usize, .{ .name = "fwrite" });
-const stdin_ext = @extern(*const ?*FILE, .{ .name = "stdin" });
-const stdout_ext = @extern(*const ?*FILE, .{ .name = "stdout" });
 const fgetc_fn = @extern(*const fn (?*FILE) callconv(.c) c_int, .{ .name = "fgetc" });
 /// Musl FILE flag constants (from stdio_impl.h)
 const F_EOF: c_uint = 16;
@@ -87,7 +86,6 @@ const SwCookie = extern struct {
     ws: [*]wchar_t,
     l: usize,
 };
-const stderr_ext = @extern(*const ?*FILE, .{ .name = "stderr" });
 const strerror_fn = @extern(*const fn (c_int) callconv(.c) [*:0]const u8, .{ .name = "strerror" });
 const vfprintf_fn = @extern(*const fn (?*FILE, [*:0]const u8, VaList) callconv(.c) c_int, .{ .name = "vfprintf" });
 const vfwprintf_fn = @extern(*const fn (?*FILE, [*:0]const wchar_t, VaList) callconv(.c) c_int, .{ .name = "vfwprintf" });
@@ -117,8 +115,79 @@ const posix_spawn_file_actions_destroy_fn = @extern(*const fn (*posix_spawn_file
 const posix_spawn_fn = @extern(*const fn (*linux.pid_t, [*:0]const u8, ?*const posix_spawn_file_actions_t, ?*const anyopaque, [*:null]const ?[*:0]u8, [*:null]const ?[*:0]u8) callconv(.c) c_int, .{ .name = "posix_spawn" });
 extern "c" var __environ: [*:null]?[*:0]u8;
 
+var stdin_buf: [BUFSIZ + UNGET]u8 = undefined;
+var stdout_buf: [BUFSIZ + UNGET]u8 = undefined;
+var stderr_buf: [UNGET]u8 = undefined;
+
+var __stdin_FILE: FILE = initStdinFile();
+var __stdout_FILE: FILE = initStdoutFile();
+var __stderr_FILE: FILE = initStderrFile();
+
+const stdin: ?*FILE = &__stdin_FILE;
+const stdout: ?*FILE = &__stdout_FILE;
+const stderr: ?*FILE = &__stderr_FILE;
+
+var __stdin_used: ?*FILE = &__stdin_FILE;
+var __stdout_used: ?*FILE = &__stdout_FILE;
+var __stderr_used: ?*FILE = &__stderr_FILE;
+
+const stdin_ext: *const ?*FILE = &stdin;
+const stdout_ext: *const ?*FILE = &stdout;
+const stderr_ext: *const ?*FILE = &stderr;
+
+fn initStdinFile() FILE {
+    var f = std.mem.zeroes(FILE);
+    f.buf = stdin_buf[UNGET..].ptr;
+    f.buf_size = BUFSIZ;
+    f.fd = 0;
+    f.flags = F_PERM | F_NOWR;
+    f.read_fn = &stdio_read_impl;
+    f.seek_fn = &stdio_seek_impl;
+    f.close_fn = &stdio_close_impl;
+    f.lock = -1;
+    return f;
+}
+
+fn initStdoutFile() FILE {
+    var f = std.mem.zeroes(FILE);
+    f.buf = stdout_buf[UNGET..].ptr;
+    f.buf_size = BUFSIZ;
+    f.fd = 1;
+    f.flags = F_PERM | F_NORD;
+    f.lbf = '\n';
+    f.write_fn = &stdout_write_impl;
+    f.seek_fn = &stdio_seek_impl;
+    f.close_fn = &stdio_close_impl;
+    f.lock = -1;
+    return f;
+}
+
+fn initStderrFile() FILE {
+    var f = std.mem.zeroes(FILE);
+    f.buf = stderr_buf[UNGET..].ptr;
+    f.buf_size = 0;
+    f.fd = 2;
+    f.flags = F_PERM | F_NORD;
+    f.lbf = -1;
+    f.write_fn = &stdio_write_impl;
+    f.seek_fn = &stdio_seek_impl;
+    f.close_fn = &stdio_close_impl;
+    f.lock = -1;
+    return f;
+}
+
 comptime {
     if (builtin.link_libc and builtin.target.isMuslLibC()) {
+        @export(&__stdin_FILE, .{ .name = "__stdin_FILE", .linkage = .weak, .visibility = .hidden });
+        @export(&__stdout_FILE, .{ .name = "__stdout_FILE", .linkage = .weak, .visibility = .hidden });
+        @export(&__stderr_FILE, .{ .name = "__stderr_FILE", .linkage = .weak, .visibility = .hidden });
+        @export(&stdin, .{ .name = "stdin", .linkage = .weak });
+        @export(&stdout, .{ .name = "stdout", .linkage = .weak });
+        @export(&stderr, .{ .name = "stderr", .linkage = .weak });
+        @export(&__stdin_used, .{ .name = "__stdin_used", .linkage = .weak, .visibility = .hidden });
+        @export(&__stdout_used, .{ .name = "__stdout_used", .linkage = .weak, .visibility = .hidden });
+        @export(&__stderr_used, .{ .name = "__stderr_used", .linkage = .weak, .visibility = .hidden });
+
         symbol(&setbuf, "setbuf");
         symbol(&setbuffer, "setbuffer");
         symbol(&setlinebuf, "setlinebuf");
@@ -217,6 +286,8 @@ comptime {
         symbol(&stdio_read_impl, "__stdio_read");
         symbol(&stdio_write_impl, "__stdio_write");
         symbol(&stdout_write_impl, "__stdout_write");
+        symbol(&stdio_exit_impl, "__stdio_exit");
+        symbol(&stdio_exit_impl, "__stdio_exit_needed");
 
         symbol(&getdelim_impl, "getdelim");
 
@@ -1016,8 +1087,6 @@ fn fclose_ca_impl(f: *FILE) callconv(.c) c_int {
 
 // --- Internal helper (__fopen_rb_ca.c) ---
 
-const F_PERM: c_uint = 1;
-
 /// __fopen_rb_ca.c: FILE *__fopen_rb_ca(const char *filename, FILE *f, unsigned char *buf, size_t len)
 fn fopen_rb_ca_impl(filename: [*:0]const u8, f: *FILE, buf: [*]u8, len: usize) callconv(.c) ?*FILE {
     f.* = std.mem.zeroes(FILE);
@@ -1143,8 +1212,8 @@ fn fdopen_impl(fd: c_int, mode: [*:0]const u8) callconv(.c) ?*FILE {
 fn fflush_impl(f_raw: ?*FILE) callconv(.c) c_int {
     if (f_raw == null) {
         var r: c_int = 0;
-        if (stdout_used.*) |f| r |= fflush_impl(f);
-        if (stderr_used.*) |f| r |= fflush_impl(f);
+        if (__stdout_used) |f| r |= fflush_impl(f);
+        if (__stderr_used) |f| r |= fflush_impl(f);
 
         const head = ofl_lock_fn();
         var f = head.*;
@@ -1404,6 +1473,26 @@ fn stdout_write_impl(f: *FILE, buf: [*]const u8, len: usize) callconv(.c) usize 
         if (r != 0) f.lbf = -1;
     }
     return stdio_write_impl(f, buf, len);
+}
+
+fn closeFileForExit(f_raw: ?*FILE) void {
+    const f = f_raw orelse return;
+    _ = flock(f);
+    if (f.wpos != f.wbase) _ = f.write_fn.?(f, @ptrCast(&[0]u8{}), 0);
+    if (f.rpos != f.rend) {
+        const delta: i64 = @intCast(@as(isize, @bitCast(@intFromPtr(f.rpos.?) -% @intFromPtr(f.rend.?))));
+        _ = f.seek_fn.?(f, delta, SEEK_CUR);
+    }
+}
+
+/// __stdio_exit.c: void __stdio_exit(void)
+fn stdio_exit_impl() callconv(.c) void {
+    const head = ofl_lock_fn();
+    var f = head.*;
+    while (f) |cur| : (f = cur.next) closeFileForExit(cur);
+    closeFileForExit(__stdin_used);
+    closeFileForExit(__stdout_used);
+    closeFileForExit(__stderr_used);
 }
 
 /// vasprintf.c: int vasprintf(char **s, const char *fmt, va_list ap)
@@ -2974,8 +3063,6 @@ const free_fn = @extern(*const fn (?*anyopaque) callconv(.c) void, .{ .name = "f
 const ofl_add_fn = @extern(*const fn (*FILE) callconv(.c) ?*FILE, .{ .name = "__ofl_add" });
 const ofl_lock_fn = @extern(*const fn () callconv(.c) *?*FILE, .{ .name = "__ofl_lock" });
 const ofl_unlock_fn = @extern(*const fn () callconv(.c) void, .{ .name = "__ofl_unlock" });
-const stdout_used = @extern(*const ?*FILE, .{ .name = "__stdout_used" });
-const stderr_used = @extern(*const ?*FILE, .{ .name = "__stderr_used" });
 const randname_fn = @extern(*const fn ([*]u8) callconv(.c) [*]u8, .{ .name = "__randname" });
 const libc_ptr = @extern(*const Libc, .{ .name = "__libc" });
 const fwide_fn = @extern(*const fn (*FILE, c_int) callconv(.c) c_int, .{ .name = "fwide" });

--- a/scripts/check_musl_migration.py
+++ b/scripts/check_musl_migration.py
@@ -36,6 +36,7 @@ EXCLUDED_FILES = {
 EXCLUDED_DIRS = {"win32"}
 
 SYMBOL_RE = re.compile(r'symbol\([^)]*?"([A-Za-z_][A-Za-z0-9_]*)"')
+EXPORT_RE = re.compile(r'@export\([^)]*?\.name\s*=\s*"([A-Za-z_][A-Za-z0-9_]*)"')
 MIGRATED_RE = re.compile(
     r'^\s*//\s*"(musl/src/[^"]+\.c)"\s*,\s*//\s*migrated to\s+([^\s;]+)'
     r'(?:\s*;\s*exports:\s*([^\n]+))?'
@@ -56,6 +57,8 @@ def collect_exported_symbols() -> set[str]:
             print(f"error: cannot read {path}: {exc}", file=sys.stderr)
             continue
         for m in SYMBOL_RE.finditer(text):
+            symbols.add(m.group(1))
+        for m in EXPORT_RE.finditer(text):
             symbols.add(m.group(1))
     return symbols
 

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -709,14 +709,14 @@ const src_files = [_][]const u8{
     //"musl/src/stdio/putw.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/putwc.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/putwchar.c", // migrated to lib/c/stdio.zig
-    "musl/src/stdio/stderr.c",
-    "musl/src/stdio/stdin.c",
+    //"musl/src/stdio/stderr.c", // migrated to lib/c/stdio.zig
+    //"musl/src/stdio/stdin.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__stdio_close.c", // migrated to lib/c/stdio.zig
-    "musl/src/stdio/__stdio_exit.c",
+    //"musl/src/stdio/__stdio_exit.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__stdio_read.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__stdio_seek.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__stdio_write.c", // migrated to lib/c/stdio.zig
-    "musl/src/stdio/stdout.c",
+    //"musl/src/stdio/stdout.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__stdout_write.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/swprintf.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/swscanf.c", // migrated to lib/c/stdio.zig


### PR DESCRIPTION
Closes #309

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/309

See branch libzigc-stdio-streams on the cataggar fork for the implementation.