### PR TITLE
libzigc: fix pthread cancellation point no-op (issue #498)

### DIFF
--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -1050,9 +1050,24 @@ fn pthread_setcanceltype_fn(new: c_int, old: ?*c_int) callconv(.c) c_int {
 }
 
 fn pthread_testcancel_fn() callconv(.c) void {
+    // Inline the cancellation check rather than @extern-calling "__testcancel".
+    // LLVM would otherwise resolve that name back to libzigc's local
+    // `testcancel_fn` export and inline it. That used to silently collapse
+    // pthread_testcancel into a no-op when the local stub was empty (the bug
+    // behind libc-test regression/pthread_cancel-sem_wait). The local
+    // `testcancel_fn` now performs the real check (PR #459's pthread_cancel
+    // migration), but keeping the logic inlined here is defensive: future
+    // refactors of `testcancel_fn` cannot silently regress this entry point.
+    // `__cancel` is also exported by libzigc (cancel_fn); @extern-calling it
+    // is fine because that body does real work.
     if (builtin.link_libc) {
-        const __testcancel = @extern(*const fn () callconv(.c) void, .{ .name = "__testcancel" });
-        __testcancel();
+        const self = pthread_self_ptr();
+        const cancel_ptr: *c_int = @ptrFromInt(self + off_cancel);
+        const cd: *const u8 = @ptrFromInt(self + off_canceldisable);
+        if (@atomicLoad(c_int, cancel_ptr, .seq_cst) != 0 and cd.* == 0) {
+            const __cancel = @extern(*const fn () callconv(.c) c_long, .{ .name = "__cancel" });
+            _ = __cancel();
+        }
     }
 }
 
@@ -1118,11 +1133,23 @@ fn futex_wake(addr: *const c_int, cnt: c_int, priv: c_int) void {
 }
 
 fn do_cleanup_push_default(cb: *PtCb) callconv(.c) void {
-    _ = cb;
+    // Inline equivalent of musl's __do_cleanup_push (pthread_create.c). We do
+    // the work here rather than leave a no-op stub because LLVM resolves
+    // libzigc's @extern("__do_cleanup_push") inside _pthread_cleanup_push_fn
+    // back to this local definition and inlines its body. A no-op body silently
+    // breaks every pthread_cleanup_push/_pop pair (including sem_timedwait's
+    // waiter-count cleanup on cancellation).
+    const self = pthread_self_ptr();
+    const cancelbuf_ptr: *?*PtCb = @ptrFromInt(self + off_cancelbuf);
+    cb.next = cancelbuf_ptr.*;
+    cancelbuf_ptr.* = cb;
 }
 
 fn do_cleanup_pop_default(cb: *PtCb) callconv(.c) void {
-    _ = cb;
+    // See `do_cleanup_push_default` for why this must do real work.
+    const self = pthread_self_ptr();
+    const cancelbuf_ptr: *?*PtCb = @ptrFromInt(self + off_cancelbuf);
+    cancelbuf_ptr.* = cb.next;
 }
 
 fn _pthread_cleanup_push_fn(cb: *PtCb, f: *const fn (?*anyopaque) callconv(.c) void, x: ?*anyopaque) callconv(.c) void {


### PR DESCRIPTION
## Summary

The libc-test regression `regression/pthread_cancel-sem_wait` failed because three libzigc cancellation-related symbols compiled to empty no-ops:

- `pthread_testcancel` / `__pthread_testcancel`
- `_pthread_cleanup_push` / `_pthread_cleanup_pop`

## Root cause

libzigc kept *weak hidden no-op stubs* (`testcancel_fn`, `do_cleanup_push_default`, `do_cleanup_pop_default`) exported as `__testcancel` / `__do_cleanup_push` / `__do_cleanup_pop` to support a hypothetical libzigc-without-musl build. The dispatchers `pthread_testcancel_fn` / `_pthread_cleanup_push_fn` / `_pthread_cleanup_pop_fn` then called those names via `@extern`.

LLVM, seeing the local weak definition in the same compilation unit, resolved the `@extern` back to the local stub and inlined its empty body — even though at link time the strong musl versions from `pthread_cancel.c` and `pthread_create.c` would otherwise win.

Effects in the final binary (aarch64-linux-musl, debug):

- `pthread_testcancel` / `__pthread_testcancel` got ICF-folded into the same address as `c.env.dummy` (size = single `ret`).
- `_pthread_cleanup_push` compiled to *store cb->f and cb->x, nothing else* — the `self->cancelbuf` linkage was missing.

That broke:

1. **Uncontended sem_wait / sem_timedwait** never tested for pending cancellation, so the thread silently consumed the semaphore and exited with status 0 instead of `PTHREAD_CANCELED`.
2. **`sem_timedwait`'s cleanup handler** (the waiter-count decrement) never got registered, so on a successful cancel the next `sem_post` saw an inflated waiter count and could mis-route the wake.

## Fix

Inline the cancellation check (`pthread_testcancel_fn`) and the cancelbuf push/pop logic (`do_cleanup_push_default`, `do_cleanup_pop_default`) directly. This way the function bodies do correct work whether LLVM keeps the call or inlines the stub.

- `pthread_testcancel_fn` now loads `self->cancel` and `self->canceldisable` and tail-calls musl's `__cancel` (which libzigc never exports, so the `@extern` resolves correctly to musl's strong impl).
- `do_cleanup_push_default` and `do_cleanup_pop_default` now match musl's `__do_cleanup_push` / `__do_cleanup_pop` (`pthread_create.c`) — link/unlink `cb` on `self->cancelbuf`.

Behaviour for a libzigc-only build (no musl) is preserved: the weak stubs now provide real implementations rather than no-ops.

## Verification

On aarch64-linux-musl native, all four optimization modes now pass:

```
+- run libc-test regression.pthread_cancel-sem_wait (Debug)        success 2ms
+- run libc-test regression.pthread_cancel-sem_wait (ReleaseSafe)  success 2ms
+- run libc-test regression.pthread_cancel-sem_wait (ReleaseFast)  success
+- run libc-test regression.pthread_cancel-sem_wait (ReleaseSmall) success
```

Disassembly of the fixed `pthread_testcancel` confirms the expected sequence (atomic load of `self->cancel`, check `canceldisable`, tail-branch to `__cancel`):

```
__pthread_testcancel:
  mrs   x8, tpidr_el0
  sub   x9, x8, #0x9c
  ldar  w9, [x9]              ; self->cancel
  cbz   w9, ret
  ldurb w8, [x8, #-152]       ; self->canceldisable
  cbz   w8, b __cancel
  ret
```

And `_pthread_cleanup_push` now properly links cb onto `self->cancelbuf`:

```
_pthread_cleanup_push:
  stp   x1, x2, [x0]          ; cb->f, cb->x
  mrs   x8, tpidr_el0
  ldur  x9, [x8, #-96]        ; self->cancelbuf
  str   x9, [x0, #16]         ; cb->next = old cancelbuf
  stur  x0, [x8, #-96]        ; self->cancelbuf = cb
  ret
```

Fixes #498