### PR TITLE
time: fix __tm_to_secs to pass leap-year flag to __month_to_secs

### DIFF
--- a/lib/c/time.zig
+++ b/lib/c/time.zig
@@ -428,8 +428,9 @@ fn __tm_to_secs(t: *const tm) callconv(.c) c_longlong {
         }
         year += adj;
     }
-    var result = __year_to_secs(year, null);
-    result += __month_to_secs(month, @intFromBool(false));
+    var is_leap: c_int = undefined;
+    var result = __year_to_secs(year, &is_leap);
+    result += __month_to_secs(month, is_leap);
     result += @as(c_longlong, 86400) * (t.tm_mday - 1);
     result += @as(c_longlong, 3600) * t.tm_hour;
     result += @as(c_longlong, 60) * t.tm_min;


### PR DESCRIPTION
`__tm_to_secs` called `__year_to_secs(year, null)` (discarding the leap-year flag it computes) and then `__month_to_secs(month, @intFromBool(false))`, hardcoding `is_leap = false`. For leap years (1972, 1976, …) and months `>= March`, this omits the +86400-second adjustment for the leap day, so `mktime(gmtime(t))` round-trips to `t - 86400`.

## Cross-check

Musl's [`__tm_to_secs.c`](https://git.musl-libc.org/cgit/musl/plain/src/time/__tm_to_secs.c) keeps an `int is_leap;` local, hands its address to `__year_to_secs(year, &is_leap)`, and then passes that flag along to `__month_to_secs(month, is_leap)`. This change matches musl line-for-line.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.time` | FAIL (three leap-year March+ cases off by -86400) | ✅ PASS (all 4 modes) |

No ABI changes; only the body of `__tm_to_secs`.