### PR TITLE
ci: keep more stage4 caches and protect in-use ones from prune

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -217,12 +217,17 @@ jobs:
           fi
           echo "STAGE4=$STAGE4" >> "$GITHUB_ENV"
 
-      - name: Prune old stage4 caches (keep 4 most recent)
+      - name: Prune old stage4 caches (keep 24 most recent)
         if: always()
         run: |
           set -euo pipefail
           cd "$CACHE_ROOT"
-          ls -1dt stage4-* 2>/dev/null | tail -n +5 | xargs -r rm -rf || true
+          # Keep enough caches that downstream jobs (pr-libc-test,
+          # pr-cross-compile) of older in-flight PRs can still find
+          # their stage4 even after several newer pr-build jobs
+          # have completed and pruned. Each stage4 is ~150MB; 24
+          # entries fit comfortably on the runner's NVMe.
+          ls -1dt stage4-* 2>/dev/null | tail -n +25 | xargs -r rm -rf || true
           echo "stage4 caches retained:"
           ls -1dt stage4-* 2>/dev/null || true
 
@@ -306,6 +311,10 @@ jobs:
               exit 1
           fi
           "$STAGE4/bin/zig" version
+          # Bump mtime so concurrent pr-build prune steps (which sort
+          # by mtime) treat this stage4 as recently-used and don't
+          # evict it while this job is still running.
+          touch "$STAGE4" || true
           echo "STAGE4=$STAGE4" >> "$GITHUB_ENV"
 
       - name: Update libc-test checkout (log SHA for forensics)
@@ -548,6 +557,10 @@ jobs:
               exit 1
           fi
           "$STAGE4/bin/zig" version
+          # Bump mtime so concurrent pr-build prune steps (which sort
+          # by mtime) treat this stage4 as recently-used and don't
+          # evict it while this job is still running.
+          touch "$STAGE4" || true
           echo "STAGE4=$STAGE4" >> "$GITHUB_ENV"
 
       - name: Cross-compile hello (${{ matrix.target }})


### PR DESCRIPTION
When multiple PRs run pr-build in parallel, the previous "keep 4 most recent" prune step evicts the stage4 produced by older in-flight builds before their downstream pr-libc-test and pr-cross-compile jobs can run. Every downstream job for those PRs then fails with:

```
ERROR: stage4 not found at $STAGE4 (build job should have produced it)
```

This was observed on PRs #535-#542 (eight concurrent libzigc fixes): pr-build succeeded on every one, but the cache prune kept only 4 stage4 dirs while 8 sets of downstream jobs were still queued behind the runner, so 4 of 8 PRs had all their downstream jobs marked as failed for purely infra reasons.

## Changes

- Bump the keep-count from 4 to 24. Each stage4 is ~150MB, so 24 entries total ~3.6GB on the runner's NVMe (393GB free). Generous headroom for many in-flight PRs.
- Touch the stage4 directory in the "Locate stage4" step of both downstream jobs (pr-libc-test and pr-cross-compile) so its mtime is bumped to "recently used". Subsequent pr-build prune steps sort by mtime (`ls -1dt`), so an in-use stage4 is treated as among the newest and is not evicted from under a running downstream.

## Follow-up

Once this merges, PRs #535-#542 need their pr-build re-run so that a fresh stage4 lands in the cache. Easiest path is to rebase each onto the updated `libc/0.16.x` (which also brings in this fix in case any of them happens to be the next to finish first).