### PR TITLE
P5: x86_64-linux-musl: inline asm '%%fs:0' rejected as 'unknown size' by self-hosted assembler

### DIFF
--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -347,7 +347,7 @@ fn __zig_stack_chk_fail() callconv(.naked) noreturn {
 // __pthread_self() for the current arch.
 inline fn get_tp() usize {
     return switch (builtin.cpu.arch) {
-        .x86_64 => asm volatile ("mov %%fs:0, %[ret]"
+        .x86_64 => asm volatile ("movq %%fs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .x86 => asm volatile ("movl %%gs:0, %[ret]"

--- a/lib/c/process.zig
+++ b/lib/c/process.zig
@@ -217,7 +217,10 @@ fn dummy0() callconv(.c) void {}
 
 fn pthreadSelfPtr() usize {
     const tp = switch (arch) {
-        .x86_64, .x86 => asm ("mov %%fs:0, %[ret]"
+        .x86_64 => asm ("movq %%fs:0, %[ret]"
+            : [ret] "=r" (-> usize),
+        ),
+        .x86 => asm ("movl %%gs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .aarch64, .aarch64_be => asm ("mrs %[ret], tpidr_el0"

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -938,7 +938,7 @@ fn mtx_unlock(mtx: ?*anyopaque) callconv(.c) c_int {
 /// Read the architecture-specific thread pointer register.
 fn get_tp() usize {
     return switch (arch) {
-        .x86_64 => asm ("mov %%fs:0, %[ret]"
+        .x86_64 => asm ("movq %%fs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .x86 => asm ("movl %%gs:0, %[ret]"


### PR DESCRIPTION
Closes #502
