### PR TITLE
ci: run curated functional libc-test subset (advisory)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -308,9 +308,66 @@ jobs:
           echo "libc-test commit: $libc_test_sha"
           echo "LIBC_TEST_SHA=$libc_test_sha" >> "$GITHUB_ENV"
 
-      - name: Skip libc-test — functional (aarch64-linux-musl, native)
+      - name: Run libc-test — functional subset (aarch64-linux-musl, native)
+        timeout-minutes: 30
+        continue-on-error: true
         run: |
-          echo "::warning::Temporarily skipping known-hanging native functional libc-test slice on libc/0.16.x."
+          set -euo pipefail
+          if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
+          if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
+          # Curated subset of functional libc-test sources to avoid known-hanging
+          # areas while libzigc migration is in flight. Excluded by category:
+          #   - pthread_*    (mutex/cond/cancel/rwlock/tsd/robust still in flux)
+          #   - sem_*        (POSIX semaphores depend on pthread internals)
+          #   - ipc_*        (SysV msg/sem/shm need kernel + cleanup)
+          #   - dlopen*      (dynamic linking not exercised by static link)
+          #   - tls_*        (TLS migration tracked in #491)
+          #   - spawn, popen, vfork (fork/exec/vfork)
+          # Each filter is a substring match (see test/src/Libc.zig).
+          filters=(
+            functional.argv
+            functional.basename
+            functional.clocale_mbfuncs
+            functional.clock_gettime
+            functional.crypt
+            functional.dirent
+            functional.dirname
+            functional.env
+            functional.fcntl
+            functional.fdopen
+            functional.fnmatch
+            functional.iconv_open
+            functional.inet_pton
+            functional.mbc
+            functional.memstream
+            functional.mntent
+            functional.qsort
+            functional.random
+            functional.search
+            functional.scanf
+            functional.setjmp
+            functional.snprintf
+            functional.socket
+            functional.stat
+            functional.str
+            functional.swprintf
+            functional.tgmath
+            functional.time
+            functional.udiv
+            functional.ungetc
+            functional.utime
+            functional.wcsstr
+            functional.wcstol
+          )
+          args=()
+          for f in "${filters[@]}"; do args+=("-Dtest-filter=$f"); done
+          "$STAGE4/bin/zig" build test-libc \
+              --zig-lib-dir lib \
+              -Dlibc-test-path="$CACHE_ROOT/libc-test" \
+              -Dtest-target-filter="${TARGET}" \
+              "${args[@]}" \
+              -j2 \
+              --summary failures
 
       - name: Run libc-test — api (aarch64-linux-musl, native)
         timeout-minutes: 20


### PR DESCRIPTION
## Summary
- replace unconditional `Skip libc-test — functional` step with a curated subset
- excludes known-flux areas (pthread/sem/ipc/dlopen/tls/spawn/popen/vfork)
- advisory (`continue-on-error: true`) and bounded (`timeout-minutes: 30`)

## Why
The step was skipping all 77 functional tests because some hang. Most are pure-library and worth exercising. This unblocks coverage incrementally.

## Filters used
```
functional.argv, basename, clocale_mbfuncs, clock_gettime, crypt, dirent,
dirname, env, fcntl, fdopen, fnmatch, iconv_open, inet_pton, mbc, memstream,
mntent, qsort, random, search, scanf, setjmp, snprintf, socket, stat, str,
swprintf, tgmath, time, udiv, ungetc, utime, wcsstr, wcstol
```

Each is a substring filter (`test/src/Libc.zig:82`), so e.g. `functional.search`
matches all `search_*` tests and `functional.str` matches `string`, `string_*`,
`strptime`, `strtod*`, `strtof`, `strtol`, `strtold`, `strftime`.

## Excluded categories
- `pthread_*` (mutex/cond/cancel/rwlock/tsd/robust migration in flux)
- `sem_*` (POSIX semaphores depend on pthread internals)
- `ipc_*` (SysV msg/sem/shm need kernel state cleanup)
- `dlopen*` (dynamic linking)
- `tls_*` (TLS migration tracked in #491)
- `spawn`, `popen`, `vfork`

## Plan
1. Land advisory subset (this PR).
2. Observe CI — if any subset entry hangs, narrow it.
3. Once green, promote to required.
4. Follow-up PR will do the same for `regression` slice.
5. Related triage: #526 (math), #454 (libc-test promotion roadmap).