### PR TITLE
fnmatch: fix escape byte count and EOS during component scan

### DIFF
--- a/lib/c/regex.zig
+++ b/lib/c/regex.zig
@@ -3478,7 +3478,7 @@ fn patNext(pat: [*]const u8, m: usize, step: *usize, flags: c_int) c_int {
     }
     step.* = 1;
     if (pat[0] == '\\' and pat[1] != 0 and flags & FNM_NOESCAPE == 0) {
-        step.* = 2;
+        esc = 1;
         return patNextEscaped(pat + 1, m - 1, step, &esc);
     }
     if (pat[0] == '[') {
@@ -3724,10 +3724,7 @@ fn fnmatchInternal(
                 break :comp_loop;
             }
             k = strNext(s, @intFromPtr(endstr2) - @intFromPtr(s), &sinc);
-            if (k == 0) {
-                // failed
-                break :comp_loop;
-            }
+            if (k == 0) return FNM_NOMATCH;
             const kfold2: c_int = if (flags & FNM_CASEFOLD != 0) casefold(k) else k;
             if (c == FNM_BRACKET) {
                 if (matchBracket(p - pinc, k, kfold2) == 0) break :comp_loop;


### PR DESCRIPTION
Two independent bugs in `lib/c/regex.zig` make `functional.fnmatch` fail.

## 1. `patNext` mishandles `\X` escapes for ASCII metacharacters

The musl reference (`src/regex/fnmatch.c`) for the `\X` escape branch is:

```c
*step = 2;
pat++;
esc = 1;
goto escaped;
```

With `esc = 1` the high-byte branch at the `escaped:` label sets `*step = k + esc` and the ASCII branch leaves `*step` alone (so it stays at the 2 written before the goto).

The Zig translation set `step.* = 2;` then called `patNextEscaped` with `esc = 0`, and `patNextEscaped`'s ASCII path (`step.* = 1 + esc.*`) clobbered the 2 back to 1. Escaped ASCII metacharacters (e.g. `\?`, `\[`, `\/`) advanced the pattern cursor by 1 instead of 2 and got re-tokenised as wildcards.

Fix: set `esc = 1` before the tail call so the ASCII branch lands on `1 + 1 = 2`.

## 2. `fnmatchInternal` middle loop continues past end-of-string

musl's "sea of stars" middle loop returns `FNM_NOMATCH` immediately when `str_next` reports the string exhausted:

```c
    return FNM_NOMATCH;
```

The Zig version did `break :comp_loop` and then tried to advance `str2` past `endstr2`, after which `strNext(str2, endstr2-str2, ...)` ran on a wrapped-around `usize` length. Pattern `*LIB*` matched `lib` because of this fall-through.

Match musl: return `FNM_NOMATCH` directly.

## Verification

Verified on aarch64-linux-musl. Four of the five failing `functional.fnmatch` cases are now passing:

- ✅ `fnmatch("\?/b", "?/b", 0)` — was returning 1, now 0
- ✅ `fnmatch("\[/b", "[/b", 0)` — was returning 1, now 0
- ✅ `fnmatch("\/", "/", FNM_PATHNAME)` — was returning 1, now 0
- ✅ `fnmatch("*LIB*", "lib", FNM_PERIOD)` — was returning 0, now 1
- ❌ `fnmatch("*[[:alpha:]]/*[[:alnum:]]", "a/b", FNM_PATHNAME)` — hits a separate `tableLookup` bug in `lib/c/ctype.zig` (tracked separately)

Refs #529.