### PR TITLE
libzigc: migrate internal floatscan to Zig

### DIFF
--- a/lib/c/internal.zig
+++ b/lib/c/internal.zig
@@ -652,6 +652,217 @@ var hwcap: usize = 0;
 var progname: ?[*]u8 = null;
 var progname_full: ?[*]u8 = null;
 
+const EINVAL = 22;
+const ERANGE = 34;
+
+// floatscan.c — scanner for strtod/scanf-family floating point conversion.
+fn setErrno(e: c_int) void {
+    std.c._errno().* = e;
+}
+
+fn asciiLower(ch: c_int) c_int {
+    return ch | 32;
+}
+
+fn isDigit(ch: c_int) bool {
+    return ch >= '0' and ch <= '9';
+}
+
+fn isHexDigit(ch: c_int) bool {
+    const lower = asciiLower(ch);
+    return isDigit(ch) or (lower >= 'a' and lower <= 'f');
+}
+
+fn isNanChar(ch: c_int) bool {
+    const lower = asciiLower(ch);
+    return isDigit(ch) or (lower >= 'a' and lower <= 'z') or ch == '_';
+}
+
+fn appendFloatScan(buf: *[4096]u8, len: *usize, ch: c_int) void {
+    if (len.* < buf.len) {
+        buf[len.*] = @intCast(ch);
+        len.* += 1;
+    }
+}
+
+fn popFloatScan(len: *usize) void {
+    if (len.* != 0) len.* -= 1;
+}
+
+fn invalidFloatScan(f: *FILE) c_longdouble {
+    setErrno(EINVAL);
+    shlim(f, 0);
+    return 0;
+}
+
+fn parseScannedFloat(comptime T: type, s: []const u8, saw_nonzero: bool) c_longdouble {
+    const parsed = std.fmt.parseFloat(T, s) catch {
+        setErrno(EINVAL);
+        return 0;
+    };
+    if (!std.math.isFinite(parsed)) {
+        setErrno(ERANGE);
+    } else if (parsed == 0 and saw_nonzero) {
+        setErrno(ERANGE);
+    }
+    return @floatCast(parsed);
+}
+
+fn finishScannedFloat(s: []const u8, prec: c_int, saw_nonzero: bool) c_longdouble {
+    return switch (prec) {
+        0 => parseScannedFloat(f32, s, saw_nonzero),
+        1 => parseScannedFloat(f64, s, saw_nonzero),
+        2 => parseScannedFloat(c_longdouble, s, saw_nonzero),
+        else => 0,
+    };
+}
+
+fn scanExponentSuffix(f: *FILE, buf: *[4096]u8, len: *usize, marker: c_int) void {
+    appendFloatScan(buf, len, marker);
+    var ch = shgetc(f);
+    var had_sign = false;
+    if (ch == '+' or ch == '-') {
+        had_sign = true;
+        appendFloatScan(buf, len, ch);
+        ch = shgetc(f);
+    }
+    if (!isDigit(ch)) {
+        shunget(f);
+        if (had_sign) {
+            shunget(f);
+            popFloatScan(len);
+        }
+        popFloatScan(len);
+        return;
+    }
+    while (isDigit(ch)) : (ch = shgetc(f)) appendFloatScan(buf, len, ch);
+    if (ch >= 0) shunget(f);
+}
+
+fn scanInfTail(f: *FILE, buf: *[4096]u8, len: *usize) void {
+    const tail = "inity";
+    var consumed: usize = 0;
+    for (tail) |want| {
+        const ch = shgetc(f);
+        if (asciiLower(ch) != want) {
+            if (ch >= 0) shunget(f);
+            while (consumed != 0) : (consumed -= 1) {
+                shunget(f);
+                popFloatScan(len);
+            }
+            return;
+        }
+        appendFloatScan(buf, len, ch);
+        consumed += 1;
+    }
+}
+
+fn floatscan(f: *FILE, prec: c_int, pok: c_int) callconv(.c) c_longdouble {
+    _ = pok;
+    var buf: [4096]u8 = undefined;
+    var len: usize = 0;
+    var saw_nonzero = false;
+
+    var ch = shgetc(f);
+    while (isSpace(ch)) ch = shgetc(f);
+
+    if (ch == '+' or ch == '-') {
+        appendFloatScan(&buf, &len, ch);
+        ch = shgetc(f);
+    }
+
+    if (asciiLower(ch) == 'i') {
+        appendFloatScan(&buf, &len, ch);
+        const n = shgetc(f);
+        const fch = shgetc(f);
+        if (asciiLower(n) != 'n' or asciiLower(fch) != 'f') {
+            if (fch >= 0) shunget(f);
+            if (n >= 0) shunget(f);
+            return invalidFloatScan(f);
+        }
+        appendFloatScan(&buf, &len, n);
+        appendFloatScan(&buf, &len, fch);
+        scanInfTail(f, &buf, &len);
+        return finishScannedFloat(buf[0..len], prec, true);
+    }
+
+    if (asciiLower(ch) == 'n') {
+        appendFloatScan(&buf, &len, ch);
+        const a = shgetc(f);
+        const n = shgetc(f);
+        if (asciiLower(a) != 'a' or asciiLower(n) != 'n') {
+            if (n >= 0) shunget(f);
+            if (a >= 0) shunget(f);
+            return invalidFloatScan(f);
+        }
+        appendFloatScan(&buf, &len, a);
+        appendFloatScan(&buf, &len, n);
+        ch = shgetc(f);
+        if (ch == '(') {
+            appendFloatScan(&buf, &len, ch);
+            while (true) {
+                ch = shgetc(f);
+                if (isNanChar(ch)) appendFloatScan(&buf, &len, ch) else break;
+            }
+            if (ch == ')') appendFloatScan(&buf, &len, ch) else if (ch >= 0) shunget(f);
+        } else if (ch >= 0) shunget(f);
+        return finishScannedFloat(buf[0..len], prec, true);
+    }
+
+    var gotdig = false;
+    if (ch == '0') {
+        appendFloatScan(&buf, &len, ch);
+        gotdig = true;
+        ch = shgetc(f);
+        if (asciiLower(ch) == 'x') {
+            appendFloatScan(&buf, &len, ch);
+            var gothex = false;
+            ch = shgetc(f);
+            while (isHexDigit(ch)) : (ch = shgetc(f)) {
+                gothex = true;
+                if (ch != '0') saw_nonzero = true;
+                appendFloatScan(&buf, &len, ch);
+            }
+            if (ch == '.') {
+                appendFloatScan(&buf, &len, ch);
+                ch = shgetc(f);
+                while (isHexDigit(ch)) : (ch = shgetc(f)) {
+                    gothex = true;
+                    if (ch != '0') saw_nonzero = true;
+                    appendFloatScan(&buf, &len, ch);
+                }
+            }
+            if (!gothex) {
+                if (ch >= 0) shunget(f);
+                shunget(f);
+                popFloatScan(&len);
+                return finishScannedFloat(buf[0..len], prec, false);
+            }
+            if (asciiLower(ch) == 'p') scanExponentSuffix(f, &buf, &len, ch) else if (ch >= 0) shunget(f);
+            return finishScannedFloat(buf[0..len], prec, saw_nonzero);
+        }
+    }
+
+    while (isDigit(ch)) : (ch = shgetc(f)) {
+        gotdig = true;
+        if (ch != '0') saw_nonzero = true;
+        appendFloatScan(&buf, &len, ch);
+    }
+    if (ch == '.') {
+        appendFloatScan(&buf, &len, ch);
+        ch = shgetc(f);
+        while (isDigit(ch)) : (ch = shgetc(f)) {
+            gotdig = true;
+            if (ch != '0') saw_nonzero = true;
+            appendFloatScan(&buf, &len, ch);
+        }
+    }
+
+    if (!gotdig) return invalidFloatScan(f);
+    if (asciiLower(ch) == 'e') scanExponentSuffix(f, &buf, &len, ch) else if (ch >= 0) shunget(f);
+    return finishScannedFloat(buf[0..len], prec, saw_nonzero);
+}
+
 // emulate_wait4.c — wait4 emulation via SYS_waitid for arches lacking
 // SYS_wait4 (currently riscv32, loongarch32). Mirrors musl's
 // `#ifndef SYS_wait4` gate and reproduces the kernel-ABI status word that
@@ -713,6 +924,7 @@ comptime {
         c.symbol(&shlim, "__shlim");
         c.symbol(&shgetcSlow, "__shgetc");
         c.symbol(&intscan, "__intscan");
+        c.symbol(&floatscan, "__floatscan");
 
         // Export __emulate_wait4 only on arches where musl needs it (i.e. those
         // lacking SYS_wait4). On other arches musl's `__sys_wait4` macro inlines

--- a/lib/c/internal.zig
+++ b/lib/c/internal.zig
@@ -708,11 +708,18 @@ fn parseScannedFloat(comptime T: type, s: []const u8, saw_nonzero: bool) c_longd
     return @floatCast(parsed);
 }
 
+const longdouble_float: type = switch (@bitSizeOf(c_longdouble)) {
+    64 => f64,
+    80 => f80,
+    128 => f128,
+    else => @compileError("unsupported c_longdouble bit size"),
+};
+
 fn finishScannedFloat(s: []const u8, prec: c_int, saw_nonzero: bool) c_longdouble {
     return switch (prec) {
         0 => parseScannedFloat(f32, s, saw_nonzero),
         1 => parseScannedFloat(f64, s, saw_nonzero),
-        2 => parseScannedFloat(c_longdouble, s, saw_nonzero),
+        2 => parseScannedFloat(longdouble_float, s, saw_nonzero),
         else => 0,
     };
 }

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -472,7 +472,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/x32/fenv.s",
     "musl/src/fenv/x86_64/fenv.s",
     //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig; exports: __emulate_wait4
-    "musl/src/internal/floatscan.c",
+    //"musl/src/internal/floatscan.c", // migrated to lib/c/internal.zig; exports: __floatscan
     "musl/src/internal/i386/defsysinfo.s",
     //"musl/src/internal/intscan.c", // migrated to lib/c/internal.zig; exports: __intscan
     //"musl/src/internal/shgetc.c", // migrated to lib/c/internal.zig; exports: __shlim, __shgetc


### PR DESCRIPTION
Closes #325

Migrates the musl internal floating-point scanner entry point to lib/c/internal.zig and removes the C source from the musl build list.