### PR TITLE
libzigc: migrate stdio popen to Zig

### DIFF
--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -105,6 +105,17 @@ const intscan_fn = @extern(*const fn (*FILE, c_uint, c_int, c_ulonglong) callcon
 const floatscan_fn = @extern(*const fn (*FILE, c_int, c_int) callconv(.c) c_longdouble, .{ .name = "__floatscan" });
 const mbrtowc_fn = @extern(*const fn (?*wchar_t, ?[*]const u8, usize, ?*mbstate_t) callconv(.c) usize, .{ .name = "mbrtowc" });
 const mbsinit_fn = @extern(*const fn (?*const mbstate_t) callconv(.c) c_int, .{ .name = "mbsinit" });
+const posix_spawn_file_actions_t = extern struct {
+    __pad0: [2]c_int,
+    __actions: ?*anyopaque,
+    __pad: [16]c_int,
+};
+const posix_spawn_file_actions_init_fn = @extern(*const fn (*posix_spawn_file_actions_t) callconv(.c) c_int, .{ .name = "posix_spawn_file_actions_init" });
+const posix_spawn_file_actions_addclose_fn = @extern(*const fn (*posix_spawn_file_actions_t, c_int) callconv(.c) c_int, .{ .name = "posix_spawn_file_actions_addclose" });
+const posix_spawn_file_actions_adddup2_fn = @extern(*const fn (*posix_spawn_file_actions_t, c_int, c_int) callconv(.c) c_int, .{ .name = "posix_spawn_file_actions_adddup2" });
+const posix_spawn_file_actions_destroy_fn = @extern(*const fn (*posix_spawn_file_actions_t) callconv(.c) c_int, .{ .name = "posix_spawn_file_actions_destroy" });
+const posix_spawn_fn = @extern(*const fn (*linux.pid_t, [*:0]const u8, ?*const posix_spawn_file_actions_t, ?*const anyopaque, [*:null]const ?[*:0]u8, [*:null]const ?[*:0]u8) callconv(.c) c_int, .{ .name = "posix_spawn" });
+extern "c" var __environ: [*:null]?[*:0]u8;
 
 comptime {
     if (builtin.link_libc and builtin.target.isMuslLibC()) {
@@ -254,6 +265,10 @@ comptime {
         symbol(&open_memstream_impl, "open_memstream");
         symbol(&open_wmemstream_impl, "open_wmemstream");
         symbol(&fopencookie_impl, "fopencookie");
+
+        // Pipe/process stdio (popen.c, pclose.c)
+        symbol(&popen_impl, "popen");
+        symbol(&pclose_impl, "pclose");
     }
 }
 
@@ -2866,6 +2881,92 @@ fn fopencookie_impl(cookie: ?*anyopaque, mode: [*:0]const u8, iofuncs: CookieIoF
     cf.f.close_fn = &cookieclose_impl;
 
     return ofl_add_fn(&cf.f);
+}
+
+/// popen.c: FILE *popen(const char *cmd, const char *mode)
+fn popen_impl(cmd: [*:0]const u8, mode: [*:0]const u8) callconv(.c) ?*FILE {
+    const op: usize = switch (mode[0]) {
+        'r' => 0,
+        'w' => 1,
+        else => {
+            setErrno(.INVAL);
+            return null;
+        },
+    };
+
+    var p: [2]c_int = undefined;
+    var pipe_flags = linux.O{};
+    pipe_flags.CLOEXEC = true;
+    if (c_errno(linux.pipe2(&p, pipe_flags)) != 0) return null;
+
+    const f = fdopen_impl(p[op], mode) orelse {
+        _ = linux.close(p[0]);
+        _ = linux.close(p[1]);
+        return null;
+    };
+
+    var e: c_int = @intFromEnum(linux.E.NOMEM);
+    var fa: posix_spawn_file_actions_t = undefined;
+    if (posix_spawn_file_actions_init_fn(&fa) == 0) {
+        var fail = false;
+        const head = ofl_lock_fn();
+        var l = head.*;
+        while (l) |file| : (l = file.next) {
+            if (file.pipe_pid != 0 and posix_spawn_file_actions_addclose_fn(&fa, file.fd) != 0) {
+                fail = true;
+                break;
+            }
+        }
+
+        if (!fail and posix_spawn_file_actions_adddup2_fn(&fa, p[1 - op], @intCast(1 - op)) == 0) {
+            var pid: linux.pid_t = undefined;
+            var argv = [_:null]?[*:0]u8{
+                @constCast("sh"),
+                @constCast("-c"),
+                @constCast(cmd),
+            };
+            e = posix_spawn_fn(&pid, "/bin/sh", &fa, null, @ptrCast(&argv), @ptrCast(&__environ));
+            if (e == 0) {
+                _ = posix_spawn_file_actions_destroy_fn(&fa);
+                f.pipe_pid = pid;
+                if (!hasModeFlag(mode, 'e'))
+                    _ = linux.fcntl(p[op], linux.F.SETFD, 0);
+                _ = linux.close(p[1 - op]);
+                ofl_unlock_fn();
+                return f;
+            }
+        }
+
+        ofl_unlock_fn();
+        _ = posix_spawn_file_actions_destroy_fn(&fa);
+    }
+
+    _ = fclose_impl(f);
+    _ = linux.close(p[1 - op]);
+    std.c._errno().* = e;
+    return null;
+}
+
+/// pclose.c: int pclose(FILE *f)
+fn pclose_impl(f: *FILE) callconv(.c) c_int {
+    var status: c_int = undefined;
+    const pid = f.pipe_pid;
+    _ = fclose_impl(f);
+    while (true) {
+        const r_raw = linux.wait4(pid, @ptrCast(&status), 0, null);
+        const r: isize = @bitCast(r_raw);
+        if (r == -@as(isize, @intFromEnum(linux.E.INTR))) continue;
+        if (r < 0) return c_errno(r_raw);
+        return status;
+    }
+}
+
+fn hasModeFlag(mode: [*:0]const u8, flag: u8) bool {
+    var p = mode;
+    while (p[0] != 0) : (p += 1) {
+        if (p[0] == flag) return true;
+    }
+    return false;
 }
 
 // Extern references to musl C functions that are still compiled from C sources.

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -702,9 +702,9 @@ const src_files = [_][]const u8{
     //"musl/src/stdio/open_memstream.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/open_wmemstream.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/__overflow.c", // migrated to lib/c/stdio.zig
-    "musl/src/stdio/pclose.c",
+    //"musl/src/stdio/pclose.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/perror.c", // migrated to lib/c/stdio.zig
-    "musl/src/stdio/popen.c",
+    //"musl/src/stdio/popen.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/puts.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/putw.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/putwc.c", // migrated to lib/c/stdio.zig


### PR DESCRIPTION
Closes #319

Migrates musl stdio popen and pclose from C into lib/c/stdio.zig and removes the corresponding musl C sources from the build.