### PR TITLE
ci: drop iconv tests from curated libc-test subsets

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -351,7 +351,6 @@ jobs:
             functional.fcntl
             functional.fdopen
             functional.fnmatch
-            functional.iconv_open
             functional.inet_pton
             functional.mbc
             functional.memstream
@@ -437,7 +436,6 @@ jobs:
             regression.fpclassify-invalid-ld80
             regression.ftello-unflushed-append
             regression.getpwnam_r-
-            regression.iconv-roundtrips
             regression.inet_
             regression.iswspace-null
             regression.lrand48-signextend


### PR DESCRIPTION
## Summary

Remove `functional.iconv_open` and `regression.iconv-roundtrips` from the curated libc-test subsets in `.github/workflows/pr-build.yml`.

## Why

Both fail at link with:

```
ld.lld: undefined symbol: iconv_open
```

The iconv stack is not migrated yet — `lib/c/locale.zig` only exports `iconv` and `iconv_close` stubs. Either a real `iconv_open` plus charset tables and conversion logic land, or these tests cannot pass.

Keeping them in the subset just adds 8 advisory failures (2 tests × 4 optimize modes) to every PR run without any signal value. Drop them; they should be re-added once iconv migration lands.

## Effect

After this PR plus the existing #531 setjmp fix, the advisory failure surface should be:

| Subset | Before | After |
|---|---|---|
| functional | 40 failed / 369 | 36 failed / 365 |
| regression | 48 failed / 377 | 44 failed / 373 |

## Related

- #527, #528 (subset PRs)
- #529 (failure triage)
- #531 (setjmp fix)
