### PR TITLE
libzigc: fix arch-specific compile errors; add cross-compile PR gate

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,6 +11,12 @@ name: pr-build
 #     This is the gate that prevents broken-code merges.
 #   - pr-libc-test (advisory): runs libc-test on the stage4 produced by
 #     pr-build. Will be promoted to required once #429 is fixed.
+#   - pr-cross-compile (advisory, fan-out matrix): cross-compiles a tiny
+#     hello.c against libzigc + musl libc.a for every target in the
+#     post-merge QEMU matrix. Catches arch-specific libzigc compile errors
+#     (missing syscall fields, unsupported ABI prongs, signed/unsigned
+#     mismatches) in seconds without paying for QEMU. Promote to required
+#     once stable.
 #
 # Trust model: this workflow runs PR-controlled code on a persistent
 # self-hosted runner. The `if:` guard on the build job restricts execution
@@ -323,3 +329,78 @@ jobs:
               -Dtest-filter="" \
               -j2 \
               --summary failures
+
+  cross-compile:
+    # Cross-compile a tiny program against libzigc + musl libc.a for every
+    # target in the post-merge QEMU matrix. This catches arch-specific
+    # compile errors in libzigc / lib/std (e.g. missing `linux.O.SYNC` on
+    # s390x, missing `linux.SYS.ppoll` on RiscV32, "unsupported ABI" in
+    # `pthread_mutex_t`) in seconds without paying for a full QEMU run.
+    # Promote to required via branch protection once stable.
+    name: pr-cross-compile (${{ matrix.target }})
+    needs: [trust-check, build]
+    if: needs.trust-check.outputs.trusted == 'true'
+    runs-on: [self-hosted, Linux, ARM64, nvme]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86-linux-musl
+          - x86_64-linux-musl
+          - arm-linux-musleabi
+          - arm-linux-musleabihf
+          - armeb-linux-musleabi
+          - armeb-linux-musleabihf
+          - thumb-linux-musleabihf
+          - thumbeb-linux-musleabihf
+          - riscv32-linux-musl
+          - riscv64-linux-musl
+          - powerpc-linux-musl
+          - powerpc64-linux-musl
+          - powerpc64le-linux-musl
+          - s390x-linux-musl
+          - loongarch64-linux-musl
+          - loongarch64-linux-muslsf
+          - wasm32-wasi-musl
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare cache root
+        run: mkdir -p "$CACHE_ROOT"
+
+      - name: Locate stage4 from build job (key=${{ needs.build.outputs.stage4_key }})
+        run: |
+          set -euo pipefail
+          STAGE4="$CACHE_ROOT/stage4-${{ needs.build.outputs.stage4_key }}"
+          if [ ! -x "$STAGE4/bin/zig" ]; then
+              echo "ERROR: stage4 not found at $STAGE4 (build job should have produced it)" >&2
+              exit 1
+          fi
+          "$STAGE4/bin/zig" version
+          echo "STAGE4=$STAGE4" >> "$GITHUB_ENV"
+
+      - name: Cross-compile hello (${{ matrix.target }})
+        run: |
+          set -euo pipefail
+          if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
+          if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+          # Tiny Zig program that calls into libc — forces sub-compilation of
+          # musl libc.a + libzigc.a + crt for the target. We don't run the
+          # binary; we only verify it links.
+          cat > "$tmpdir/hello.zig" <<'EOF'
+          const std = @import("std");
+          extern fn puts(s: [*:0]const u8) c_int;
+          pub fn main() void {
+              _ = puts("hello");
+          }
+          EOF
+          "$STAGE4/bin/zig" build-exe \
+              --zig-lib-dir lib \
+              -target ${{ matrix.target }} \
+              -mcpu baseline \
+              -lc \
+              -femit-bin="$tmpdir/hello" \
+              "$tmpdir/hello.zig"

--- a/lib/c/aio.zig
+++ b/lib/c/aio.zig
@@ -10,8 +10,14 @@ const linux = std.os.linux;
 const c_lib = @import("../c.zig");
 
 /// O_SYNC and O_DSYNC as integer constants for the C ABI.
+/// On most archs we derive these from `linux.O`; on archs whose `O` does not
+/// expose a `SYNC` field (s390x, hexagon, or1k) we fall back to the POSIX
+/// numeric value (`O_SYNC = 04010000` per musl `bits/fcntl.h`).
 const O_DSYNC: c_int = @bitCast(@as(linux.O, .{ .DSYNC = true }));
-const O_SYNC: c_int = @bitCast(@as(linux.O, .{ .SYNC = true, .DSYNC = true }));
+const O_SYNC: c_int = if (@hasField(linux.O, "SYNC"))
+    @bitCast(@as(linux.O, .{ .SYNC = true, .DSYNC = true }))
+else
+    0o4010000;
 
 /// Wrapper for pthread_sigmask that discards the old mask (passes a dummy instead of null).
 fn sigmaskRestore(origmask: *const std.c.sigset_t) void {

--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -388,7 +388,8 @@ fn __init_libc_fn(envp: [*:null]?[*:0]u8, pn: ?[*:0]u8) callconv(.c) void {
     if (aux[AT_UID] == aux[AT_EUID] and aux[AT_GID] == aux[AT_EGID] and aux[AT_SECURE] == 0) return;
 
     // Check for closed stdin/stdout/stderr and open /dev/null if needed.
-    const SYS_ppoll = linux.SYS.ppoll;
+    // RiscV32 (and a few other 32-bit archs) lack the legacy ppoll syscall and use ppoll_time64.
+    const SYS_ppoll: linux.SYS = if (@hasField(linux.SYS, "ppoll") and builtin.cpu.arch != .hexagon) .ppoll else .ppoll_time64;
     var pfd: [3]extern struct { fd: c_int, events: c_short, revents: c_short } = .{
         .{ .fd = 0, .events = 0, .revents = 0 },
         .{ .fd = 1, .events = 0, .revents = 0 },

--- a/lib/c/linux.zig
+++ b/lib/c/linux.zig
@@ -700,7 +700,7 @@ fn settimeofdayLinux(tv: ?*const linux.timeval, _: ?*const anyopaque) callconv(.
 }
 
 fn stimeLinux(t: *const linux.time_t) callconv(.c) c_int {
-    const tv = linux.timeval{ .sec = t.*, .usec = 0 };
+    const tv = linux.timeval{ .sec = @intCast(t.*), .usec = 0 };
     return settimeofdayLinux(&tv, null);
 }
 

--- a/lib/c/stat.zig
+++ b/lib/c/stat.zig
@@ -257,7 +257,7 @@ fn fstatatImpl(fd: c_int, path: [*:0]const u8, buf: *anyopaque, flag: c_int) cal
         st.ctim32 = .{ .sec = @truncate(stx.ctime.sec), .nsec = @intCast(stx.ctime.nsec) };
     }
     if (@hasField(MuStat, "ino_truncated")) {
-        st.ino_truncated = @truncate(stx.ino);
+        st.ino_truncated = @bitCast(@as(u32, @truncate(stx.ino)));
     }
     return 0;
 }

--- a/lib/c/time.zig
+++ b/lib/c/time.zig
@@ -146,7 +146,7 @@ fn gettimeofdayLinux(tv: ?*linux.timeval, _: ?*anyopaque) callconv(.c) c_int {
     const t = tv orelse return 0;
     var ts: linux.timespec = undefined;
     _ = linux.clock_gettime(.REALTIME, &ts);
-    t.sec = ts.sec;
+    t.sec = @intCast(ts.sec);
     t.usec = @intCast(@divTrunc(ts.nsec, 1000));
     return 0;
 }
@@ -1412,7 +1412,8 @@ fn timer_createLinux(clk: c_int, evp: ?*sigevent, res: **opaque {}) callconv(.c)
 }
 
 fn is32Bit(x: linux.time_t) bool {
-    return ((x +% 0x80000000) >> 32) == 0;
+    if (@sizeOf(linux.time_t) <= 4) return true;
+    return ((x +% @as(i64, 0x80000000)) >> 32) == 0;
 }
 
 // timer_settime.c

--- a/lib/c/unistd.zig
+++ b/lib/c/unistd.zig
@@ -271,7 +271,21 @@ fn pipe2Linux(fd: *[2]c_int, flags: c_int) callconv(.c) c_int {
 }
 
 fn lseekLinux(fd: c_int, offset: linux.off_t, whence: c_int) callconv(.c) linux.off_t {
-    const signed: isize = @bitCast(linux.lseek(fd, offset, @intCast(@as(c_uint, @bitCast(whence)))));
+    const w: usize = @intCast(@as(c_uint, @bitCast(whence)));
+    const signed: i64 = signed: {
+        if (@sizeOf(usize) >= 8) {
+            // 64-bit: kernel `lseek` syscall takes a 64-bit offset directly
+            // and returns the new position (or a negative errno) in a single
+            // register.
+            break :signed @as(isize, @bitCast(linux.lseek(fd, offset, w)));
+        }
+        // 32-bit: kernel only has `_llseek` which takes a hi/lo offset pair
+        // and writes the new file position to a result pointer.
+        var result_off: u64 = 0;
+        const r: isize = @bitCast(linux.llseek(fd, @bitCast(@as(i64, offset)), &result_off, w));
+        if (r < 0) break :signed r;
+        break :signed @bitCast(result_off);
+    };
     if (signed < 0) {
         @branchHint(.unlikely);
         std.c._errno().* = @intCast(-signed);

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -7916,7 +7916,7 @@ pub const pthread_mutex_t = switch (native_os) {
         data: [data_len]u8 align(@alignOf(usize)) = [_]u8{0} ** data_len,
 
         const data_len = switch (native_abi) {
-            .musl, .musleabi, .musleabihf, .muslabin32, .muslx32 => if (@sizeOf(usize) == 8) 40 else 24,
+            .musl, .musleabi, .musleabihf, .muslabin32, .muslabi64, .muslf32, .muslsf, .muslx32 => if (@sizeOf(usize) == 8) 40 else 24,
             .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => switch (native_arch) {
                 .aarch64 => 48,
                 .x86_64 => if (native_abi == .gnux32) 32 else 40,


### PR DESCRIPTION
Fixes pre-existing compile errors that have kept the `libc/0.16.x` post-merge QEMU matrix red for many runs because `pr-build` only cross-compiles for aarch64 today and lets these slip through.

## Code fixes

| File | Bug |
|---|---|
| `lib/c/stat.zig` | `ino_truncated` is signed (i32); `@truncate(stx.ino)` to signed type rejected. Truncate to u32 first then `@bitCast`. |
| `lib/c/env.zig` | RiscV32 lacks `linux.SYS.ppoll`; mirror std-lib's `@hasField` guard with `ppoll_time64` fallback. |
| `lib/c/aio.zig` | `linux.O` on s390x/hexagon/or1k has no `SYNC` field; guard with `@hasField`, fall back to `0o4010000`. |
| `lib/std/c.zig` | `pthread_mutex_t.data_len` musl prong was missing `.muslsf`, `.muslabi64`, `.muslf32` — hit `unsupported ABI` on loongarch64-sf etc. |
| `lib/c/time.zig` (`is32Bit`) | `x +% 0x80000000` overflowed signed type when `time_t = i32` (x86). Short-circuit on 32-bit time_t. |
| `lib/c/time.zig` + `lib/c/linux.zig` | `timespec.sec` is i64 on riscv32 (`kernel_timespec`) but `timeval.sec` is i32 (isize); add `@intCast`. |
| `lib/c/unistd.zig` (`lseekLinux`) | `linux.lseek` is 64-bit-only; route 32-bit archs through `linux.llseek` and use i64 throughout so >2 GiB offsets survive. |

## CI gate

New `pr-cross-compile` matrix job in `.github/workflows/pr-build.yml` — cross-compiles a tiny libc-linked Zig program against libzigc + musl libc.a for every target in the post-merge QEMU matrix (no QEMU run, no libc-test). Surfaces all of the bugs above in seconds. **Advisory for now**; promote to required via branch protection once stable.

## Verification

Cross-compiled locally with stage4 for x86, s390x, arm, riscv32, riscv64, loongarch64-sf — all libzigc/std compile cleanly post-fix.

Remaining post-merge red after this lands:
* `wasm32-wasi-musl`: `vfprintf.o: undefined symbol: wctomb` — fixed by in-flight #466.
* riscv64/loongarch64 `fenv.S` clang `posix_spawn failed` — runner-side flake under high parallelism, will file separately.
* wasm32-wasi-musl ubsan signature mismatch — separate libzigc/ubsan ABI bug, will file separately.