### PR TITLE
fix libc cross-target advisory failures

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -365,7 +365,7 @@ jobs:
           - target: x86-linux-musl
             allow_failure: false
           - target: x86_64-linux-musl
-            allow_failure: true
+            allow_failure: false
           - target: arm-linux-musleabi
             allow_failure: false
           - target: arm-linux-musleabihf
@@ -379,7 +379,7 @@ jobs:
           - target: thumbeb-linux-musleabihf
             allow_failure: false
           - target: riscv32-linux-musl
-            allow_failure: true
+            allow_failure: false
           - target: riscv64-linux-musl
             allow_failure: false
           - target: powerpc64-linux-musl
@@ -393,7 +393,7 @@ jobs:
           - target: loongarch64-linux-muslsf
             allow_failure: false
           - target: wasm32-wasi-musl
-            allow_failure: true
+            allow_failure: false
     steps:
       - uses: actions/checkout@v4
 

--- a/lib/c/linux.zig
+++ b/lib/c/linux.zig
@@ -144,8 +144,8 @@ comptime {
             symbol(&sync_file_rangeLinux, "sync_file_range")
         else if (@hasField(linux.SYS, "sync_file_range2"))
 
-        // sysinfo
-        symbol(&sysinfoLinux, "__lsysinfo");
+            // sysinfo
+            symbol(&sysinfoLinux, "__lsysinfo");
 
         // timerfd
         symbol(&timerfd_createLinux, "timerfd_create");
@@ -610,7 +610,10 @@ fn wait3Linux(status: ?*c_int, options: c_int, usage: ?*anyopaque) callconv(.c) 
 }
 
 fn wait4Linux(pid: linux.pid_t, status: ?*c_int, options: c_int, ru: ?*anyopaque) callconv(.c) linux.pid_t {
-    return errno(linux.syscall4(.wait4, arg(pid), arg(status), arg(options), arg(ru)));
+    var status_buf: u32 = undefined;
+    const status_ptr: *u32 = if (status) |p| @ptrCast(p) else &status_buf;
+    const usage: ?*linux.rusage = if (ru) |p| @ptrCast(@alignCast(p)) else null;
+    return errno(linux.wait4(pid, status_ptr, @bitCast(options), usage));
 }
 
 // ─── xattr ──────────────────────────────────────────────────────────────────

--- a/lib/c/mq.zig
+++ b/lib/c/mq.zig
@@ -3,6 +3,9 @@ const std = @import("std");
 const linux = std.os.linux;
 const c = @import("../c.zig");
 
+const SYS_mq_timedsend: linux.SYS = if (@hasField(linux.SYS, "mq_timedsend")) .mq_timedsend else .mq_timedsend_time64;
+const SYS_mq_timedreceive: linux.SYS = if (@hasField(linux.SYS, "mq_timedreceive")) .mq_timedreceive else .mq_timedreceive_time64;
+
 comptime {
     if (builtin.target.isMuslLibC()) {
         c.symbol(&mq_closeLinux, "mq_close");
@@ -60,7 +63,7 @@ fn mq_receiveLinux(mqdes: c_int, msg: [*]u8, len: usize, prio: ?*c_uint) callcon
 
 fn mq_timedsendLinux(mqdes: c_int, msg: [*]const u8, len: usize, prio: c_uint, at: ?*const linux.timespec) callconv(.c) c_int {
     return c.errno(linux.syscall5(
-        .mq_timedsend,
+        SYS_mq_timedsend,
         iarg(mqdes),
         @intFromPtr(msg),
         len,
@@ -71,7 +74,7 @@ fn mq_timedsendLinux(mqdes: c_int, msg: [*]const u8, len: usize, prio: c_uint, a
 
 fn mq_timedreceiveLinux(mqdes: c_int, msg: [*]u8, len: usize, prio: ?*c_uint, at: ?*const linux.timespec) callconv(.c) isize {
     const ret = linux.syscall5(
-        .mq_timedreceive,
+        SYS_mq_timedreceive,
         iarg(mqdes),
         @intFromPtr(msg),
         len,

--- a/lib/c/process.zig
+++ b/lib/c/process.zig
@@ -386,13 +386,9 @@ fn waitLinux(status: ?*c_int) callconv(.c) linux.pid_t {
 }
 
 fn waitpidLinux(pid: linux.pid_t, status: ?*c_int, options: c_int) callconv(.c) linux.pid_t {
-    return errnoP(linux.syscall4(
-        .wait4,
-        @as(usize, @bitCast(@as(isize, pid))),
-        @intFromPtr(status),
-        @as(usize, @bitCast(@as(isize, options))),
-        0,
-    ));
+    var status_buf: u32 = undefined;
+    const status_ptr: *u32 = if (status) |p| @ptrCast(p) else &status_buf;
+    return errnoP(linux.wait4(pid, status_ptr, @bitCast(options), null));
 }
 
 fn waitidLinux(idtype: c_uint, id: c_uint, info: ?*linux.siginfo_t, options: c_int) callconv(.c) c_int {

--- a/lib/c/stat.zig
+++ b/lib/c/stat.zig
@@ -5,6 +5,9 @@ const linux = std.os.linux;
 const symbol = @import("../c.zig").symbol;
 const errno = @import("../c.zig").errno;
 
+const SYS_statfs: linux.SYS = if (@hasField(linux.SYS, "statfs")) .statfs else .statfs64;
+const SYS_fstatfs: linux.SYS = if (@hasField(linux.SYS, "fstatfs")) .fstatfs else .fstatfs64;
+
 comptime {
     if (builtin.target.isMuslLibC()) {
         symbol(&mkdirLinux, "mkdir");
@@ -26,7 +29,7 @@ comptime {
             symbol(&statLinux, "stat");
             symbol(&lstatLinux, "lstat");
             symbol(&fstatLinux, "__fstat");
-        symbol(&fstatLinux, "fstat");
+            symbol(&fstatLinux, "fstat");
             symbol(&futimensLinux, "futimens");
             symbol(&lchmodLinux, "lchmod");
             symbol(&__futimesat, "__futimesat");
@@ -113,8 +116,7 @@ fn kstatMatchesStat() bool {
     const abi = builtin.target.abi;
     if (abi == .muslx32) return true;
     return switch (builtin.cpu.arch) {
-        .x86_64, .aarch64, .aarch64_be, .riscv64, .loongarch64,
-        .powerpc64, .powerpc64le, .s390x => true,
+        .x86_64, .aarch64, .aarch64_be, .riscv64, .loongarch64, .powerpc64, .powerpc64le, .s390x => true,
         else => false,
     };
 }
@@ -131,72 +133,177 @@ fn muStatType() type {
     return switch (arch) {
         // Generic layout: aarch64, hexagon, loongarch64, riscv32, riscv64
         .aarch64, .aarch64_be, .hexagon, .loongarch64, .riscv32, .riscv64 => extern struct {
-            dev: u64, ino: u64, mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __pad: u64 = 0, size: i64, blksize: i32, __pad2: i32 = 0,
-            blocks: i64, atim: Ts, mtim: Ts, ctim: Ts, __unused: [2]u32 = .{ 0, 0 },
+            dev: u64,
+            ino: u64,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __pad: u64 = 0,
+            size: i64,
+            blksize: i32,
+            __pad2: i32 = 0,
+            blocks: i64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            __unused: [2]u32 = .{ 0, 0 },
         },
         .x86_64 => extern struct {
-            dev: u64, ino: u64, nlink: u64, mode: u32, uid: u32, gid: u32,
-            __pad0: u32 = 0, rdev: u64, size: i64, blksize: i64, blocks: i64,
-            atim: Ts, mtim: Ts, ctim: Ts, __unused: [3]i64 = .{ 0, 0, 0 },
+            dev: u64,
+            ino: u64,
+            nlink: u64,
+            mode: u32,
+            uid: u32,
+            gid: u32,
+            __pad0: u32 = 0,
+            rdev: u64,
+            size: i64,
+            blksize: i64,
+            blocks: i64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            __unused: [3]i64 = .{ 0, 0, 0 },
         },
         .powerpc64, .powerpc64le => extern struct {
-            dev: u64, ino: u64, nlink: u64, mode: u32, uid: u32, gid: u32,
-            __pad0: u32 = 0, rdev: u64, size: i64, blksize: i64, blocks: i64,
-            atim: Ts, mtim: Ts, ctim: Ts, __unused: [3]u64 = .{ 0, 0, 0 },
+            dev: u64,
+            ino: u64,
+            nlink: u64,
+            mode: u32,
+            uid: u32,
+            gid: u32,
+            __pad0: u32 = 0,
+            rdev: u64,
+            size: i64,
+            blksize: i64,
+            blocks: i64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            __unused: [3]u64 = .{ 0, 0, 0 },
         },
         .s390x => extern struct {
-            dev: u64, ino: u64, nlink: u64, mode: u32, uid: u32, gid: u32,
-            __pad0: u32 = 0, rdev: u64, size: i64,
-            atim: Ts, mtim: Ts, ctim: Ts,
-            blksize: i64, blocks: i64, __unused: [3]u64 = .{ 0, 0, 0 },
+            dev: u64,
+            ino: u64,
+            nlink: u64,
+            mode: u32,
+            uid: u32,
+            gid: u32,
+            __pad0: u32 = 0,
+            rdev: u64,
+            size: i64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            blksize: i64,
+            blocks: i64,
+            __unused: [3]u64 = .{ 0, 0, 0 },
         },
         .mips64, .mips64el => extern struct {
-            dev: u64, __pad1: [3]i32 = .{ 0, 0, 0 },
-            ino: u64, mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __pad2: [2]u32 = .{ 0, 0 }, size: i64, __pad3: i32 = 0,
-            atim: Ts, mtim: Ts, ctim: Ts,
-            blksize: i64, __pad4: u32 = 0, blocks: i64, __pad5: [14]i32 = .{0} ** 14,
+            dev: u64,
+            __pad1: [3]i32 = .{ 0, 0, 0 },
+            ino: u64,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __pad2: [2]u32 = .{ 0, 0 },
+            size: i64,
+            __pad3: i32 = 0,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            blksize: i64,
+            __pad4: u32 = 0,
+            blocks: i64,
+            __pad5: [14]i32 = .{0} ** 14,
         },
         .arm, .armeb, .thumb, .thumbeb, .x86 => extern struct {
-            dev: u64, __dev_pad: i32 = 0, ino_truncated: i32 = 0,
-            mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __rdev_pad: i32 = 0,
-            size: i64, blksize: i32, blocks: i64,
+            dev: u64,
+            __dev_pad: i32 = 0,
+            ino_truncated: i32 = 0,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __rdev_pad: i32 = 0,
+            size: i64,
+            blksize: i32,
+            blocks: i64,
             atim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             mtim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             ctim32: Ts32 = .{ .sec = 0, .nsec = 0 },
-            ino: u64, atim: Ts, mtim: Ts, ctim: Ts,
+            ino: u64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
         },
         .m68k => extern struct {
-            dev: u64, __dev_pad: i16 = 0, ino_truncated: i32 = 0,
-            mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __rdev_pad: i16 = 0,
-            size: i64, blksize: i32, blocks: i64,
+            dev: u64,
+            __dev_pad: i16 = 0,
+            ino_truncated: i32 = 0,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __rdev_pad: i16 = 0,
+            size: i64,
+            blksize: i32,
+            blocks: i64,
             atim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             mtim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             ctim32: Ts32 = .{ .sec = 0, .nsec = 0 },
-            ino: u64, atim: Ts, mtim: Ts, ctim: Ts,
+            ino: u64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
         },
         .mips, .mipsel => extern struct {
-            dev: u64, __pad1: [2]i32 = .{ 0, 0 },
-            ino: u64, mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __pad2: [2]i32 = .{ 0, 0 }, size: i64,
+            dev: u64,
+            __pad1: [2]i32 = .{ 0, 0 },
+            ino: u64,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __pad2: [2]i32 = .{ 0, 0 },
+            size: i64,
             atim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             mtim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             ctim32: Ts32 = .{ .sec = 0, .nsec = 0 },
-            blksize: i32, __pad3: i32 = 0, blocks: i64,
-            atim: Ts, mtim: Ts, ctim: Ts, __pad4: [2]i32 = .{ 0, 0 },
+            blksize: i32,
+            __pad3: i32 = 0,
+            blocks: i64,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
+            __pad4: [2]i32 = .{ 0, 0 },
         },
         .powerpc, .powerpcle => extern struct {
-            dev: u64, ino: u64, mode: u32, nlink: u32, uid: u32, gid: u32,
-            rdev: u64, __rdev_pad: i16 = 0,
-            size: i64, blksize: i32, blocks: i64,
+            dev: u64,
+            ino: u64,
+            mode: u32,
+            nlink: u32,
+            uid: u32,
+            gid: u32,
+            rdev: u64,
+            __rdev_pad: i16 = 0,
+            size: i64,
+            blksize: i32,
+            blocks: i64,
             atim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             mtim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             ctim32: Ts32 = .{ .sec = 0, .nsec = 0 },
             __unused: [2]u32 = .{ 0, 0 },
-            atim: Ts, mtim: Ts, ctim: Ts,
+            atim: Ts,
+            mtim: Ts,
+            ctim: Ts,
         },
         else => @compileError("unsupported architecture for musl stat"),
     };
@@ -204,14 +311,26 @@ fn muStatType() type {
 
 /// mipsn32: mips64 arch with .muslabin32 ABI (32-bit address, 64-bit regs)
 const MuStatMipsN32 = extern struct {
-    dev: u64, __pad1: [2]i32 = .{ 0, 0 },
-    ino: u64, mode: u32, nlink: u32, uid: u32, gid: u32,
-    rdev: u64, __pad2: [2]i32 = .{ 0, 0 }, size: i64,
+    dev: u64,
+    __pad1: [2]i32 = .{ 0, 0 },
+    ino: u64,
+    mode: u32,
+    nlink: u32,
+    uid: u32,
+    gid: u32,
+    rdev: u64,
+    __pad2: [2]i32 = .{ 0, 0 },
+    size: i64,
     atim32: Ts32 = .{ .sec = 0, .nsec = 0 },
     mtim32: Ts32 = .{ .sec = 0, .nsec = 0 },
     ctim32: Ts32 = .{ .sec = 0, .nsec = 0 },
-    blksize: i32, __pad3: i32 = 0, blocks: i64,
-    atim: Ts, mtim: Ts, ctim: Ts, __pad4: [2]i32 = .{ 0, 0 },
+    blksize: i32,
+    __pad3: i32 = 0,
+    blocks: i64,
+    atim: Ts,
+    mtim: Ts,
+    ctim: Ts,
+    __pad4: [2]i32 = .{ 0, 0 },
 };
 
 fn fstatatImpl(fd: c_int, path: [*:0]const u8, buf: *anyopaque, flag: c_int) callconv(.c) c_int {
@@ -228,9 +347,11 @@ fn fstatatImpl(fd: c_int, path: [*:0]const u8, buf: *anyopaque, flag: c_int) cal
     // Use statx and convert to the arch-specific musl stat struct.
     var stx: linux.Statx = undefined;
     const stx_rc: isize = @bitCast(linux.statx(
-        fd, path,
+        fd,
+        path,
         @as(u32, @bitCast(flag)) | linux.AT.NO_AUTOMOUNT,
-        linux.STATX.BASIC_STATS, &stx,
+        linux.STATX.BASIC_STATS,
+        &stx,
     ));
     if (stx_rc < 0) {
         std.c._errno().* = @intCast(-stx_rc);
@@ -273,7 +394,10 @@ fn lstatLinux(noalias path: [*:0]const u8, noalias buf: *anyopaque) callconv(.c)
     return fstatat(linux.AT.FDCWD, path, buf, linux.AT.SYMLINK_NOFOLLOW);
 }
 fn fstatLinux(fd: c_int, buf: *anyopaque) callconv(.c) c_int {
-    if (fd < 0) { std.c._errno().* = @intFromEnum(linux.E.BADF); return -1; }
+    if (fd < 0) {
+        std.c._errno().* = @intFromEnum(linux.E.BADF);
+        return -1;
+    }
     return fstatat(fd, "", buf, linux.AT.EMPTY_PATH);
 }
 fn futimensLinux(fd: c_int, times: ?*const [2]linux.timespec) callconv(.c) c_int {
@@ -288,7 +412,8 @@ const timeval = extern struct { tv_sec: isize, tv_usec: isize };
 fn __futimesat(dirfd: c_int, pathname: ?[*:0]const u8, times: ?*const [2]timeval) callconv(.c) c_int {
     if (times) |tv| {
         if (tv[0].tv_usec >= 1000000 or tv[1].tv_usec >= 1000000) {
-            std.c._errno().* = @intFromEnum(linux.E.INVAL); return -1;
+            std.c._errno().* = @intFromEnum(linux.E.INVAL);
+            return -1;
         }
         const ts = [2]linux.timespec{
             .{ .sec = tv[0].tv_sec, .nsec = tv[0].tv_usec * 1000 },
@@ -303,23 +428,31 @@ fn __futimesat(dirfd: c_int, pathname: ?[*:0]const u8, times: ?*const [2]timeval
 
 fn __fxstat(ver: c_int, fd: c_int, buf: *anyopaque) callconv(.c) c_int {
     _ = ver;
-    if (fd < 0) { std.c._errno().* = @intFromEnum(linux.E.BADF); return -1; }
+    if (fd < 0) {
+        std.c._errno().* = @intFromEnum(linux.E.BADF);
+        return -1;
+    }
     return fstatat(fd, "", buf, linux.AT.EMPTY_PATH);
 }
 fn __fxstatat(ver: c_int, fd: c_int, path: [*:0]const u8, buf: *anyopaque, flag: c_int) callconv(.c) c_int {
-    _ = ver; return fstatat(fd, path, buf, flag);
+    _ = ver;
+    return fstatat(fd, path, buf, flag);
 }
 fn __lxstat(ver: c_int, path: [*:0]const u8, buf: *anyopaque) callconv(.c) c_int {
-    _ = ver; return fstatat(linux.AT.FDCWD, path, buf, linux.AT.SYMLINK_NOFOLLOW);
+    _ = ver;
+    return fstatat(linux.AT.FDCWD, path, buf, linux.AT.SYMLINK_NOFOLLOW);
 }
 fn __xstat_fn(ver: c_int, path: [*:0]const u8, buf: *anyopaque) callconv(.c) c_int {
-    _ = ver; return fstatat(linux.AT.FDCWD, path, buf, 0);
+    _ = ver;
+    return fstatat(linux.AT.FDCWD, path, buf, 0);
 }
 fn __xmknod(ver: c_int, path: [*:0]const u8, mode: linux.mode_t, dev: *const linux.dev_t) callconv(.c) c_int {
-    _ = ver; return mknodLinux(path, mode, dev.*);
+    _ = ver;
+    return mknodLinux(path, mode, dev.*);
 }
 fn __xmknodat(ver: c_int, fd: c_int, path: [*:0]const u8, mode: linux.mode_t, dev: *const linux.dev_t) callconv(.c) c_int {
-    _ = ver; return mknodatLinux(fd, path, mode, dev.*);
+    _ = ver;
+    return mknodatLinux(fd, path, mode, dev.*);
 }
 
 // --- fchmodat with AT_SYMLINK_NOFOLLOW fallback ---
@@ -343,10 +476,16 @@ fn fchmodatLinux(fd: c_int, path: [*:0]const u8, mode: linux.mode_t, flag: c_int
     // Check if target is a symlink using statx
     var stx: linux.Statx = undefined;
     const stx_rc: isize = @bitCast(linux.statx(
-        fd, path, linux.AT.SYMLINK_NOFOLLOW | linux.AT.NO_AUTOMOUNT,
-        .{ .MODE = true }, &stx,
+        fd,
+        path,
+        linux.AT.SYMLINK_NOFOLLOW | linux.AT.NO_AUTOMOUNT,
+        .{ .MODE = true },
+        &stx,
     ));
-    if (stx_rc < 0) { std.c._errno().* = @intCast(-stx_rc); return -1; }
+    if (stx_rc < 0) {
+        std.c._errno().* = @intCast(-stx_rc);
+        return -1;
+    }
     if (linux.S.ISLNK(@as(linux.mode_t, stx.mode))) {
         std.c._errno().* = @intFromEnum(linux.E.OPNOTSUPP);
         return -1;
@@ -354,11 +493,17 @@ fn fchmodatLinux(fd: c_int, path: [*:0]const u8, mode: linux.mode_t, flag: c_int
 
     // Open with O_PATH|O_NOFOLLOW, chmod via /proc/self/fd/N
     const fd2: isize = @bitCast(linux.openat(fd, path, .{
-        .ACCMODE = .RDONLY, .PATH = true, .NOFOLLOW = true, .NOCTTY = true, .CLOEXEC = true,
+        .ACCMODE = .RDONLY,
+        .PATH = true,
+        .NOFOLLOW = true,
+        .NOCTTY = true,
+        .CLOEXEC = true,
     }, 0));
     if (fd2 < 0) {
         std.c._errno().* = @intCast(if (fd2 == -@as(isize, @intFromEnum(linux.E.LOOP)))
-            @intFromEnum(linux.E.OPNOTSUPP) else -fd2);
+            @intFromEnum(linux.E.OPNOTSUPP)
+        else
+            -fd2);
         return -1;
     }
 
@@ -371,7 +516,11 @@ fn fchmodatLinux(fd: c_int, path: [*:0]const u8, mode: linux.mode_t, flag: c_int
     // Verify not a symlink via statx on proc path, then chmod
     var stx2: linux.Statx = undefined;
     const stx2_rc: isize = @bitCast(linux.statx(
-        linux.AT.FDCWD, @ptrCast(proc.ptr), linux.AT.NO_AUTOMOUNT, .{ .MODE = true }, &stx2,
+        linux.AT.FDCWD,
+        @ptrCast(proc.ptr),
+        linux.AT.NO_AUTOMOUNT,
+        .{ .MODE = true },
+        &stx2,
     ));
     const result: c_int = if (stx2_rc < 0) blk: {
         std.c._errno().* = @intCast(-stx2_rc);
@@ -420,12 +569,12 @@ const Statvfs = extern struct {
 
 fn statfsLinux(path: [*:0]const u8, buf: *Statfs) callconv(.c) c_int {
     buf.* = std.mem.zeroes(Statfs);
-    return errno(linux.syscall2(.statfs, @intFromPtr(path), @intFromPtr(buf)));
+    return errno(linux.syscall2(SYS_statfs, @intFromPtr(path), @intFromPtr(buf)));
 }
 
 fn fstatfsLinux(fd: c_int, buf: *Statfs) callconv(.c) c_int {
     buf.* = std.mem.zeroes(Statfs);
-    return errno(linux.syscall2(.fstatfs, @as(usize, @bitCast(@as(isize, fd))), @intFromPtr(buf)));
+    return errno(linux.syscall2(SYS_fstatfs, @as(usize, @bitCast(@as(isize, fd))), @intFromPtr(buf)));
 }
 
 fn fixup(out: *Statvfs, in_buf: *const Statfs) void {

--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -1987,7 +1987,7 @@ fn store_int(dest: ?*anyopaque, size: c_int, i: c_ulonglong) void {
     }
 }
 
-fn arg_n(ap: VaList, n: c_uint) ?*anyopaque {
+fn arg_n(ap: VaList, n: c_uint) callconv(.c) ?*anyopaque {
     var ap_src = ap;
     var ap2 = @cVaCopy(&ap_src);
     defer @cVaEnd(&ap2);
@@ -2464,7 +2464,7 @@ fn vfwscanfStoreInt(dest: ?*anyopaque, size: VfwscanfSize, i: c_ulonglong) void 
     }
 }
 
-fn vfwscanfArgN(ap: VaList, n: c_uint) ?*anyopaque {
+fn vfwscanfArgN(ap: VaList, n: c_uint) callconv(.c) ?*anyopaque {
     var ap_src = ap;
     var ap2 = @cVaCopy(&ap_src);
     defer @cVaEnd(&ap2);

--- a/lib/c/sys/select.zig
+++ b/lib/c/sys/select.zig
@@ -5,6 +5,8 @@ const linux = std.os.linux;
 const symbol = @import("../../c.zig").symbol;
 const errno = @import("../../c.zig").errno;
 
+const SYS_pselect6: linux.SYS = if (@hasField(linux.SYS, "pselect6")) .pselect6 else .pselect6_time64;
+
 comptime {
     if (builtin.target.isMuslLibC()) {
         symbol(&pollLinux, "poll");
@@ -32,7 +34,7 @@ fn pselectLinux(
 ) callconv(.c) c_int {
     const data = [2]usize{ @intFromPtr(sigmask), linux.NSIG / 8 };
     return errno(linux.syscall6(
-        .pselect6,
+        SYS_pselect6,
         @as(usize, @intCast(@as(c_uint, @bitCast(nfds)))),
         @intFromPtr(readfds),
         @intFromPtr(writefds),
@@ -60,7 +62,7 @@ fn selectLinux(
         };
         const data = [2]usize{ 0, linux.NSIG / 8 };
         return errno(linux.syscall6(
-            .pselect6,
+            SYS_pselect6,
             @as(usize, @intCast(@as(c_uint, @bitCast(nfds)))),
             @intFromPtr(readfds),
             @intFromPtr(writefds),
@@ -71,7 +73,7 @@ fn selectLinux(
     } else {
         const data = [2]usize{ 0, linux.NSIG / 8 };
         return errno(linux.syscall6(
-            .pselect6,
+            SYS_pselect6,
             @as(usize, @intCast(@as(c_uint, @bitCast(nfds)))),
             @intFromPtr(readfds),
             @intFromPtr(writefds),

--- a/lib/c/temp.zig
+++ b/lib/c/temp.zig
@@ -29,7 +29,9 @@ const L_tmpnam = 20;
 fn __randname(template: [*]u8) callconv(.c) [*]u8 {
     var ts: linux.timespec = undefined;
     _ = linux.clock_gettime(.REALTIME, &ts);
-    var r: usize = @bitCast(ts.sec +% ts.nsec +% @as(isize, linux.gettid()) *% 65537);
+    const seed: i64 = ts.sec +% ts.nsec +% @as(i64, linux.gettid()) *% 65537;
+    const bits: u64 = @bitCast(seed);
+    var r: usize = @intCast(bits & @as(u64, std.math.maxInt(usize)));
     for (0..6) |i| {
         template[i] = @intCast(@as(u8, 'A') + (@as(u8, @truncate(r & 15))) + (@as(u8, @truncate(r & 16)) * 2));
         r >>= 5;

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -178,6 +178,7 @@ const FUTEX_REQUEUE: usize = 3;
 const FUTEX_PRIVATE: usize = 128;
 const SYS_futex_time64: usize = if (@hasField(linux.SYS, "futex_time64")) @intFromEnum(linux.SYS.futex_time64) else 0;
 const SYS_futex: usize = if (@hasField(linux.SYS, "futex")) @intFromEnum(linux.SYS.futex) else SYS_futex_time64;
+const SYS_FUTEX: linux.SYS = if (@hasField(linux.SYS, "futex")) .futex else .futex_time64;
 var dummy_eintr_valid_flag: c_int = 0;
 var unmap_base: ?*anyopaque = null;
 var unmap_size: usize = 0;
@@ -1126,9 +1127,9 @@ fn futex_wake(addr: *const c_int, cnt: c_int, priv: c_int) void {
     const p: usize = if (priv != 0) FUTEX_PRIVATE else 0;
     const max_int: c_int = std.math.maxInt(c_int);
     const c: usize = @intCast(if (cnt < 0) max_int else cnt);
-    const rc: isize = @bitCast(std.os.linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAKE | p, c, 0));
+    const rc: isize = @bitCast(std.os.linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAKE | p, c, 0));
     if (rc == -@as(isize, @intFromEnum(E.NOSYS))) {
-        _ = std.os.linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAKE, c, 0);
+        _ = std.os.linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAKE, c, 0);
     }
 }
 
@@ -1464,7 +1465,7 @@ fn pthread_sigmask_fn(how: c_int, set: ?*const anyopaque, old: ?*anyopaque) call
 fn wake(addr: *anyopaque, cnt: c_int, priv_val: c_int) void {
     const p: usize = if (priv_val != 0) FUTEX_PRIVATE else 0;
     const n: usize = if (cnt < 0) @as(usize, @intCast(std.math.maxInt(c_int))) else @as(usize, @intCast(cnt));
-    _ = linux.syscall3(.futex, @intFromPtr(addr), FUTEX_WAKE | p, n);
+    _ = linux.syscall3(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAKE | p, n);
 }
 
 fn pthread_mutexattr_setprotocol_fn(a: *c_uint, protocol: c_int) callconv(.c) c_int {
@@ -1475,7 +1476,7 @@ fn pthread_mutexattr_setprotocol_fn(a: *c_uint, protocol: c_int) callconv(.c) c_
         var r = @atomicLoad(c_int, &check_pi_result, .monotonic);
         if (r < 0) {
             var lk: c_int = 0;
-            const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(&lk), FUTEX_LOCK_PI, 0, 0));
+            const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(&lk), FUTEX_LOCK_PI, 0, 0));
             r = @as(c_int, @intCast(-rc));
             @atomicStore(c_int, &check_pi_result, r, .release);
         }
@@ -1603,10 +1604,10 @@ fn __wait_fn(addr: *anyopaque, waiters_opt: ?*anyopaque, val: c_int, priv_arg: c
     // Futex wait loop
     while (@atomicLoad(c_int, addr_ptr, .monotonic) == val) {
         const val_u: usize = @as(usize, @bitCast(@as(isize, val)));
-        const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
+        const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
         // Fall back to shared futex if private not supported
         if (rc == -@as(isize, @intCast(@intFromEnum(E.NOSYS)))) {
-            _ = linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
+            _ = linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
         }
     }
 
@@ -1639,18 +1640,18 @@ fn vm_unlock_fn() callconv(.c) void {
 fn futexWait(addr: *volatile c_int, val: c_int, priv_flag: bool) void {
     const priv: usize = if (priv_flag) FUTEX_PRIVATE else 0;
     const val_u: usize = @bitCast(@as(isize, val));
-    const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
+    const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
     if (rc == -@as(isize, @intCast(@intFromEnum(E.NOSYS)))) {
-        _ = linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
+        _ = linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
     }
 }
 
 fn futexWake(addr: *volatile c_int, cnt: c_int, priv_flag: bool) void {
     const priv: usize = if (priv_flag) FUTEX_PRIVATE else 0;
     const n: usize = if (cnt < 0) @intCast(std.math.maxInt(c_int)) else @intCast(cnt);
-    const rc: isize = @bitCast(linux.syscall3(.futex, @intFromPtr(addr), FUTEX_WAKE | priv, n));
+    const rc: isize = @bitCast(linux.syscall3(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAKE | priv, n));
     if (rc == -@as(isize, @intCast(@intFromEnum(E.NOSYS)))) {
-        _ = linux.syscall3(.futex, @intFromPtr(addr), FUTEX_WAKE, n);
+        _ = linux.syscall3(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAKE, n);
     }
 }
 
@@ -2149,9 +2150,9 @@ fn condUnlockRequeue(l: *c_int, r: *c_int, w: c_int) void {
     if (w != 0) {
         wake(@ptrCast(l), 1, 1);
     } else {
-        const rc1: isize = @bitCast(linux.syscall5(.futex, @intFromPtr(l), FUTEX_REQUEUE | FUTEX_PRIVATE, 0, 1, @intFromPtr(r)));
+        const rc1: isize = @bitCast(linux.syscall5(SYS_FUTEX, @intFromPtr(l), FUTEX_REQUEUE | FUTEX_PRIVATE, 0, 1, @intFromPtr(r)));
         if (rc1 == -@as(isize, @intCast(eint(.NOSYS)))) {
-            _ = linux.syscall5(.futex, @intFromPtr(l), FUTEX_REQUEUE, 0, 1, @intFromPtr(r));
+            _ = linux.syscall5(SYS_FUTEX, @intFromPtr(l), FUTEX_REQUEUE, 0, 1, @intFromPtr(r));
         }
     }
 }
@@ -2474,7 +2475,7 @@ fn mutex_trylock_owner_fn(m: *anyopaque) callconv(.c) c_int {
     // success path
     if ((@"type" & 8) != 0 and m_i[2] != 0) { // PI + waiters
         const priv: usize = (@as(usize, @intCast(@"type" & 128)) ^ 128);
-        _ = linux.syscall2(.futex, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
+        _ = linux.syscall2(SYS_FUTEX, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
         robustPending(self_a).* = 0;
         return if ((@"type" & 4) != 0) eint(.NOTRECOVERABLE) else eint(.BUSY);
     }
@@ -2524,7 +2525,7 @@ fn mutex_timedlock_pi(m: *anyopaque, at: ?*const anyopaque) c_int {
     var e: c_int = undefined;
     while (true) {
         const at_addr: usize = if (at) |p| @intFromPtr(p) else 0;
-        const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(&m_i[1]), FUTEX_LOCK_PI | priv, 0, at_addr));
+        const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(&m_i[1]), FUTEX_LOCK_PI | priv, 0, at_addr));
         e = -@as(c_int, @intCast(@as(i32, @truncate(rc))));
         if (e != eint(.INTR)) break;
     }
@@ -2537,7 +2538,7 @@ fn mutex_timedlock_pi(m: *anyopaque, at: ?*const anyopaque) c_int {
             // Catch spurious success for non-robust mutexes
             if ((@"type" & 4) == 0 and ((@atomicLoad(c_int, &m_i[1], .monotonic) & 0x40000000) != 0 or m_i[2] != 0)) {
                 @atomicStore(c_int, &m_i[2], -1, .seq_cst);
-                _ = linux.syscall2(.futex, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
+                _ = linux.syscall2(SYS_FUTEX, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
                 robustPending(self_a).* = 0;
             } else {
                 m_i[5] = -1; // _m_count = -1
@@ -2641,7 +2642,7 @@ fn mutex_unlock_fn(m: *anyopaque) callconv(.c) c_int {
     if ((m_i[0] & 8) != 0) { // PI mutex
         if (old < 0 or @cmpxchgStrong(c_int, &m_i[1], old, new, .seq_cst, .seq_cst) != null) {
             if (new != 0) @atomicStore(c_int, &m_i[2], -1, .seq_cst);
-            _ = linux.syscall2(.futex, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
+            _ = linux.syscall2(SYS_FUTEX, @intFromPtr(&m_i[1]), FUTEX_UNLOCK_PI | priv);
         }
         cont = 0;
     } else {
@@ -2900,7 +2901,7 @@ fn mutexattr_setprotocol_fn(a: *c_uint, protocol: c_int) callconv(.c) c_int {
             var r = @atomicLoad(c_int, &check_pi_result, .seq_cst);
             if (r < 0) {
                 var lk: c_int = 0;
-                const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(&lk), 6, 0, 0)); // FUTEX_LOCK_PI=6
+                const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(&lk), 6, 0, 0)); // FUTEX_LOCK_PI=6
                 r = -@as(c_int, @truncate(rc));
                 @atomicStore(c_int, &check_pi_result, r, .seq_cst);
             }
@@ -3332,9 +3333,9 @@ fn wait_fn(addr: *volatile c_int, waiters: ?*volatile c_int, val: c_int, priv_ar
     }
     while (addr.* == val) {
         const val_u: usize = @bitCast(@as(isize, val));
-        const rc: isize = @bitCast(linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
+        const rc: isize = @bitCast(linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT | priv, val_u, 0));
         if (rc == -@as(isize, @intCast(@intFromEnum(E.NOSYS)))) {
-            _ = linux.syscall4(.futex, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
+            _ = linux.syscall4(SYS_FUTEX, @intFromPtr(addr), FUTEX_WAIT, val_u, 0);
         }
     }
     if (waiters) |w| {

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -1999,7 +1999,7 @@ fn barrier_wait_fn(b: *anyopaque) callconv(.c) c_int {
         // Wait until woken by last exiting thread
         while (@atomicLoad(c_int, &new_inst.finished, .seq_cst) == 1) {
             const rc: isize = @bitCast(linux.syscall4(
-                .futex,
+                SYS_FUTEX,
                 @intFromPtr(&new_inst.finished),
                 FUTEX_WAIT | FUTEX_PRIVATE,
                 1,
@@ -2007,7 +2007,7 @@ fn barrier_wait_fn(b: *anyopaque) callconv(.c) c_int {
             ));
             if (rc == -@as(isize, @intCast(@intFromEnum(E.NOSYS)))) {
                 _ = linux.syscall4(
-                    .futex,
+                    SYS_FUTEX,
                     @intFromPtr(&new_inst.finished),
                     FUTEX_WAIT,
                     1,

--- a/lib/c/wasi_sources.zig
+++ b/lib/c/wasi_sources.zig
@@ -30,6 +30,7 @@ extern fn clearenv() c_int;
 extern fn getentropy(buf: [*]u8, len: usize) c_int;
 
 extern fn _Exit(status: c_int) noreturn;
+extern fn __stdio_exit() void;
 
 // cloudlibc nocwd functions
 extern fn __wasilibc_nocwd_openat_nomode(dirfd: c_int, path: [*:0]const u8, oflag: c_int) c_int;
@@ -875,49 +876,70 @@ fn openImpl(path: [*:0]const u8, oflag: c_int) callconv(.c) c_int {
 fn accessImpl(path: [*:0]const u8, amode: c_int) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_faccessat(dirfd, relative_path, amode, 0);
 }
 
 fn readlinkImpl(path: [*:0]const u8, buf: [*]u8, bufsiz: usize) callconv(.c) isize {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_readlinkat(dirfd, relative_path, buf, bufsiz);
 }
 
 fn statImpl(path: [*:0]const u8, buf: *Stat) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_fstatat(dirfd, relative_path, buf, 0);
 }
 
 fn lstatImpl(path: [*:0]const u8, buf: *Stat) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_fstatat(dirfd, relative_path, buf, AT_SYMLINK_NOFOLLOW);
 }
 
 fn unlinkImpl(path: [*:0]const u8) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return wasilibcNocwdUnlinkatImpl(dirfd, relative_path);
 }
 
 fn rmdirImpl(path: [*:0]const u8) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return wasilibcNocwdRmdiratImpl(dirfd, relative_path);
 }
 
 fn removeImpl(path: [*:0]const u8) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     var r = wasilibcNocwdUnlinkatImpl(dirfd, relative_path);
     if (r != 0 and (std.c._errno().* == EISDIR or std.c._errno().* == ENOENT)) {
         r = wasilibcNocwdRmdiratImpl(dirfd, relative_path);
@@ -929,28 +951,40 @@ fn removeImpl(path: [*:0]const u8) callconv(.c) c_int {
 fn mkdirImpl(path: [*:0]const u8, _: c_uint) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_mkdirat_nomode(dirfd, relative_path);
 }
 
 fn opendirImpl(dirname: [*:0]const u8) callconv(.c) ?*anyopaque {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(dirname, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return null; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return null;
+    }
     return __wasilibc_nocwd_opendirat(dirfd, relative_path);
 }
 
 fn scandirImpl(dir: [*:0]const u8, namelist: *?*anyopaque, filter: ?*const anyopaque, compar: ?*const anyopaque) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(dir, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_scandirat(dirfd, relative_path, namelist, filter, compar);
 }
 
 fn symlinkImpl(target: [*:0]const u8, linkpath: [*:0]const u8) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(linkpath, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_symlinkat(target, dirfd, relative_path);
 }
 
@@ -1002,21 +1036,30 @@ fn fstatvfsImpl(_: c_int, _: *anyopaque) callconv(.c) c_int {
 fn wasilibcAccessImpl(path: [*:0]const u8, mode: c_int, flags: c_int) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_faccessat(dirfd, relative_path, mode, flags);
 }
 
 fn wasilibcUtimensImpl(path: [*:0]const u8, times: ?*const anyopaque, flags: c_int) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_utimensat(dirfd, relative_path, times, flags);
 }
 
 fn wasilibcStatImpl(path: [*:0]const u8, st: *Stat, flags: c_int) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_fstatat(dirfd, relative_path, st, flags);
 }
 
@@ -1025,35 +1068,50 @@ fn wasilibcLinkImpl(oldpath: [*:0]const u8, newpath: [*:0]const u8, flags: c_int
     var new_relative: [*:0]u8 = undefined;
     const old_dirfd = findRelpath(oldpath, &old_relative);
     const new_dirfd = findRelpath(newpath, &new_relative);
-    if (old_dirfd == -1 or new_dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (old_dirfd == -1 or new_dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_linkat(old_dirfd, old_relative, new_dirfd, new_relative, flags);
 }
 
 fn wasilibcLinkOldatImpl(olddirfd: c_int, oldpath: [*:0]const u8, newpath: [*:0]const u8, flags: c_int) callconv(.c) c_int {
     var new_relative: [*:0]u8 = undefined;
     const new_dirfd = findRelpath(newpath, &new_relative);
-    if (new_dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (new_dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_linkat(olddirfd, oldpath, new_dirfd, new_relative, flags);
 }
 
 fn wasilibcLinkNewatImpl(oldpath: [*:0]const u8, newdirfd: c_int, newpath: [*:0]const u8, flags: c_int) callconv(.c) c_int {
     var old_relative: [*:0]u8 = undefined;
     const old_dirfd = findRelpath(oldpath, &old_relative);
-    if (old_dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (old_dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_linkat(old_dirfd, old_relative, newdirfd, newpath, flags);
 }
 
 fn wasilibcRenameOldatImpl(fromdirfd: c_int, from: [*:0]const u8, to: [*:0]const u8) callconv(.c) c_int {
     var to_relative: [*:0]u8 = undefined;
     const to_dirfd = findRelpath(to, &to_relative);
-    if (to_dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (to_dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_renameat(fromdirfd, from, to_dirfd, to_relative);
 }
 
 fn wasilibcRenameNewatImpl(from: [*:0]const u8, todirfd: c_int, to: [*:0]const u8) callconv(.c) c_int {
     var from_relative: [*:0]u8 = undefined;
     const from_dirfd = findRelpath(from, &from_relative);
-    if (from_dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (from_dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     return __wasilibc_nocwd_renameat(from_dirfd, from_relative, todirfd, to);
 }
 
@@ -1207,12 +1265,21 @@ fn wasilibcMaybeReinitializeEnvironEagerlyStrong() callconv(.c) void {
     wasilibcInitializeEnvironImpl();
 }
 
+fn funcsOnExitImpl() callconv(.c) void {}
+
+fn wasmCallDtorsImpl() callconv(.c) void {
+    funcsOnExitImpl();
+    __stdio_exit();
+}
+
 // =========================================================================
 // __main_void.c (WASIP1 path)
 // =========================================================================
 extern fn __main_argc_argv(argc: usize, argv: [*:null]?[*:0]u8) c_int;
 
 fn mainVoidImpl() callconv(.c) c_int {
+    wasilibcInitializeEnvironEagerly();
+
     var argv_buf_size: usize = 0;
     var argc: usize = 0;
     var err = wasi.args_sizes_get(&argc, &argv_buf_size);
@@ -1379,7 +1446,10 @@ const Timespec = extern struct { tv_sec: i64, tv_nsec: i64 };
 fn utimeImpl(path: [*:0]const u8, times: ?*const Utimbuf) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     if (times) |t| {
         var ts: [2]Timespec = .{
             .{ .tv_sec = t.actime, .tv_nsec = 0 },
@@ -1393,7 +1463,10 @@ fn utimeImpl(path: [*:0]const u8, times: ?*const Utimbuf) callconv(.c) c_int {
 fn utimesImpl(path: [*:0]const u8, times: ?*const [2]Timeval) callconv(.c) c_int {
     var relative_path: [*:0]u8 = undefined;
     const dirfd = findRelpath(path, &relative_path);
-    if (dirfd == -1) { std.c._errno().* = ENOENT; return -1; }
+    if (dirfd == -1) {
+        std.c._errno().* = ENOENT;
+        return -1;
+    }
     if (times) |t| {
         var ts: [2]Timespec = .{
             .{ .tv_sec = t[0].tv_sec, .tv_nsec = t[0].tv_usec * 1000 },
@@ -1554,6 +1627,11 @@ comptime {
         symbol(&wasilibcMaybeReinitializeEnvironEagerlyImpl, "__wasilibc_maybe_reinitialize_environ_eagerly");
         symbol(&wasilibcInitializeEnvironEagerly, "__wasilibc_initialize_environ_eagerly");
         symbol(&wasilibc_environ_storage, "__wasilibc_environ");
+        symbol(&wasilibc_environ_storage, "__environ");
+        symbol(&wasilibc_environ_storage, "_environ");
+        symbol(&wasilibc_environ_storage, "environ");
+        symbol(&funcsOnExitImpl, "__funcs_on_exit");
+        symbol(&wasmCallDtorsImpl, "__wasm_call_dtors");
 
         // __main_void.c
         symbol(&mainVoidImpl, "__main_void");

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1805,10 +1805,11 @@ pub fn unlinkat(dirfd: i32, path: [*:0]const u8, flags: u32) usize {
 }
 
 pub fn waitpid(pid: pid_t, status: *u32, flags: u32) usize {
-    return syscall4(.wait4, @as(usize, @bitCast(@as(isize, pid))), @intFromPtr(status), flags, 0);
+    return wait4(pid, status, flags, null);
 }
 
 pub fn wait4(pid: pid_t, status: *u32, flags: u32, usage: ?*rusage) usize {
+    if (comptime !@hasField(SYS, "wait4")) return wait4Emulate(pid, status, flags, usage);
     return syscall4(
         .wait4,
         @as(usize, @bitCast(@as(isize, pid))),
@@ -1816,6 +1817,45 @@ pub fn wait4(pid: pid_t, status: *u32, flags: u32, usage: ?*rusage) usize {
         flags,
         @intFromPtr(usage),
     );
+}
+
+fn wait4Emulate(pid: pid_t, status: ?*u32, flags: u32, usage: ?*rusage) usize {
+    const WEXITED = 4;
+    var info: siginfo_t = undefined;
+    info.fields.common.first.piduid.pid = 0;
+
+    var id: pid_t = pid;
+    const id_type: P = if (pid < -1) blk: {
+        id = -pid;
+        break :blk .PGID;
+    } else if (pid == -1) .ALL else if (pid == 0) .PGID else .PID;
+
+    const rc = syscall5(
+        .waitid,
+        @intFromEnum(id_type),
+        @as(usize, @bitCast(@as(isize, id))),
+        @intFromPtr(&info),
+        flags | WEXITED,
+        @intFromPtr(usage),
+    );
+    const signed: isize = @bitCast(rc);
+    if (signed < 0) return rc;
+
+    const si_pid = info.fields.common.first.piduid.pid;
+    if (si_pid != 0) if (status) |sp| {
+        const si_status = info.fields.common.second.sigchld.status;
+        const code: CLD = @enumFromInt(info.code);
+        sp.* = switch (code) {
+            .CONTINUED => 0xffff,
+            .DUMPED => @as(u32, @intCast(si_status & 0x7f)) | 0x80,
+            .EXITED => @as(u32, @intCast(si_status & 0xff)) << 8,
+            .KILLED => @as(u32, @intCast(si_status & 0x7f)),
+            .STOPPED, .TRAPPED => (@as(u32, @bitCast(si_status)) << 8) + 0x7f,
+            else => 0,
+        };
+    };
+
+    return @intCast(si_pid);
 }
 
 pub fn waitid(id_type: P, id: i32, infop: *siginfo_t, flags: u32, usage: ?*rusage) usize {
@@ -2000,6 +2040,15 @@ pub fn settimeofday(tv: *const timeval, tz: *const timezone) usize {
 }
 
 pub fn nanosleep(req: *const timespec, rem: ?*timespec) usize {
+    if (comptime !@hasField(SYS, "nanosleep")) {
+        return syscall4(
+            if (@hasField(SYS, "clock_nanosleep") and native_arch != .hexagon) .clock_nanosleep else .clock_nanosleep_time64,
+            @intFromEnum(CLOCK.REALTIME),
+            0,
+            @intFromPtr(req),
+            @intFromPtr(rem),
+        );
+    }
     return syscall2(.nanosleep, @intFromPtr(req), @intFromPtr(rem));
 }
 


### PR DESCRIPTION
## Summary
- fixes the x86_64 libzigc varargs helper codegen failure by using C calling convention for VaList helpers
- adds RISC-V 32-bit fallbacks for generic/time64 Linux syscalls used by libzigc
- provides WASI environ aliases and __wasm_call_dtors so wasm32-wasi-musl links again
- makes x86_64, riscv32, and wasm32 cross-compile PR jobs required again

## Validation
- `zig build-exe /tmp/zig-libc-hello.c -target x86_64-linux-musl -lc --zig-lib-dir lib -fno-emit-bin`
- `zig build-exe /tmp/zig-libc-hello.c -target x86_64-linux-muslx32 -lc --zig-lib-dir lib -fno-emit-bin`
- `zig build-exe /tmp/zig-libc-hello.c -target riscv32-linux-musl -lc --zig-lib-dir lib -fno-emit-bin`
- `zig build-exe /tmp/zig-libc-hello.c -target wasm32-wasi-musl -lc --zig-lib-dir lib -fno-emit-bin`
- `actionlint -ignore 'label "nvme" is unknown' .github/workflows/pr-build.yml`