### PR TITLE
search: set errno=ENOMEM on hcreate_r allocation failure

### DIFF
--- a/lib/c/search.zig
+++ b/lib/c/search.zig
@@ -357,13 +357,17 @@ fn resize(tab: *Tab, nel: usize) bool {
 
 fn hcreate_rImpl(nel: usize, htab: *HSearchData) callconv(.c) c_int {
     const tab_ptr: ?*Tab = @ptrCast(@alignCast(std.c.malloc(@sizeOf(Tab))));
-    if (tab_ptr == null) return 0;
+    if (tab_ptr == null) {
+        std.c._errno().* = @intFromEnum(std.os.linux.E.NOMEM);
+        return 0;
+    }
     const tab = tab_ptr.?;
     tab.entries = null;
     tab.mask = 0;
     tab.used = 0;
     if (!resize(tab, nel)) {
         std.c.free(@ptrCast(tab));
+        std.c._errno().* = @intFromEnum(std.os.linux.E.NOMEM);
         return 0;
     }
     htab.tab = tab;


### PR DESCRIPTION
## Bug

`hcreate((size_t)-1)` should fail with `errno=ENOMEM`, but `hcreate_rImpl` returned 0 without touching errno on either the `malloc` failure path or the `resize` failure path. `libc-test`'s `functional.search_hsearch` checks for this:

```
hcreate((size_t)-1) should fail with ENOMEM got No error information
```

## Fix

Match musl's `__hcreate_r` (src/search/hsearch_r.c): set `errno = ENOMEM` before returning 0 in both failure branches.

## Verification

Verified on aarch64-linux-musl: `functional.search_hsearch` now passes in all 4 optimize modes.

Refs #529.