### PR TITLE
signal: reject sub-userspace stacks in sigaltstack

### DIFF
--- a/lib/c/signal.zig
+++ b/lib/c/signal.zig
@@ -194,7 +194,7 @@ fn sigpendingLinux(set: *linux.sigset_t) callconv(.c) c_int {
 
 fn sigaltstackLinux(ss: ?*const linux.stack_t, old: ?*linux.stack_t) callconv(.c) c_int {
     if (ss) |s| {
-        if (s.flags & linux.SS.DISABLE == 0 and s.size < linux.MINSIGSTKSZ) {
+        if (s.flags & linux.SS.DISABLE == 0 and s.size < MINSIGSTKSZ) {
             std.c._errno().* = @intFromEnum(linux.E.NOMEM);
             return -1;
         }
@@ -205,6 +205,19 @@ fn sigaltstackLinux(ss: ?*const linux.stack_t, old: ?*linux.stack_t) callconv(.c
     }
     return errno(linux.sigaltstack(ss, old));
 }
+
+// musl-userspace `MINSIGSTKSZ` (from `arch/<arch>/bits/signal.h`). These
+// values intentionally differ from `std.os.linux.MINSIGSTKSZ`, which is
+// the kernel UAPI minimum; the userspace value is generally larger
+// because it includes space for libc bookkeeping. `sigaltstack` must
+// reject sub-userspace-minimum stacks with `ENOMEM` so that musl-built
+// libc-test cases (e.g. `regression.sigaltstack`) see the same
+// behaviour they see against musl.
+const MINSIGSTKSZ: usize = switch (builtin.cpu.arch) {
+    .aarch64, .aarch64_be => 6144,
+    .loongarch32, .loongarch64, .powerpc, .powerpcle, .powerpc64, .powerpc64le, .s390x => 4096,
+    else => 2048,
+};
 
 fn sigprocmaskLinux(how: c_int, noalias set: ?*const linux.sigset_t, noalias old: ?*linux.sigset_t) callconv(.c) c_int {
     const rc = linux.sigprocmask(@bitCast(@as(u32, @bitCast(how))), set, old);


### PR DESCRIPTION
## Bug

`regression.sigaltstack` expects `sigaltstack` to fail with `ENOMEM` whenever `ss_size < MINSIGSTKSZ` (the userspace value exposed via musl's `arch/<arch>/bits/signal.h`).

The libzigc wrapper was comparing against `std.os.linux.MINSIGSTKSZ`, which is the kernel UAPI minimum. On most architectures those values match, but on aarch64 the kernel value is `5120` while the userspace value is `6144`, so the wrapper accepted stacks musl-built code expects it to reject:

```c
ss.ss_size = MINSIGSTKSZ-1; // = 6143 on aarch64
sigaltstack(&ss, 0);        // returned 0 instead of -1/ENOMEM
```

## Fix

Mirror musl's per-arch userspace values inside the wrapper so the rejection happens at the right threshold:

| arch | userspace MINSIGSTKSZ |
|---|---|
| aarch64 / aarch64_be | 6144 |
| loongarch{32,64}, powerpc{,le,64,64le}, s390x | 4096 |
| rest | 2048 |

These match `lib/libc/musl/arch/<arch>/bits/signal.h`.

## Verification

Verified on aarch64-linux-musl: `regression.sigaltstack` now passes in all 4 optimize modes.

Refs #529.