### PR TITLE
Fix #488: pass -no-canonical-prefixes to clang

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6690,6 +6690,16 @@ pub fn addCCArgs(
     // can be disabled.
     try argv.append("--no-default-config");
 
+    // Tell clang to use argv[0] (which we always pass as the absolute path to
+    // the running zig binary, see `self_exe_path` above) as its executable
+    // path, rather than canonicalizing via /proc/self/exe + dladdr. The
+    // canonicalization path can fail under some build configurations, leaving
+    // ClangExecutable empty and producing a confusing
+    // "posix_spawn failed: No such file or directory" when clang tries to
+    // spawn an out-of-process cc1 (e.g. the preprocess step for `.S` files).
+    // See ctaggart/zig#488.
+    try argv.append("-no-canonical-prefixes");
+
     // We don't ever put `-fcolor-diagnostics` or `-fno-color-diagnostics` because in passthrough mode
     // we want Clang to infer it, and in normal mode we always want it off, which will be true since
     // clang will detect stderr as a pipe rather than a terminal.


### PR DESCRIPTION
Fixes #488.

## What

When zig invokes itself as a clang sub-process, pass `-no-canonical-prefixes` so clang uses argv[0] as its executable path rather than canonicalizing via `/proc/self/exe` + `dladdr`. Zig already passes the fully-resolved absolute path of its own binary as argv[0] (from `process.executablePathAlloc`), so the canonicalization step adds no value and triggers a regression where it produces an empty path.

## Symptom

When building any musl assembly file (`.S`) for an arch where clang spawns an out-of-process cc1 for the preprocess phase (loongarch64, riscv32, etc.), the cc1 spawn fails with:

```
zig: error: unable to execute command: posix_spawn failed: No such file or directory
```

`strace` shows the inner spawn argv has both **path** and **argv[0]** empty:

```
execve("", ["", "-cc1", "-triple", "loongarch64-...", "-E", ...]) = -1 ENOENT
```

The repro is deterministic and surfaces 6000+ failures per loongarch64-linux-muslsf or riscv32-linux-musl job in `post-merge-libc` (every test invocation tries to preprocess `fenv.S`, `longjmp.S`, `setjmp.S`). The `pr-cross-compile` advisory matrix added by #487 also fails on the same .S files for these targets.

## Repro

```sh
echo '.global x
x: ret' > /tmp/t.S
stage4/bin/zig build-obj -target loongarch64-linux-muslsf /tmp/t.S \\
    --zig-lib-dir lib
```

## Verification

`zig clang -no-canonical-prefixes ...` on the same .S file produces the .o successfully. With `zig clang` default (canonical-prefixes), it fails. So the patched in-tree call site (`addCCArgs`) inherits the proven workaround.

## Why not bisect the regression

The same source (`zig_clang_driver.cpp` is unchanged from v0.16.0 to libc/0.16.x HEAD) somehow produces different behavior; `/proc/self/exe` resolves correctly to the full path under `strace`, yet `Driver::ClangExecutable` ends up empty. Likely a subtle interaction with LLVM 21.1.x release patches and how the static aarch64-linux-musl binary is produced. Tracking the exact root cause separately is welcome, but `-no-canonical-prefixes` is the correct setting for zig's use case regardless: zig knows its own absolute path and there is no upstream-clang reason to re-canonicalize.

## Risk

Very low. `-no-canonical-prefixes` only changes how clang resolves argv[0] internally. Zig already passes the canonical absolute path. No effect on emitted code, no effect on diagnostics.

## CI Validation

The pre-existing `pr-cross-compile` advisory matrix on this PR will turn from RED → GREEN if this fix works, validating across 17 cross-compile targets including loongarch64-linux-muslsf and riscv32-linux-musl.