### PR TITLE
search: fix tdelete rebalance loop to not balance the rootp slot

### DIFF
--- a/lib/c/search.zig
+++ b/lib/c/search.zig
@@ -205,10 +205,15 @@ fn tdeleteImpl(key: ?*const anyopaque, rootp: ?*?*anyopaque, cmp: ComparFn) call
     std.c.free(@ptrCast(node));
     i -= 1;
     a[i].* = child;
-    while (i > 0) {
+    // Walk the ancestor chain rebalancing each node. Mirrors musl's
+    // `while (--i && __tsearch_balance(a[i]));`: pre-decrement, exit
+    // when i reaches 0 (i.e. don't call balance on the rootp slot
+    // a[0]; `*a[0]` may have just been set to null when the tree
+    // becomes empty, which would segfault inside `balance`).
+    while (true) {
         i -= 1;
-        if (balance(a[i]) == 0) break;
         if (i == 0) break;
+        if (balance(a[i]) == 0) break;
     }
     return @ptrCast(parent);
 }


### PR DESCRIPTION
`tdeleteImpl` walked the ancestor chain one slot too far. The old loop:

```zig
i -= 1;
a[i].* = child;
while (i > 0) {
    i -= 1;
    if (balance(a[i]) == 0) break;
    if (i == 0) break;
}
```

would enter the loop when `i == 1`, decrement to 0, then call `balance(a[0])`. Both `a[0]` and `a[1]` are initialised to `rootp` at the start of `tdeleteImpl` (mirroring musl). When the deletion empties the tree, `a[i].* = child` writes `null` into `*rootp`, and the subsequent `balance(a[0])` dereferences `*rootp` (null) inside `balance` → SIGSEGV (the original failure mode for `functional.search_tsearch`).

## Cross-check

Musl's [`tdelete.c`](https://git.musl-libc.org/cgit/musl/plain/src/search/tdelete.c) ends with:

```c
*a[--i] = child;
while (--i && __tsearch_balance(a[i]));
```

The `while (--i && …)` pre-decrements and short-circuits when `i` reaches 0, so `balance` is never invoked on `a[0]`. This change mirrors that semantic explicitly.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.search_tsearch` | SIGSEGV on first `tdelete` exercise | ✅ PASS (all 4 modes) |
| `functional.search_hsearch` | PASS | PASS (no regression) |
| `functional.search_lsearch` | PASS | PASS (no regression) |

No ABI changes; loop body only.