### PR TITLE
stdio: fix fgetwc fast path returning undefined wc on -1 from mbtowc

### DIFF
--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -448,8 +448,16 @@ fn fgetwc_unlocked_internal(f: *FILE) wint_t {
 
     if (f.rpos != f.rend) {
         const len = @intFromPtr(f.rend.?) - @intFromPtr(f.rpos.?);
-        l = @intCast(mbtowc_fn(&wc, f.rpos, len));
-        if (l +% 1 >= 1) {
+        // `mbtowc` returns a `c_int`: a non-negative byte count on
+        // success, or -1 on incomplete / invalid sequence. Casting
+        // a negative `c_int` to `usize` with `@intCast` is illegal
+        // behaviour in safe build modes and undefined in optimised
+        // modes (which here caused us to return the still-undefined
+        // `wc` to the caller). Mirror musl's behaviour: fall through
+        // to the byte-by-byte path on a negative return.
+        const ret: c_int = mbtowc_fn(&wc, f.rpos, len);
+        if (ret >= 0) {
+            l = @intCast(ret);
             f.rpos = f.rpos.? + l + @intFromBool(l == 0);
             return @intCast(wc);
         }


### PR DESCRIPTION
`fgetwc_unlocked_internal` cast the `c_int` return of `mbtowc` straight to `usize` via `@intCast`, then checked `l +% 1 >= 1` to detect the "-1 means incomplete / invalid" case and fall through.

Casting a negative `c_int` to `usize` with `@intCast` is illegal behaviour:

- In Debug / ReleaseSafe builds it should panic — but the safety check was elided in the optimised libzigc, so the cast produced an out-of-range value that satisfied `l +% 1 >= 1` and the function happily returned the still-undefined `wc` (stack garbage like `0xcea68a08` when run live; cached binaries showed `0x78` ('x' from the previous byte) or `0x0`).
- In ReleaseFast / ReleaseSmall the result is UB; observed values were `0x78` and `0x0`.

## Fix

Mirror musl's [`__fgetwc_unlocked`](https://git.musl-libc.org/cgit/musl/plain/src/stdio/fgetwc.c): keep the return as a signed `c_int`, fall through to the byte-by-byte path on a negative return, and only cast to `usize` on a non-negative count.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `regression.fgetwc-buffering` | FAIL (line 28 `wanted 0x800, got 0x0` / `got 0x78`) | ✅ PASS (all 4 modes) |

This is the second of the two follow-up bugs newly exposed by #544 (UTF-8 locale support); the first is #547 (iswupper / iswlower ASCII-only).

No ABI changes; only the body of `fgetwc_unlocked_internal`.