### PR TITLE
ctype: make iswupper/iswlower a pure ASCII check, matching musl

### DIFF
--- a/lib/c/ctype.zig
+++ b/lib/c/ctype.zig
@@ -1404,11 +1404,17 @@ fn iswgraph_fn(wc: wint_t) callconv(.c) c_int {
 }
 
 fn iswlower_fn(wc: wint_t) callconv(.c) c_int {
-    return @intFromBool(towupper_fn(wc) != wc);
+    // Mirrors musl's `iswlower`: a pure ASCII `a..z` check. The
+    // earlier `towupper_fn(wc) != wc` implementation over-classified
+    // non-letter codepoints (e.g. the private-use codeunits
+    // 0xdf80–0xdfff used by libzigc's single-byte mapping, and any
+    // non-ASCII codepoint whose casemap table entry happens to be
+    // non-zero) as having case.
+    return @intFromBool(wc -% 'a' < 26);
 }
 
 fn iswupper_fn(wc: wint_t) callconv(.c) c_int {
-    return @intFromBool(towlower_fn(wc) != wc);
+    return @intFromBool(wc -% 'A' < 26);
 }
 
 fn iswxdigit_fn(wc: wint_t) callconv(.c) c_int {


### PR DESCRIPTION
`iswlower_fn` / `iswupper_fn` defined "has case" as `towupper_fn(wc) != wc` / `towlower_fn(wc) != wc`. That over-classifies any non-letter codepoint whose `casemap()` table entry happens to be non-zero — most visibly the private-use codeunits `0xdf80..0xdfff` libzigc uses to round-trip non-ASCII single bytes through the C locale, but also legitimately non-letter Unicode characters whose casemap rows aren't all-zero.

## Cross-check

Musl's [`iswlower.c`](https://git.musl-libc.org/cgit/musl/plain/src/ctype/iswlower.c) / [`iswupper.c`](https://git.musl-libc.org/cgit/musl/plain/src/ctype/iswupper.c) are simply:

```c
int iswlower(wint_t wc) { return wc-'a'<26U; }
int iswupper(wint_t wc) { return wc-'A'<26U; }
```

— a pure ASCII range check, locale-independent. This change mirrors that exactly.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.clocale_mbfuncs` | FAIL (line 77 `iswupper returned true for dffd (fd)`) | ✅ PASS (all 4 modes) |
| `functional.mbc` | PASS | PASS (no regression) |
| `functional.swprintf` | PASS | PASS (no regression) |
| `functional.fnmatch` | PASS | PASS (no regression) |
| `functional.wcsstr` | PASS | PASS (no regression) |
| `functional.wcstol` | PASS | PASS (no regression) |

This is the second of the two follow-up bugs newly exposed by #544 (UTF-8 locale support).

No ABI changes; only two function bodies.