### PR TITLE
Fix x32 libc API validation

### DIFF
--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -115,7 +115,7 @@ jobs:
     needs: build-stage4
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    continue-on-error: ${{ matrix.allow_failure }}
+    continue-on-error: ${{ matrix.allow_failure && inputs.test-filter != 'api' }}
     strategy:
       fail-fast: false
       matrix:

--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -347,7 +347,7 @@ fn __zig_stack_chk_fail() callconv(.naked) noreturn {
 // __pthread_self() for the current arch.
 inline fn get_tp() usize {
     return switch (builtin.cpu.arch) {
-        .x86_64 => asm volatile ("movq %%fs:0, %[ret]"
+        .x86_64 => asm volatile ("mov %%fs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .x86 => asm volatile ("movl %%gs:0, %[ret]"

--- a/lib/c/env.zig
+++ b/lib/c/env.zig
@@ -347,9 +347,14 @@ fn __zig_stack_chk_fail() callconv(.naked) noreturn {
 // __pthread_self() for the current arch.
 inline fn get_tp() usize {
     return switch (builtin.cpu.arch) {
-        .x86_64 => asm volatile ("mov %%fs:0, %[ret]"
-            : [ret] "=r" (-> usize),
-        ),
+        .x86_64 => if (builtin.target.abi == .muslx32 or builtin.target.abi == .gnux32)
+            asm volatile ("movl %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            )
+        else
+            asm volatile ("movq %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            ),
         .x86 => asm volatile ("movl %%gs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),

--- a/lib/c/process.zig
+++ b/lib/c/process.zig
@@ -217,7 +217,7 @@ fn dummy0() callconv(.c) void {}
 
 fn pthreadSelfPtr() usize {
     const tp = switch (arch) {
-        .x86_64 => asm ("movq %%fs:0, %[ret]"
+        .x86_64 => asm ("mov %%fs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .x86 => asm ("movl %%gs:0, %[ret]"

--- a/lib/c/process.zig
+++ b/lib/c/process.zig
@@ -217,9 +217,14 @@ fn dummy0() callconv(.c) void {}
 
 fn pthreadSelfPtr() usize {
     const tp = switch (arch) {
-        .x86_64 => asm ("mov %%fs:0, %[ret]"
-            : [ret] "=r" (-> usize),
-        ),
+        .x86_64 => if (builtin.target.abi == .muslx32 or builtin.target.abi == .gnux32)
+            asm ("movl %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            )
+        else
+            asm ("movq %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            ),
         .x86 => asm ("movl %%gs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -939,9 +939,14 @@ fn mtx_unlock(mtx: ?*anyopaque) callconv(.c) c_int {
 /// Read the architecture-specific thread pointer register.
 fn get_tp() usize {
     return switch (arch) {
-        .x86_64 => asm ("mov %%fs:0, %[ret]"
-            : [ret] "=r" (-> usize),
-        ),
+        .x86_64 => if (builtin.target.abi == .muslx32 or builtin.target.abi == .gnux32)
+            asm ("movl %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            )
+        else
+            asm ("movq %%fs:0, %[ret]"
+                : [ret] "=r" (-> usize),
+            ),
         .x86 => asm ("movl %%gs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),

--- a/lib/c/thread.zig
+++ b/lib/c/thread.zig
@@ -939,7 +939,7 @@ fn mtx_unlock(mtx: ?*anyopaque) callconv(.c) c_int {
 /// Read the architecture-specific thread pointer register.
 fn get_tp() usize {
     return switch (arch) {
-        .x86_64 => asm ("movq %%fs:0, %[ret]"
+        .x86_64 => asm ("mov %%fs:0, %[ret]"
             : [ret] "=r" (-> usize),
         ),
         .x86 => asm ("movl %%gs:0, %[ret]"

--- a/lib/c/unistd.zig
+++ b/lib/c/unistd.zig
@@ -86,8 +86,7 @@ comptime {
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
         symbol(&swab, "swab");
     }
-    if (builtin.target.isWasiLibC()) {
-    }
+    if (builtin.target.isWasiLibC()) {}
 }
 
 fn _exit(exit_code: c_int) callconv(.c) noreturn {
@@ -255,9 +254,6 @@ fn fchownLinux(fd: c_int, owner: linux.uid_t, group: linux.gid_t) callconv(.c) c
     return errno(linux.fchown(fd, owner, group));
 }
 
-
-
-
 fn isattyLinux(fd: c_int) callconv(.c) c_int {
     var wsz: std.posix.winsize = undefined;
     if (errno(linux.ioctl(fd, linux.T.IOCGWINSZ, @intFromPtr(&wsz))) == 0) return 1;
@@ -273,10 +269,10 @@ fn pipe2Linux(fd: *[2]c_int, flags: c_int) callconv(.c) c_int {
 fn lseekLinux(fd: c_int, offset: linux.off_t, whence: c_int) callconv(.c) linux.off_t {
     const w: usize = @intCast(@as(c_uint, @bitCast(whence)));
     const signed: i64 = signed: {
-        if (@sizeOf(usize) >= 8) {
-            // 64-bit: kernel `lseek` syscall takes a 64-bit offset directly
-            // and returns the new position (or a negative errno) in a single
-            // register.
+        if (@sizeOf(usize) >= 8 or !@hasField(linux.SYS, "llseek")) {
+            // 64-bit and x32-style ABIs: kernel `lseek` syscall takes a 64-bit
+            // offset directly and returns the new position (or a negative
+            // errno) in a single register.
             break :signed @as(isize, @bitCast(linux.lseek(fd, offset, w)));
         }
         // 32-bit: kernel only has `_llseek` which takes a hi/lo offset pair


### PR DESCRIPTION
## Summary
- fix x32 lseek by using the direct syscall when llseek is absent
- use x32-compatible x86_64 thread-pointer inline asm
- make API-only test-libc runs fail even for advisory target groups

## Validation
- zig build-exe /tmp/zig-libc-lseek.c -target x86_64-linux-muslx32 -lc --zig-lib-dir lib -fno-emit-bin
- zig build-exe /tmp/zig-libc-lseek.c -target x86_64-linux-musl -lc --zig-lib-dir lib -fno-emit-bin
- zig build-exe /tmp/zig-libc-pthread-self.c -target x86_64-linux-muslx32 -lc --zig-lib-dir lib -fno-emit-bin
- zig build-exe /tmp/zig-libc-pthread-self.c -target x86_64-linux-musl -lc --zig-lib-dir lib -fno-emit-bin
- actionlint -ignore 'label "nvme" is unknown' .github/workflows/test-libc.yml\n- git diff --check