### PR TITLE
ci: make s390x-linux-musl PR cross-compile required

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -387,7 +387,7 @@ jobs:
           - target: powerpc64le-linux-musl
             allow_failure: false
           - target: s390x-linux-musl
-            allow_failure: true
+            allow_failure: false
           - target: loongarch64-linux-musl
             allow_failure: false
           - target: loongarch64-linux-muslsf


### PR DESCRIPTION
## Summary
- promote `s390x-linux-musl` PR cross-compile job from advisory to required

## Context
The job has been passing on recent merged PRs (#523, #524). With this change, future regressions will block PR merges instead of being silently advisory.

## Validation
- `zig build-exe --zig-lib-dir lib -target s390x-linux-musl -mcpu baseline -lc -fno-emit-bin <hello.zig>` succeeds locally
- workflow yaml parses
- only `allow_failure: true` -> `false` for s390x in `pr-cross-compile`