### PR TITLE
locale: support UTF-8 codeset for setlocale, MB_CUR_MAX, nl_langinfo

### DIFF
--- a/lib/c/ctype.zig
+++ b/lib/c/ctype.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const symbol = @import("../c.zig").symbol;
+const lc_state = @import("locale.zig");
 
 comptime {
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
@@ -1718,7 +1719,10 @@ fn __ctype_b_loc() callconv(.c) *const [*]const u16 {
 }
 
 fn __ctype_get_mb_cur_max() callconv(.c) usize {
-    return 4;
+    // `MB_CUR_MAX` is locale-dependent: 1 in the C / POSIX locale,
+    // 4 in any UTF-8 locale. Read the active LC_CTYPE from
+    // `lib/c/locale.zig` (honours `uselocale`) rather than a constant.
+    return if (lc_state.isLcCtypeUtf8()) 4 else 1;
 }
 
 // glibc compat: __ctype_tolower_loc

--- a/lib/c/locale.zig
+++ b/lib/c/locale.zig
@@ -165,6 +165,46 @@ fn iconv_close(_: ?*anyopaque) callconv(.c) c_int {
 }
 
 const c_locale_str: [:0]const u8 = "C";
+const c_utf8_locale_str: [:0]const u8 = "C.UTF-8";
+
+/// Tracks whether the global LC_CTYPE category currently uses UTF-8.
+/// Updated by `setlocale(LC_CTYPE, …)`; read by `isLcCtypeUtf8` (which
+/// also honours the per-thread `uselocale` override) and through that
+/// by `nl_langinfo(CODESET)`, `__ctype_get_mb_cur_max`, and every
+/// multibyte / wide-char helper in libzigc.
+var lc_ctype_global_utf8: bool = false;
+
+/// Returns `true` iff the LC_CTYPE category of the active locale uses
+/// UTF-8 encoding. The active locale is the per-thread override set by
+/// `uselocale` if one is installed, otherwise the process-global locale
+/// set by `setlocale`.
+///
+/// Callers in libzigc (multibyte decode/encode, ctype helpers,
+/// `nl_langinfo`, the wide-char stdio paths, regex parsing) use this
+/// to switch between the single-byte C/POSIX behaviour and UTF-8.
+pub fn isLcCtypeUtf8() bool {
+    if (thread_locale) |tl| {
+        return tl == @as(*anyopaque, @ptrCast(&__c_dot_utf8_locale_obj));
+    }
+    return lc_ctype_global_utf8;
+}
+
+/// Returns `true` for any locale name whose codeset is UTF-8 — including
+/// `C.UTF-8`, `POSIX.UTF-8`, `en_US.UTF-8`, plain `UTF-8`, and case
+/// variants like `.utf8`. Permissive matching mirrors what libc-test's
+/// `t_setutf8` helper expects: applications try several names in
+/// sequence (`||`-chained `setlocale` calls) and the first non-NULL
+/// return wins.
+fn isUtf8LocaleName(name: []const u8) bool {
+    if (std.ascii.eqlIgnoreCase(name, "UTF-8")) return true;
+    if (std.ascii.eqlIgnoreCase(name, "utf8")) return true;
+    if (std.mem.lastIndexOfScalar(u8, name, '.')) |dot| {
+        const suffix = name[dot + 1 ..];
+        if (std.ascii.eqlIgnoreCase(suffix, "UTF-8")) return true;
+        if (std.ascii.eqlIgnoreCase(suffix, "utf8")) return true;
+    }
+    return false;
+}
 
 // C-locale langinfo data (mirrors musl src/locale/langinfo.c).
 // Items within a category are stored back-to-back, separated by NULs.
@@ -206,8 +246,7 @@ const NL_ITEM_CODESET: c_int = 14;
 
 fn nlLangInfoImpl(item: c_int) [*:0]const u8 {
     if (item == NL_ITEM_CODESET) {
-        // C locale uses ASCII; the C.UTF-8 locale is not tracked here.
-        return "ASCII";
+        return if (isLcCtypeUtf8()) "UTF-8" else "ASCII";
     }
     const u_item = @as(u32, @bitCast(item));
     const cat = u_item >> 16;
@@ -300,14 +339,16 @@ fn localeconv() callconv(.c) *c_lconv {
 
 fn newlocale(_: c_int, name: ?[*:0]const c_char, base: ?*anyopaque) callconv(.c) ?*anyopaque {
     // The C and POSIX locales always resolve to the same global C-locale
-    // object; any other locale name is unknown and falls back to `base`
-    // (the musl behaviour for unsupported names with a non-null base).
+    // object; any UTF-8 codeset name (`C.UTF-8`, `en_US.UTF-8`, …)
+    // resolves to the C.UTF-8 locale object. Anything else is unknown
+    // and falls back to `base` (matches musl's behaviour for unsupported
+    // names with a non-null base).
     if (name) |n_raw| {
         const n = std.mem.span(@as([*:0]const u8, @ptrCast(n_raw)));
         if (n.len == 0 or std.mem.eql(u8, n, "C") or std.mem.eql(u8, n, "POSIX")) {
             return @ptrCast(&__c_locale_obj);
         }
-        if (std.mem.eql(u8, n, "C.UTF-8")) {
+        if (isUtf8LocaleName(n)) {
             return @ptrCast(&__c_dot_utf8_locale_obj);
         }
     }
@@ -321,12 +362,23 @@ fn __pleval(_: [*:0]const c_char, _: c_ulong) callconv(.c) c_ulong {
 fn setlocale(_: c_int, locale: ?[*:0]const c_char) callconv(.c) ?[*:0]const c_char {
     if (locale) |loc| {
         const l = std.mem.span(@as([*:0]const u8, @ptrCast(loc)));
-        if (l.len == 0 or std.mem.eql(u8, l, "C") or std.mem.eql(u8, l, "POSIX")) {
+        // Empty string means "use environment variables" (POSIX). We
+        // don't read the env yet, so leave the current LC_CTYPE state
+        // alone and return whatever it is.
+        if (l.len == 0) {
+            return @ptrCast(if (lc_ctype_global_utf8) c_utf8_locale_str.ptr else c_locale_str.ptr);
+        }
+        if (std.mem.eql(u8, l, "C") or std.mem.eql(u8, l, "POSIX")) {
+            lc_ctype_global_utf8 = false;
             return @ptrCast(c_locale_str.ptr);
+        }
+        if (isUtf8LocaleName(l)) {
+            lc_ctype_global_utf8 = true;
+            return @ptrCast(c_utf8_locale_str.ptr);
         }
         return null;
     }
-    return @ptrCast(c_locale_str.ptr);
+    return @ptrCast(if (lc_ctype_global_utf8) c_utf8_locale_str.ptr else c_locale_str.ptr);
 }
 
 fn strfmon(_: [*]c_char, _: usize, _: [*:0]const c_char) callconv(.c) isize {

--- a/lib/c/multibyte.zig
+++ b/lib/c/multibyte.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const symbol = @import("../c.zig").symbol;
+const lc_state = @import("locale.zig");
 
 comptime {
     if (builtin.target.isMuslLibC() or builtin.target.isWasiLibC()) {
@@ -33,17 +34,14 @@ const MB_LEN_MAX = 4;
 const SA: u8 = 0xc2;
 const SB: u8 = 0xf4;
 
-extern "c" fn setlocale(category: c_int, locale: ?[*:0]const u8) ?[*:0]const u8;
-
-/// Check if the current locale uses UTF-8 encoding (MB_CUR_MAX > 1).
-/// In the C locale (default), MB_CUR_MAX is 1 and bytes 0x80-0xFF are
-/// valid single-byte characters.
+/// Returns `true` iff the active LC_CTYPE locale uses UTF-8 encoding.
+/// Single source of truth lives in `lib/c/locale.zig`; it honours both
+/// the per-thread `uselocale` override and the process-global state
+/// last set by `setlocale(LC_CTYPE, …)`. In the C / POSIX locale,
+/// `MB_CUR_MAX == 1` and bytes 0x80–0xFF are valid single-byte
+/// characters.
 fn currentUtf8() bool {
-    const loc = setlocale(0, null) orelse return false; // LC_CTYPE = 0
-    // C locale returns "C", POSIX returns "POSIX" — both are single-byte
-    if (loc[0] == 'C' and loc[1] == 0) return false;
-    if (loc[0] == 'P') return false; // "POSIX"
-    return true;
+    return lc_state.isLcCtypeUtf8();
 }
 
 /// Interval [a,b). Either a must be 0x80 or b must be 0xc0, lower 3 bits clear.


### PR DESCRIPTION
Wire `setlocale(LC_CTYPE, …)` to actually accept UTF-8 locale names (`C.UTF-8`, `en_US.UTF-8`, plain `UTF-8`, etc.) and route every codeset-sensitive call site in libzigc through a single LC_CTYPE state in `lib/c/locale.zig`.

## Why

The libzigc `setlocale` only accepted `C` / `POSIX` / empty, so libc-test's `t_setutf8()` helper (a `||`-chain of seven UTF-8 locale names) always fell through and ended up calling `setlocale(LC_CTYPE, "")`. Tests then checked `nl_langinfo(CODESET) == "UTF-8"`, which was hard-coded to `"ASCII"`, and bailed.

Additionally:
- `__ctype_get_mb_cur_max()` (and therefore `MB_CUR_MAX`) always returned `4`, even in the C locale where it must be `1`.
- `multibyte.zig:currentUtf8()` parsed the string from `setlocale(0, null)`, but that string was always `"C"`.

## Design

Single source of truth: `isLcCtypeUtf8()` in `lib/c/locale.zig` checks the per-thread `uselocale` override first, then a process-global `lc_ctype_global_utf8` flag updated by `setlocale`.

- `setlocale` accepts any name that is `C`, `POSIX`, empty, or whose codeset suffix matches `UTF-8` / `utf8` (case-insensitive). Other names still return NULL.
- `newlocale` accepts the same broader UTF-8 spelling and routes to `__c_dot_utf8_locale_obj`.
- `nl_langinfo(CODESET)` reads `isLcCtypeUtf8()`.
- `__ctype_get_mb_cur_max()` returns 1 in C / POSIX, 4 in UTF-8.
- `multibyte.zig:currentUtf8()` calls `isLcCtypeUtf8()` directly.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.swprintf` | FAIL | ✅ PASS (all 4 modes) |
| `functional.mbc` | FAIL | ✅ PASS (all 4 modes) |
| `regression.regex-escaped-high-byte` | FAIL | ✅ PASS (all 4 modes) |
| `functional.clocale_mbfuncs` | FAIL | FAIL (exposes `iswupper` bug — see Follow-up) |
| `regression.fgetwc-buffering` | FAIL | FAIL (exposes wide-char buffering bug — see Follow-up) |

Verified no regressions in `api`, `functional.strftime`, `functional.fnmatch`, `regression.uselocale-0`, `regression.strverscmp`.

## Follow-up bugs newly exposed

These both surface only **after** the UTF-8 locale machinery starts working (before, the tests bailed out earlier):

1. **`functional.clocale_mbfuncs:77`** — `iswupper_fn` reports `true` for codeunit 0xdffd. Musl's `iswupper` is a plain ASCII check (`wc - 'A' < 26U`); libzigc's `iswupper_fn = (towlower_fn(wc) != wc)` over-classifies via the casemap tables for private-use surrogates and high codeunits.
2. **`regression.fgetwc-buffering`** — `fgetwc_unlocked_internal` doesn't preserve `mbrtowc` state when a UTF-8 sequence straddles two read calls from a pipe; second `fgetwc` returns 0x78 / 0x0 instead of `0x800`.

Both will land as separate PRs to keep one bug per PR.