### PR TITLE
string: fix strverscmp sign for trailing NUL vs digit

### DIFF
--- a/lib/c/string.zig
+++ b/lib/c/string.zig
@@ -469,7 +469,11 @@ fn strverscmp_fn(l0: [*:0]const u8, r0: [*:0]const u8) callconv(.c) c_int {
         }
         if (std.ascii.isDigit(r0[j])) return -1;
     } else if (z and dp < i and (std.ascii.isDigit(l0[i]) or std.ascii.isDigit(r0[i]))) {
-        return @as(c_int, l0[i]) - @as(c_int, '0') - (@as(c_int, r0[i]) - @as(c_int, '0'));
+        // Match musl: `(unsigned char)(l[i]-'0') - (unsigned char)(r[i]-'0')`.
+        // The differences must wrap as u8 *before* widening, so e.g.
+        // 'NUL'-'0' becomes 208, not -48. Otherwise comparing "00" vs "000"
+        // returns the wrong sign.
+        return @as(c_int, l0[i] -% '0') - @as(c_int, r0[i] -% '0');
     }
 
     return @as(c_int, l0[i]) - @as(c_int, r0[i]);


### PR DESCRIPTION
## Bug

`strverscmp("00", "000")` should return `>0` and `strverscmp("000", "00")` should return `<0`. The Zig translation returned the opposite sign because the digit-vs-NUL difference was widened to `c_int` *before* wrapping at `unsigned char` width:

```zig
return @as(c_int, l0[i]) - @as(c_int, '0') - (@as(c_int, r0[i]) - @as(c_int, '0'));
```

When `r[i]` is the terminating NUL, the inner difference was `-48` (signed), so the function returned `+48` instead of musl's expected `-208`.

## Fix

Match musl's reference (`src/string/strverscmp.c`):

```c
return (unsigned char)(l[i]-'0') - (unsigned char)(r[i]-'0');
```

Wrap each side at `u8` first, then widen to `c_int` for the final subtraction:

```zig
return @as(c_int, l0[i] -% '0') - @as(c_int, r0[i] -% '0');
```

## Verification

Verified on aarch64-linux-musl. `regression.strverscmp` now passes in all 4 optimize modes.

Refs #529.