### PR TITLE
regex: fix REG_ESPACE returned for every regexec call

### DIFF
--- a/lib/c/regex.zig
+++ b/lib/c/regex.zig
@@ -2655,8 +2655,21 @@ fn treTnfaRunParallel(
 
     const num_tags: c_int = if (match_tags != null) tnfa.num_tags else 0;
 
-    if (tnfa.num_states == 0 or num_tags > @as(c_int, @intCast(std.math.maxInt(usize) / (8 * @sizeOf(regoff_t)) / @as(usize, @intCast(tnfa.num_states)))))
-        if (tnfa.num_states > 0) return REG_ESPACE;
+    // Overflow guard mirroring musl tre regexec: bail if num_tags is so
+    // large that allocating the per-state work area would overflow size_t.
+    // The original C compares `num_tags > SIZE_MAX / ... / num_states` with
+    // implicit unsigned promotion. The previous Zig port wrapped the right
+    // side in @intCast(c_int, ...), which truncated to a negative value for
+    // typical (small) num_states and caused regexec to return REG_ESPACE
+    // for every regex.
+    if (tnfa.num_states > 0) {
+        const max_per_state = std.math.maxInt(usize) / (8 * @sizeOf(regoff_t)) /
+            @as(usize, @intCast(tnfa.num_states));
+        if (num_tags < 0 or @as(usize, @intCast(num_tags)) > max_per_state)
+            return REG_ESPACE;
+    }
+    // If num_states == 0 (or somehow negative), fall through; the allocation
+    // sizes below evaluate to zero/small and the run loop is a no-op.
 
     const tbytes = @sizeOf(regoff_t) * @as(usize, @intCast(num_tags));
     const rbytes = @sizeOf(TreReach) * @as(usize, @intCast(tnfa.num_states + 1));


### PR DESCRIPTION
## Summary

Fix `treTnfaRunParallel` overflow guard that caused every `regexec` call to return `REG_ESPACE` (Out of memory).

## Root cause

The original guard:

```zig
if (tnfa.num_states == 0 or num_tags > @as(c_int, @intCast(
    std.math.maxInt(usize) / (8 * @sizeOf(regoff_t))
    / @as(usize, @intCast(tnfa.num_states))
)))
    if (tnfa.num_states > 0) return REG_ESPACE;
```

The right-hand side of the comparison computes `SIZE_MAX / 32 / num_states`, which for any reasonable `num_states` is roughly `2^59 / num_states`. The outer `@as(c_int, @intCast(...))` then truncates that to `i32`. The low 32 bits of those huge values interpreted as `i32` are negative for typical small `num_states`:

| `num_states` | rhs (size_t) | low 32 bits as `i32` |
|---|---|---|
| 1 | 5.76 × 10¹⁷ | **-1** |
| 2 | 2.88 × 10¹⁷ | **-1** |
| 5 | 1.15 × 10¹⁷ | **-1717986919** |
| 10 | 5.76 × 10¹⁶ | **-858993460** |
| 20 | 2.88 × 10¹⁶ | 1717986918 |

So `num_tags > negative_sentinel` is true for any non-negative `num_tags`, the outer `if` fires, and since `num_states > 0` we return `REG_ESPACE` — for every regex with `num_states` small enough that the truncation flips sign.

## Effect

Six libc-test regression tests fail today because of this with errors like:

```
src/regression/regex-bracket-icase.c:41: regexec(/[^aBcC]/, "a")
  returned 12 (Out of memory), wanted 1
```

- `regex-backref-0`
- `regex-bracket-icase`
- `regex-ere-backref`
- `regex-escaped-high-byte`
- `regex-negated-range`
- `regexec-nosub`

## Fix

Do the overflow check in `usize` space, never round the budget back through `c_int`:

```zig
if (tnfa.num_states > 0) {
    const max_per_state =
        std.math.maxInt(usize) / (8 * @sizeOf(regoff_t))
        / @as(usize, @intCast(tnfa.num_states));
    if (num_tags < 0 or @as(usize, @intCast(num_tags)) > max_per_state)
        return REG_ESPACE;
}
```

This matches the original musl tre C semantics (`SIZE_MAX / sizeof(regoff_t) / 8 / tnfa->num_states`) without the truncation.

## Validation

- `treTnfaRunBacktrack` doesn't have the same pattern (uses `std.c.malloc` directly).
- Other `@intCast` to `c_int` in `lib/c/regex.zig` don't compare against `maxInt(usize)`.

## Related

- #527, #528 (subsets), #529 (triage), #531 (setjmp), #532 (drop iconv)
