### PR TITLE
ci: bound post-merge libc validation to API tests

### DIFF
--- a/.github/workflows/post-merge-libc.yml
+++ b/.github/workflows/post-merge-libc.yml
@@ -26,17 +26,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: full test-libc on libc/0.16.x HEAD
+  test-api:
+    name: post-merge test-libc API on libc/0.16.x HEAD
     uses: ./.github/workflows/test-libc.yml
     with:
       branch: ${{ github.sha }}
-      test-filter: ""
+      # The full libc-test suite currently has known-hanging functional and
+      # regression slices on libc/0.16.x. Keep post-merge validation bounded
+      # by running the API slice across the target matrix; broken targets stay
+      # advisory in test-libc.yml until fixed.
+      test-filter: api
       targets: all
 
   on-failure:
     name: notify on test failure
-    needs: test
+    needs: test-api
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -57,9 +61,9 @@ jobs:
           author="$(git log -1 --pretty=%an "$HEAD_SHA")"
           merge_pr="$(printf '%s' "$subject" | sed -nE 's/.*\(#([0-9]+)\)$/\1/p')"
 
-          title="post-merge test-libc failure on libc/0.16.x @ ${short_sha}"
+          title="post-merge test-libc API failure on libc/0.16.x @ ${short_sha}"
           body=$(cat <<EOF
-          The full \`test-libc\` matrix failed against \`libc/0.16.x\` after a merge.
+          The post-merge \`test-libc\` API matrix failed against \`libc/0.16.x\` after a merge.
 
           - Commit: [\`${short_sha}\`](${{ github.server_url }}/${{ github.repository }}/commit/${HEAD_SHA})
           - Subject: \`${subject}\`


### PR DESCRIPTION
## Summary
- change post-merge libc validation from full libc-test to the API slice across the matrix
- keep known-broken targets advisory through `test-libc.yml`
- update failure issue wording to reflect API validation

This keeps post-merge validation bounded while functional/regression hangs and math failures are tracked separately.