### PR TITLE
lib/c/env: workaround LLVM 21.1.8 codegen crash on __stack_chk_fail (#495)

### DIFF
--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -129,7 +129,11 @@ comptime {
         @export(&environ_var, .{ .name = "environ", .linkage = .weak, .visibility = .hidden });
         symbol(&__stack_chk_guard, "__stack_chk_guard");
         symbol(&__init_ssp, "__init_ssp");
-        symbol(&__stack_chk_fail, "__stack_chk_fail");
+        if (llvm_stack_chk_fail_buggy) {
+            symbol(&__zig_stack_chk_fail, "__zig_stack_chk_fail");
+        } else {
+            symbol(&__stack_chk_fail, "__stack_chk_fail");
+        }
         symbol(&issetugidImpl, "issetugid");
         symbol(&__reset_tls_fn, "__reset_tls");
         symbol(&dummy, "_init");
@@ -301,8 +305,43 @@ fn __init_ssp(entropy: ?*const anyopaque) callconv(.c) void {
     }
 }
 
+// LLVM 21.1.8 segfaults during codegen on most non-aarch64/non-x86_64
+// backends when a compilation unit emits an LLVM function whose name is
+// `__stack_chk_fail` (see ctaggart/zig#495). Workaround on the affected
+// backends: emit the symbol via assembler directives in the body of a
+// function with a *different* LLVM-visible name, so the IR never contains
+// a function named `__stack_chk_fail`. aarch64 and x86_64 are unaffected
+// by the LLVM bug and additionally x86_64 uses Zig's self-hosted
+// assembler which does not accept the `.weak`/`.hidden` directives, so
+// those targets keep the straightforward `@export` path.
+const llvm_stack_chk_fail_buggy = switch (builtin.cpu.arch) {
+    .aarch64, .aarch64_be, .x86_64 => false,
+    else => true,
+};
+
 fn __stack_chk_fail() callconv(.c) noreturn {
     @trap();
+}
+
+fn __zig_stack_chk_fail() callconv(.naked) noreturn {
+    asm volatile (".weak __stack_chk_fail\n" ++
+            ".hidden __stack_chk_fail\n" ++
+            "__stack_chk_fail:\n" ++
+            switch (builtin.cpu.arch) {
+                .x86 => "ud2",
+                .arm, .armeb, .thumb, .thumbeb => "udf #0",
+                .riscv32, .riscv64 => "unimp",
+                .loongarch32, .loongarch64 => "break 0",
+                .mips, .mipsel, .mips64, .mips64el => "break",
+                .powerpc, .powerpcle, .powerpc64, .powerpc64le => "trap",
+                .s390x => "j .",
+                .sparc, .sparc64 => "unimp",
+                .m68k => "illegal",
+                .hexagon => "trap0(#1)",
+                .xtensa => "ill",
+                .wasm32, .wasm64 => "unreachable",
+                else => @compileError("__stack_chk_fail: trap instruction not defined for " ++ @tagName(builtin.cpu.arch)),
+            });
 }
 
 // __pthread_self() for the current arch.


### PR DESCRIPTION
Workaround for #495 — LLVM 21.1.8 segfault during cross-compile codegen.

## What the bug is

LLVM 21.1.8 segfaults during `LLVM Emit Object` whenever the IR for a
compilation unit emits a function whose name is literally
`__stack_chk_fail`, on every backend except aarch64 and x86_64. Bisection
in #495 narrowed it to `lib/c/env.zig` line `symbol(&__stack_chk_fail, "__stack_chk_fail");`.
Renaming the export to anything else made the crash disappear, while
keeping the export name and changing the function body did not — so the
trigger is the LLVM-visible function name, not anything about its body.

## What this change does

Keep the ABI exactly as before — a weak, hidden `__stack_chk_fail` symbol
that traps when called — but on the LLVM-buggy backends emit the symbol
via assembler directives in the body of a wrapper function whose
LLVM-visible name is `__zig_stack_chk_fail`:

```zig
fn __zig_stack_chk_fail() callconv(.naked) noreturn {
    asm volatile (".weak __stack_chk_fail\n" ++
            ".hidden __stack_chk_fail\n" ++
            "__stack_chk_fail:\n" ++
            switch (builtin.cpu.arch) { ... arch trap ... });
}
```

The Zig (and therefore LLVM) function symbol is `__zig_stack_chk_fail`;
the assembler emits a second label `__stack_chk_fail` at the same
instruction. The IR never contains a function literally named
`__stack_chk_fail`, so the LLVM crash path is bypassed.

aarch64 and x86_64 keep the original `@export` path — they're unaffected
by the LLVM bug, and x86_64 additionally uses Zig's self-hosted assembler
which does not accept the `.weak`/`.hidden` directives.

## Cross-compile matrix

Run with the cached `stage4` `aarch64-linux-musl` zig used by the failing
PR matrix; same hello-world repro as #495.

| target | before | after |
| --- | --- | --- |
| `aarch64-linux-musl` | ✅ | ✅ |
| `x86-linux-musl` | 💥 | ✅ |
| `loongarch64-linux-musl{,sf}` | 💥 | ✅ |
| `riscv64-linux-musl` | 💥 | ✅ |
| `arm{,eb}-linux-musleabi{,hf}` | 💥 | ✅ |
| `powerpc-linux-musleabi{,hf}` | 💥 | ✅ |
| `powerpc64-linux-musl` | 💥 | ✅ |
| `powerpc64le-linux-musl` | 💥 | ✅ |

`s390x`, `thumb`, `riscv32`, `x86_64-linux-musl`, `powerpc-linux-musl` are
still failing in the matrix, but for *different*, pre-existing reasons —
not the `__stack_chk_fail` LLVM crash from #495. Details and links are in
[issue #495](https://github.com/ctaggart/zig/issues/495#issuecomment-4415502404).

## Verification

`readelf` on a hello-world that explicitly references `__stack_chk_fail`
on `loongarch64-linux-muslsf` shows both names resolving to the same
address:

```
3605: …  8 FUNC    LOCAL  DEFAULT   c.env.__zig_stack_chk_fail
7362: …  0 NOTYPE  LOCAL  HIDDEN    __stack_chk_fail
8017: …  8 FUNC    LOCAL  HIDDEN    __zig_stack_chk_fail
```

The bytes at `0x127b140` are `00 00 2a 00`, i.e. `break 0` on
loongarch64 (LE) — the trap we want.

Closes #495.
