### PR TITLE
libzigc: fix pthread_mutex_trylock returning negative on waiters bit (#429)

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -2438,7 +2438,13 @@ fn mutex_trylock_owner_fn(m: *anyopaque) callconv(.c) c_int {
 fn mutex_trylock_fn(m: *anyopaque) callconv(.c) c_int {
     const m_i: [*]c_int = @ptrCast(@alignCast(m));
     if ((m_i[0] & 15) == 0) { // PTHREAD_MUTEX_NORMAL
-        return @cmpxchgStrong(c_int, &m_i[1], 0, eint(.BUSY), .seq_cst, .seq_cst) orelse 0;
+        // musl: `return (a_cas(&m->_m_lock, 0, EBUSY) & 0x7fffffff) ? EBUSY : 0;`
+        // The waiters bit (0x80000000) must be masked off before deciding;
+        // otherwise a contended-with-waiters mutex returns a negative c_int
+        // here, which propagates through pthread_mutex_(timed)lock and causes
+        // libc++ to throw `system_error("mutex lock failed: ...")`.
+        const old = @cmpxchgStrong(c_int, &m_i[1], 0, eint(.BUSY), .seq_cst, .seq_cst) orelse return 0;
+        return if ((old & 0x7fffffff) != 0) eint(.BUSY) else 0;
     }
     return mutex_trylock_owner_fn(m);
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent libc++ `std::system_error("mutex lock failed: No error information")` / `condition_variable wait failed` / `__cxa_guard_acquire failed to acquire mutex` crashes at stage4 startup tracked in #429.

## Root cause

`mutex_trylock_fn` in `lib/c/thread.zig` was returning the raw cmpxchg-failure value when the mutex was already held. When a contender had already set the "has-waiters" high bit (`0x80000000`) on the lock word, the resulting value (e.g. `tid | 0x80000000`) was a negative `c_int`. That negative value propagated through:

```
mutex_trylock_fn  →  mutex_timedlock_fn  →  pthread_mutex_(timed)lock  →  std::__1::mutex::lock
```

`std::__1::mutex::lock` checks the return code and throws `std::system_error` on non-zero, with the errno-style suffix from `strerror`. With a negative value out of `errmsg[]` range, `strerror` returns `"No error information"` — the exact message we were seeing.

The bug only manifests under contention (it requires another thread to have entered the slow path of `mutex_timedlock_fn` and set the waiters bit), which matches the LLVM `ThreadPoolExecutor` racing N worker threads against the main thread on the same static `Lock`.

## Fix

Match musl's `pthread_mutex_trylock.c` exactly:

```c
return (a_cas(&m->_m_lock, 0, EBUSY) & 0x7fffffff) ? EBUSY : 0;
```

The `& 0x7fffffff` masks off the waiters bit before deciding the return value, so we only ever return `0` (acquired) or `EBUSY`, never a negative number.

## Verification

aarch64-linux Azure VM, cold-cache `build-exe` loop on a trivial `pub fn main() void {}`:

| stage4                               | crashes |
|--------------------------------------|---------|
| **baseline** (origin/libc/0.16.x)    | **7 / 30**  (~23%) |
| **with this fix**                    | **0 / 100** (0%)   |

The crash signatures observed on the baseline match #429 verbatim:
- `libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: No error information`
- `libc++abi: terminating due to uncaught exception of type std::__1::system_error: condition_variable wait failed: No error information`

A gdb backtrace from a coredump confirmed the failing thread chain:
```
__throw_system_error
  std::__1::mutex::lock                     (libcxx/src/mutex.cpp:32)
   std::__1::unique_lock<std::__1::mutex>::unique_lock
    llvm::ThreadPoolExecutor::work          (llvm/lib/Support/Parallel.cpp:115)
```

## Notes

- This affects only the migrated `pthread_mutex_trylock` (and its callers via `mutex_timedlock_fn`). Other paths (`mutex_lock_fn` fast path, `mutex_timedlock_fn` fast path) already discard the cmpxchg result correctly via `== null`.
- Fixes #429 — should unblock Step 2 (`pr-libc-test` as a required gate) of the staged-promotion ladder in #454.