### PR TITLE
ctype: fix towupper/towlower for ASCII letters

### DIFF
--- a/lib/c/ctype.zig
+++ b/lib/c/ctype.zig
@@ -1494,10 +1494,19 @@ fn casemap(c_arg: c_uint, dir: u1) c_uint {
 }
 
 fn towupper_fn(wc: wint_t) callconv(.c) wint_t {
+    // ASCII fast path mirrors musl's towupper().
+    // casemap()'s tables are designed for non-ASCII (Unicode general
+    // category rules) and do not produce correct results for ASCII letters.
+    if (wc < 128) {
+        return if (wc -% 'a' < 26) wc - 32 else wc;
+    }
     return casemap(wc, 1);
 }
 
 fn towlower_fn(wc: wint_t) callconv(.c) wint_t {
+    if (wc < 128) {
+        return if (wc -% 'A' < 26) wc + 32 else wc;
+    }
     return casemap(wc, 0);
 }
 


### PR DESCRIPTION
## Summary

Fix `towupper(wint_t)` and `towlower(wint_t)` for ASCII letters. They were returning the input unchanged instead of switching case.

## Root cause

`lib/c/ctype.zig`:

```zig
fn towupper_fn(wc: wint_t) callconv(.c) wint_t {
    return casemap(wc, 1);
}
```

`casemap()` (and its tables `casemap_tab`, `casemap_rules`, `casemap_rulebases`) is a transcription of musl's `__casemap`, which is designed for **non-ASCII** (Unicode general category rules). For ASCII letters its table lookup yields `rt=1` (already uppercase) for `'a'`, so `towupper('a')` returns `97` instead of `65`.

The C original in musl is:

```c
wint_t towupper(wint_t wc) {
    if (wc<128) return (unsigned)wc-'a' < 26 ? wc-32 : wc;
    return __casemap(wc, 1);
}
```

The Zig port dropped the ASCII fast path. As a result:

- `towupper(97)` returned `97` instead of `65`
- `towlower(66)` returned `66` instead of `98`
- `iswlower(97)` returned `0` (because `iswlower_fn` is `@intFromBool(towupper_fn(wc) != wc)`)
- `iswupper(66)` returned `0`

This silently broke any code path that relies on wide-char case classification.

## Effect

The immediate test failure exposed by this:

```
regression.regex-bracket-icase.c:41: regexec(/[^aBcC]/i, "A") returned 0, wanted 1
regression.regex-bracket-icase.c:41: regexec(/[^aBcC]/i, "b") returned 0, wanted 1
```

`lib/c/regex.zig:addIcaseLiterals()` uses `iswlower`/`iswupper` to decide whether to add the opposite-case literal for each bracket char. With both classifiers returning `0`, the icase expansion silently did nothing, so the bracket only contained the literal characters from the pattern; `'A'` and `'b'` slipped through the negation.

## Fix

Add the musl ASCII fast path to both `towupper_fn` and `towlower_fn`:

```zig
fn towupper_fn(wc: wint_t) callconv(.c) wint_t {
    if (wc < 128) {
        return if (wc -% 'a' < 26) wc - 32 else wc;
    }
    return casemap(wc, 1);
}

fn towlower_fn(wc: wint_t) callconv(.c) wint_t {
    if (wc < 128) {
        return if (wc -% 'A' < 26) wc + 32 else wc;
    }
    return casemap(wc, 0);
}
```

## Validation

Built stage4 + linked the test against in-tree `lib/`:

```
Before:
  iswlower(97)=0  iswupper(66)=0
  towupper(97)=97 towlower(66)=66
  regexec(/[^aBcC]/i, "A") = 0  (wanted 1)
  regexec(/[^aBcC]/i, "b") = 0  (wanted 1)

After:
  iswlower(97)=1  iswupper(66)=1
  towupper(97)=65 towlower(66)=98
  regexec(/[^aBcC]/i, "A") = 1
  regexec(/[^aBcC]/i, "b") = 1
  regexec(/[^aBcC]/i, "d") = 0  (correct match)
  regexec(/[^aBcC]/i, "D") = 0  (correct match)
```

`std.ascii.isLower` / `std.ascii.isUpper` based byte-level `islower`/`isupper` aren't affected — only the wide-char variants.

## Related

- #527, #528 (subsets), #529 (triage), #531 (setjmp), #532 (drop iconv), #533 (regex ESPACE)
