### PR TITLE
libzigc: migrate network IPv6 address constants

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -253,7 +253,7 @@ comptime {
         symbol(&ntohl_impl, "ntohl");
         symbol(&ntohs_impl, "ntohs");
 
-        // in6addr_any.c / in6addr_loopback.c
+        // IPv6 address constants: in6addr_any.c / in6addr_loopback.c
         symbol(&in6addr_any, "in6addr_any");
         symbol(&in6addr_loopback, "in6addr_loopback");
 


### PR DESCRIPTION
Closes #343

Keeps the migrated in6addr_any/in6addr_loopback exports in lib/c/network.zig and documents the IPv6 address constant migration.