### PR TITLE
libzigc: libzigc: migrate fenv loongarch64-sf, s390x from C to Zig

### DIFF
--- a/lib/c/fenv.zig
+++ b/lib/c/fenv.zig
@@ -163,6 +163,14 @@ comptime {
             symbol(&powerpc___fesetround, "__fesetround");
             symbol(&powerpc_fegetenv, "fegetenv");
             symbol(&powerpc_fesetenv, "fesetenv");
+        } else if (builtin.cpu.arch == .s390x) {
+            symbol(&s390x_feclearexcept, "feclearexcept");
+            symbol(&s390x_feraiseexcept, "feraiseexcept");
+            symbol(&s390x_fetestexcept, "fetestexcept");
+            symbol(&s390x_fegetround, "fegetround");
+            symbol(&s390x___fesetround, "__fesetround");
+            symbol(&s390x_fegetenv, "fegetenv");
+            symbol(&s390x_fesetenv, "fesetenv");
         } else {
             // Weak generic fallbacks (from fenv.c).
             // Overridden by arch-specific implementations at link time.
@@ -189,6 +197,59 @@ const POWERPC_FE_INVALID: u64 = 0x20000000;
 const POWERPC_FE_ALL_INVALID: u64 = 0x01f80700;
 const POWERPC_FE_INVALID_SOFTWARE: u64 = 0x00000400;
 const POWERPC_FE_DFL_ENV = @as(usize, std.math.maxInt(usize));
+const S390X_FE_DFL_ENV = @as(usize, std.math.maxInt(usize));
+
+fn s390x_get_fpc() c_uint {
+    return asm volatile ("efpc %[fpc]"
+        : [fpc] "=r" (-> c_uint),
+    );
+}
+
+fn s390x_set_fpc(fpc: c_uint) void {
+    asm volatile ("sfpc %[fpc]"
+        :
+        : [fpc] "r" (fpc),
+    );
+}
+
+fn s390x_feclearexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & @as(c_uint, @intCast(FE_ALL_EXCEPT));
+    s390x_set_fpc(s390x_get_fpc() & ~exceptions);
+    return 0;
+}
+
+fn s390x_feraiseexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & @as(c_uint, @intCast(FE_ALL_EXCEPT));
+    s390x_set_fpc(s390x_get_fpc() | exceptions);
+    return 0;
+}
+
+fn s390x_fetestexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & @as(c_uint, @intCast(FE_ALL_EXCEPT));
+    return @intCast(s390x_get_fpc() & exceptions);
+}
+
+fn s390x_fegetround() callconv(.c) c_int {
+    return @intCast(s390x_get_fpc() & 3);
+}
+
+fn s390x___fesetround(r: c_int) callconv(.c) c_int {
+    var fpc = s390x_get_fpc();
+    fpc &= ~@as(c_uint, 3);
+    fpc |= @as(c_uint, @bitCast(r)) & 3;
+    s390x_set_fpc(fpc);
+    return 0;
+}
+
+fn s390x_fegetenv(envp: *c_uint) callconv(.c) c_int {
+    envp.* = s390x_get_fpc();
+    return 0;
+}
+
+fn s390x_fesetenv(envp: *const c_uint) callconv(.c) c_int {
+    s390x_set_fpc(if (@intFromPtr(envp) != S390X_FE_DFL_ENV) envp.* else 0);
+    return 0;
+}
 
 fn powerpc_get_fpscr_f() f64 {
     var fpscr: f64 = undefined;

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -453,7 +453,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/hexagon/fenv.S",
     "musl/src/fenv/i386/fenv.s",
     "musl/src/fenv/loongarch64/fenv.S",
-    "musl/src/fenv/loongarch64/fenv-sf.c",
+    //"musl/src/fenv/loongarch64/fenv-sf.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/m68k/fenv.c",
     "musl/src/fenv/mips64/fenv.S",
     //"musl/src/fenv/mips64/fenv-sf.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
@@ -468,7 +468,7 @@ const src_files = [_][]const u8{
     //"musl/src/fenv/riscv32/fenv-sf.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/riscv64/fenv.S",
     //"musl/src/fenv/riscv64/fenv-sf.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
-    "musl/src/fenv/s390x/fenv.c",
+    //"musl/src/fenv/s390x/fenv.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/x32/fenv.s",
     "musl/src/fenv/x86_64/fenv.s",
     //"musl/src/internal/emulate_wait4.c", // migrated to lib/c/internal.zig; exports: __emulate_wait4


### PR DESCRIPTION
Closes #359

Auto-opened by driver after the autopilot session declared DONE without creating a PR.

Issue: ctaggart/zig/issues/359

See branch libzigc-fenv-loongarch-s390x on the cataggar fork for the implementation.