### PR TITLE
network: use @truncate to encode IPv6 hextet bytes

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -764,8 +764,16 @@ fn inet_pton_impl(af: c_int, s0: [*:0]const u8, a0: *anyopaque) callconv(.c) c_i
     var out: [*]u8 = a;
     var j: usize = 0;
     while (j < 8) : (j += 1) {
-        out[0] = @intCast(ip[j] >> 8);
-        out[1] = @intCast(ip[j]);
+        // musl `out[0] = ip[j]>>8; out[1] = ip[j];` — both rely on the
+        // implicit C truncation from unsigned short to unsigned char.
+        // `@intCast(ip[j])` is undefined behaviour whenever `ip[j] > 0xff`,
+        // which LLVM exploits in optimised builds to assume `ip[j] < 256`
+        // and propagate that back through the parsing loop, silently
+        // dropping the high byte of every group (so `ffff` decodes as
+        // `00 ff`). Use `@truncate` to make the byte truncation explicit
+        // and well-defined.
+        out[0] = @truncate(ip[j] >> 8);
+        out[1] = @truncate(ip[j]);
         out += 2;
     }
     if (need_v4 and inet_pton_impl(linux.AF.INET, s, a + 12) <= 0) return 0;


### PR DESCRIPTION
## Bug

The IPv6 byte-encoding loop in `inet_pton_impl` used `@intCast` to truncate each u16 group to u8, but `@intCast(u16 -> u8)` is undefined behaviour whenever the value exceeds `0xff`. LLVM exploited that UB in optimised builds to assume every `ip[j] < 256` and propagated the assumption back through the hex parse loop, so any hextet `>= 0x100` silently lost its high byte:

```
inet_pton(AF_INET6, "ffff::", a)              -> 00 ff 00 00 00 00 ...
inet_pton(AF_INET6, "::ffff:1.2.3.4", a)      -> ... 00 ff 01 02 03 04
```

This in turn broke the v4-mapped detection in `inet_ntop_impl` (`a[10..12] == ff ff` was never true), causing `regression.inet_ntop-v4mapped` to render `::ff:c0a8:1` instead of `::ffff:192.168.0.1`.

## Fix

Match musl's implicit unsigned-short → unsigned-char truncation with `@truncate`, which is well-defined for all values:

```zig
out[0] = @truncate(ip[j] >> 8);
out[1] = @truncate(ip[j]);
```

## Verification

Verified on aarch64-linux-musl. `regression.inet_ntop-v4mapped` now passes in all 4 optimize modes.

`functional.inet_pton` still has other failures unrelated to this bug (tracked separately).

Refs #529.