### PR TITLE
P8: drop powerpc-linux-musl (no -eabi) from pr-cross-compile matrix

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -356,7 +356,6 @@ jobs:
           - thumbeb-linux-musleabihf
           - riscv32-linux-musl
           - riscv64-linux-musl
-          - powerpc-linux-musl
           - powerpc64-linux-musl
           - powerpc64le-linux-musl
           - s390x-linux-musl


### PR DESCRIPTION
Closes #505
