### PR TITLE
ctype: widen tableLookup multiplication before u8 wrap

### DIFF
--- a/lib/c/ctype.zig
+++ b/lib/c/ctype.zig
@@ -1337,7 +1337,15 @@ const casemap_exceptions = [_][2]u8{
 };
 
 fn tableLookup(table: []const u8, wc: c_uint) bool {
-    return (table[table[wc >> 8] *% 32 +% ((wc & 255) >> 3)] >> @intCast(wc & 7)) & 1 != 0;
+    // `table[b]` is a u8 page index that must be widened before
+    // multiplication: musl's two-level lookup uses pages of 32 bytes,
+    // so page_index * 32 routinely overflows u8 (e.g. page index 18
+    // for ASCII characters yields 18 * 32 = 576). The previous version
+    // used `*%` and `+%`, which wrapped to u8 and produced incorrect
+    // bit positions for any page index >= 8.
+    const page: c_uint = table[wc >> 8];
+    const idx: c_uint = page * 32 + ((wc & 255) >> 3);
+    return (table[idx] >> @intCast(wc & 7)) & 1 != 0;
 }
 
 fn iswalpha_fn(wc: wint_t) callconv(.c) c_int {


### PR DESCRIPTION
## Bug

`tableLookup` performs a two-level lookup that mirrors musl's ctype tables: `table[wc >> 8]` indexes a 256-entry page table, and that page index is multiplied by 32 (the bytes per page) and added to a within-page bit offset.

The previous version used `*%` and `+%`, which wrap at u8 (the table element type). Page indices >= 8 (which includes most ASCII — for `alpha_table` the page-0 index is 18) produced `18 *% 32 = 64` instead of 576, so every ASCII character mapped to the wrong bit in the wrong row, and `iswalpha`/`iswalnum`/`iswpunct`/`wcwidth` returned 0 for ASCII letters.

Equivalent C code (`musl src/ctype/iswalpha.c`):

```c
return ((alpha[(__alphatab[wc>>8])*32+((wc&255)>>3)]>>(wc&7))&1);
```

C's integer promotion widens `unsigned char` to `int` before multiplication, so this works correctly. The Zig translation kept the result as `u8` and wrapped silently.

## Fix

Widen the page index to `c_uint` before multiplying and adding the within-page offset.

## Verification

Verified on aarch64-linux-musl (`zig run` against libzigc):

| Call | Before | After |
|---|---|---|
| `iswalpha('a')` | 0 | 1 |
| `iswalnum('a')` | 0 | 1 |
| `iswpunct('!')` | 0 | 1 |
| `iswpunct('.')` | 0 | 1 |
| `wcwidth(0x4E2D)` (中) | 1 | 2 |

Combined with #536 this clears the last failing `functional.fnmatch` case (`*[[:alpha:]]/*[[:alnum:]]` vs `a/b`).

Other callers of `tableLookup` (`iswpunct_fn`, `wcwidth_fn` via `nonspacing_table` and `wide_table`) are also fixed by this change.

Refs #529.