### PR TITLE
Revert #458: env __init_tls migration broke TLS layout on TLS_ABOVE_TP archs

### DIFF
--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -1,7 +1,6 @@
 const builtin = @import("builtin");
 var environ_var: ?[*:null]?[*:0]u8 = null;
 const std = @import("std");
-const elf = std.elf;
 const linux = std.os.linux;
 const symbol = @import("../c.zig").symbol;
 // C library dependencies.
@@ -28,103 +27,8 @@ const tls_module = extern struct {
     @"align": usize,
     offset: usize,
 };
-
-const LocaleStruct = extern struct {
-    cat: [6]?*const anyopaque,
-};
-
-const RobustList = extern struct {
-    head: ?*volatile anyopaque,
-    off: c_long,
-    pending: ?*volatile anyopaque,
-};
-
-const PThread = extern struct {
-    self: ?*PThread,
-    dtv_or_prev: ?[*]usize,
-    prev_or_next: ?*PThread,
-    next_or_sysinfo: usize,
-    sysinfo_or_canary: usize,
-    canary: usize,
-    tid: c_int,
-    errno_val: c_int,
-    detach_state: c_int,
-    cancel: c_int,
-    canceldisable: u8,
-    cancelasync: u8,
-    tsd_flags: u8,
-    map_base: ?[*]u8,
-    map_size: usize,
-    stack: ?*anyopaque,
-    stack_size: usize,
-    guard_size: usize,
-    result: ?*anyopaque,
-    cancelbuf: ?*anyopaque,
-    tsd: ?[*]?*anyopaque,
-    robust_list: RobustList,
-    h_errno_val: c_int,
-    timer_id: c_int,
-    locale: ?*LocaleStruct,
-    killlock: [1]c_int,
-    dlerror_buf: ?[*]u8,
-    stdio_locks: ?*anyopaque,
-    tls_above_canary: usize,
-    tls_above_dtv: ?[*]usize,
-
-    fn dtvPtr(td: *PThread) *?[*]usize {
-        return if (TLS_ABOVE_TP) &td.tls_above_dtv else &td.dtv_or_prev;
-    }
-
-    fn prevPtr(td: *PThread) *?*PThread {
-        return if (TLS_ABOVE_TP) @ptrCast(&td.dtv_or_prev) else @ptrCast(&td.prev_or_next);
-    }
-
-    fn nextPtr(td: *PThread) *?*PThread {
-        return if (TLS_ABOVE_TP) @ptrCast(&td.prev_or_next) else @ptrCast(&td.next_or_sysinfo);
-    }
-
-    fn sysinfoPtr(td: *PThread) *usize {
-        return if (TLS_ABOVE_TP) &td.next_or_sysinfo else &td.sysinfo_or_canary;
-    }
-};
-
-const BuiltinTls = extern struct {
-    c: u8,
-    pt: PThread,
-    space: [16]?*anyopaque,
-};
-
-const MIN_TLS_ALIGN = @offsetOf(BuiltinTls, "pt");
-const TP_OFFSET: usize = if (builtin.cpu.arch.isMIPS() or builtin.cpu.arch.isPowerPC() or builtin.cpu.arch == .m68k) 0x7000 else 0;
-const GAP_ABOVE_TP: usize = switch (builtin.cpu.arch) {
-    .aarch64, .aarch64_be => 16,
-    .arm, .armeb, .thumb, .thumbeb => 8,
-    else => 0,
-};
-const TLS_ABOVE_TP = switch (builtin.cpu.arch) {
-    .aarch64,
-    .aarch64_be,
-    .arm,
-    .armeb,
-    .thumb,
-    .thumbeb,
-    .loongarch64,
-    .m68k,
-    .mips,
-    .mipsel,
-    .mips64,
-    .mips64el,
-    .powerpc,
-    .powerpc64,
-    .powerpc64le,
-    .riscv32,
-    .riscv64,
-    => true,
-    else => false,
-};
-var builtin_tls: [1]BuiltinTls = undefined;
-var main_tls: tls_module = undefined;
-// Partial __libc struct — fields through global_locale.
+// Partial __libc struct — only the fields we access.
+// After page_size, there's global_locale which we don't touch.
 const LibC = extern struct {
     can_do_threads: u8,
     threaded: u8,
@@ -137,23 +41,11 @@ const LibC = extern struct {
     tls_align: usize,
     tls_cnt: usize,
     page_size: usize,
-    global_locale: LocaleStruct,
 };
 extern "c" fn __set_thread_area(tp: *anyopaque) c_int;
 extern "c" fn memset(dst: *anyopaque, c: c_int, n: usize) *anyopaque;
-fn a_crash() noreturn {
-    @trap();
-}
 extern "c" fn _init() void;
 extern "c" fn exit(code: c_int) noreturn;
-fn get_DYNAMIC() ?[*]const usize {
-    return @extern([*]const usize, .{
-        .name = "_DYNAMIC",
-        .linkage = .weak,
-        .visibility = .hidden,
-    });
-}
-
 const AT_PHDR = 3;
 const AT_PHENT = 4;
 const AT_PHNUM = 5;
@@ -192,123 +84,6 @@ else
 // On aarch64 (TLS_ABOVE_TP): dtv is at end of struct after canary.
 const DTV_OFFSET: usize = @sizeOf(usize); // offset of dtv in struct pthread (after self ptr)
 
-fn __init_tp_fn(p: *anyopaque) callconv(.c) c_int {
-    const td: *PThread = @ptrCast(@alignCast(p));
-    td.self = td;
-    const tp = if (TLS_ABOVE_TP) @as(*anyopaque, @ptrFromInt(@intFromPtr(p) + @sizeOf(PThread) + TP_OFFSET)) else p;
-    const r = __set_thread_area(tp);
-    if (r < 0) return -1;
-    if (r == 0) __libc.can_do_threads = 1;
-    td.detach_state = 2; // DT_JOINABLE
-    td.tid = @bitCast(@as(u32, @truncate(linux.syscall1(.set_tid_address, @intFromPtr(&__thread_list_lock)))));
-    td.locale = &__libc.global_locale;
-    td.robust_list.head = @ptrCast(&td.robust_list.head);
-    td.sysinfoPtr().* = __sysinfo;
-    td.nextPtr().* = td;
-    td.prevPtr().* = td;
-    return 0;
-}
-
-fn __copy_tls_fn(mem_arg: [*]u8) callconv(.c) *anyopaque {
-    var mem = mem_arg;
-    var td: *PThread = undefined;
-    var dtv: [*]usize = undefined;
-
-    if (TLS_ABOVE_TP) {
-        dtv = @ptrCast(@alignCast(mem + __libc.tls_size - (@sizeOf(usize) * (__libc.tls_cnt + 1))));
-
-        mem += (0 -% (@intFromPtr(mem) + @sizeOf(PThread))) & (__libc.tls_align - 1);
-        td = @ptrCast(@alignCast(mem));
-        mem += @sizeOf(PThread);
-
-        var i: usize = 1;
-        var p = __libc.tls_head;
-        while (p) |mod| : ({
-            i += 1;
-            p = mod.next;
-        }) {
-            dtv[i] = @intFromPtr(mem + mod.offset) + DTP_OFFSET;
-            _ = memcpy(mem + mod.offset, mod.image orelse continue, mod.len);
-        }
-    } else {
-        dtv = @ptrCast(@alignCast(mem));
-
-        mem += __libc.tls_size - @sizeOf(PThread);
-        mem -= @intFromPtr(mem) & (__libc.tls_align - 1);
-        td = @ptrCast(@alignCast(mem));
-
-        var i: usize = 1;
-        var p = __libc.tls_head;
-        while (p) |mod| : ({
-            i += 1;
-            p = mod.next;
-        }) {
-            dtv[i] = @intFromPtr(mem - mod.offset) + DTP_OFFSET;
-            _ = memcpy(mem - mod.offset, mod.image orelse continue, mod.len);
-        }
-    }
-
-    dtv[0] = __libc.tls_cnt;
-    td.dtvPtr().* = dtv;
-    return td;
-}
-
-fn __init_tls_fn(aux: [*]usize) callconv(.c) void {
-    var tls_phdr: ?*elf.Phdr = null;
-    var base: usize = 0;
-
-    var p: [*]u8 = @ptrFromInt(aux[AT_PHDR]);
-    var n = aux[AT_PHNUM];
-    while (n != 0) : ({
-        n -= 1;
-        p += aux[AT_PHENT];
-    }) {
-        const phdr: *elf.Phdr = @ptrCast(@alignCast(p));
-        switch (phdr.p_type) {
-            elf.PT_PHDR => base = aux[AT_PHDR] - phdr.p_vaddr,
-            elf.PT_DYNAMIC => if (get_DYNAMIC()) |dyn| {
-                base = @intFromPtr(dyn) - phdr.p_vaddr;
-            },
-            elf.PT_TLS => tls_phdr = phdr,
-            PT_GNU_STACK => if (phdr.p_memsz > __default_stacksize) {
-                __default_stacksize = if (phdr.p_memsz < DEFAULT_STACK_MAX) @intCast(phdr.p_memsz) else DEFAULT_STACK_MAX;
-            },
-            else => {},
-        }
-    }
-
-    if (tls_phdr) |phdr| {
-        main_tls.image = @ptrFromInt(base + phdr.p_vaddr);
-        main_tls.len = phdr.p_filesz;
-        main_tls.size = phdr.p_memsz;
-        main_tls.@"align" = phdr.p_align;
-        __libc.tls_cnt = 1;
-        __libc.tls_head = &main_tls;
-    }
-
-    const image_addr = @intFromPtr(main_tls.image);
-    main_tls.size += (0 -% main_tls.size -% image_addr) & (main_tls.@"align" - 1);
-    if (TLS_ABOVE_TP) {
-        main_tls.offset = GAP_ABOVE_TP;
-        main_tls.offset += (0 -% GAP_ABOVE_TP +% image_addr) & (main_tls.@"align" - 1);
-    } else {
-        main_tls.offset = main_tls.size;
-    }
-    if (main_tls.@"align" < MIN_TLS_ALIGN) main_tls.@"align" = MIN_TLS_ALIGN;
-
-    __libc.tls_align = main_tls.@"align";
-    __libc.tls_size = (2 * @sizeOf(?*anyopaque) + @sizeOf(PThread) +
-        (if (TLS_ABOVE_TP) main_tls.offset else 0) + main_tls.size + main_tls.@"align" +
-        MIN_TLS_ALIGN - 1) & (@as(usize, 0) -% MIN_TLS_ALIGN);
-
-    const mem: [*]u8 = if (__libc.tls_size > @sizeOf(@TypeOf(builtin_tls)))
-        @ptrFromInt(linux.mmap(null, __libc.tls_size, .{ .READ = true, .WRITE = true }, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0))
-    else
-        @ptrCast(&builtin_tls);
-
-    if (__init_tp_fn(__copy_tls_fn(mem)) < 0) a_crash();
-}
-
 fn __reset_tls_fn() callconv(.c) void {
     const tp = get_tp();
     // On non-TLS_ABOVE_TP (x86_64), pthread_self = tp, dtv at offset 8.
@@ -343,7 +118,7 @@ extern var __progname: ?[*:0]u8;
 extern var __progname_full: ?[*:0]u8;
 extern "c" fn __libc_start_init() void;
 extern var __default_stacksize: c_uint;
-var __thread_list_lock: c_int = 0;
+extern var __thread_list_lock: c_int;
 extern "c" fn __init_tls(aux: [*]usize) void;
 
 comptime {
@@ -356,10 +131,6 @@ comptime {
         symbol(&__init_ssp, "__init_ssp");
         symbol(&__stack_chk_fail, "__stack_chk_fail");
         symbol(&issetugidImpl, "issetugid");
-        symbol(&__init_tp_fn, "__init_tp");
-        symbol(&__copy_tls_fn, "__copy_tls");
-        symbol(&__init_tls_fn, "__init_tls");
-        @export(&__thread_list_lock, .{ .name = "__thread_list_lock", .linkage = .strong, .visibility = .hidden });
         symbol(&__reset_tls_fn, "__reset_tls");
         symbol(&dummy, "_init");
         symbol(&libc_start_init_fn, "__libc_start_init");

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -446,7 +446,7 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
 }
 
 const src_files = [_][]const u8{
-    //"musl/src/env/__init_tls.c", // migrated to lib/c/env.zig
+    "musl/src/env/__init_tls.c",
     "musl/src/fenv/aarch64/fenv.s",
     //"musl/src/fenv/arm/fenv.c", // migrated to lib/c/fenv.zig; exports: feclearexcept,feraiseexcept,fetestexcept,fegetround,__fesetround,fegetenv,fesetenv
     "musl/src/fenv/arm/fenv-hf.S",


### PR DESCRIPTION
Reverts #458 (commit `36bed999e8`).

## Why

The post-merge-libc run on `be352757` (run [25614224801](https://github.com/ctaggart/zig/actions/runs/25614224801)) shows new failures across **all TLS_ABOVE_TP archs** (aarch64, arm, loongarch64, riscv, etc.):

* `functional.tls_init` — segfaults under both native aarch64 and `qemu-aarch64_be` (`uncaught target signal 11 (Segmentation fault)`).
* `functional.pthread_cond`, `functional.pthread_mutex`, `functional.pthread_tsd`, `functional.sem_init` — new failures, same root cause.

Comparing aarch64 failure counts before/after:

| Run | Commit | Failures |
|---|---|---|
| Previous | 1cbb222f (May 8) | 1507 |
| Current | be352757 (#458 + #470 + #487) | 1651 (+144) |

The fixes in #487 are a strict subset of the regressed tests, so the +144 are entirely from #458 + #470. `functional.tls_init` and the pthread/sem family are TLS-bound, pointing squarely at #458.

## Root cause

The migrated `PThread` struct in `lib/c/env.zig` defines 6 pointer-sized fields at the start:

```zig
const PThread = extern struct {
    self: ?*PThread,
    dtv_or_prev: ?[*]usize,        // (1)
    prev_or_next: ?*PThread,       // (2)
    next_or_sysinfo: usize,        // (3)
    sysinfo_or_canary: usize,      // (4)
    canary: usize,                 // (5)
    tid: c_int,
    ...
```

But musl's `struct pthread` on TLS_ABOVE_TP has **only 4** pointer-sized fields before Part 2:

```c
struct pthread {
    struct pthread *self;       // 0
    struct pthread *prev, *next; // 8, 16
    uintptr_t sysinfo;          // 24
    /* Part 2 */
    int tid;                    // 32
    int errno_val;              // 36
    volatile int detach_state;  // 40
    ...
    /* Part 3 (TLS_ABOVE_TP only) */
    uintptr_t canary;
    uintptr_t *dtv;
};
```

The extra `sysinfo_or_canary` and `canary` slots in the Zig struct push every Part 2 field by 16 bytes on TLS_ABOVE_TP. Writes via `td.tid`, `td.detach_state`, `td.locale`, `td.robust_list` land at the wrong offsets, and the Zig-declared `canary` field overwrites musl's `tid` + `errno_val`. The non-TLS_ABOVE_TP path (x86_64) coincidentally has 6 pointer slots so the layout works there.

## Fix forward

Re-do the migration with a comptime-conditional struct (separate `extern struct` definitions for TLS_ABOVE_TP vs not), and require post-merge-libc to pass on both an aarch64 (TLS_ABOVE_TP, native) and an x86_64 (non-TLS_ABOVE_TP) host before merge. I'll file an issue.

The pre-existing C `__init_tls.c` is reinstated by un-commenting it in `src/libs/musl.zig`.