### PR TITLE
musl: add siglongjmp.c and sigsetjmp_tail.c to manifest

### DIFF
--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -669,6 +669,8 @@ const src_files = [_][]const u8{
     "musl/src/signal/s390x/restore.s",
     "musl/src/signal/s390x/sigsetjmp.s",
     "musl/src/signal/sigaction.c",
+    "musl/src/signal/siglongjmp.c",
+    "musl/src/signal/sigsetjmp_tail.c",
     "musl/src/signal/x32/restore.s",
     "musl/src/signal/x32/sigsetjmp.s",
     "musl/src/signal/x86_64/restore.s",


### PR DESCRIPTION
## Summary

Adds `musl/src/signal/siglongjmp.c` and `musl/src/signal/sigsetjmp_tail.c` to the musl source manifest.

## Why

`functional.setjmp` libc-test fails at link with:

```
ld.lld: undefined hidden symbol: __sigsetjmp_tail
ld.lld: undefined symbol: siglongjmp
```

(Observed in the libc-test functional subset run on `aarch64-linux-musl` — see #527 results captured in #529.)

The musl assembly entry points `sigsetjmp.s` for every arch end with a `b __sigsetjmp_tail` tail call to the C helper, and `siglongjmp.c` is a tiny wrapper around `longjmp`. Both were missing from `src/libs/musl.zig`, so `libc.a` did not contain either symbol.

## Fix

Add both source files to the manifest. They are not migrated to `lib/c/` — there's no Zig replacement, and they're small enough that no migration is needed.

## Validation

- `scripts/check_musl_migration.py` passes
- Both source files exist under `lib/libc/musl/src/signal/`
- Inserted in alphabetical order (`siglongjmp` < `sigsetjmp_tail` < `x32/`)

## Effect

The functional.setjmp test should now link. It still has to pass at runtime, but the link blocker is gone.

## Related

- #527, #528 (subset PRs)
- #529 (failure triage)
