### PR TITLE
network: fix inet_ntop AF_INET overrun on undersized destination

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -853,15 +853,22 @@ fn inet_ntop_impl(af: c_int, a0: *const anyopaque, s: [*]u8, l: linux.socklen_t)
 
     switch (af) {
         linux.AF.INET => {
-            inetNtopWriteUnsigned(s, &len, 10, a[0]);
-            inetNtopWriteByte(s, &len, '.');
-            inetNtopWriteUnsigned(s, &len, 10, a[1]);
-            inetNtopWriteByte(s, &len, '.');
-            inetNtopWriteUnsigned(s, &len, 10, a[2]);
-            inetNtopWriteByte(s, &len, '.');
-            inetNtopWriteUnsigned(s, &len, 10, a[3]);
+            // Write into the local buffer first; only copy into `s`
+            // after a bounds check. The previous version wrote into
+            // `s` directly and only validated `len < l` afterwards,
+            // which let `inet_ntop(AF_INET, "xxxx", "", 0)` overrun
+            // a zero-length destination (segfaulting libc-test's
+            // ENOSPC error-path test). Mirrors musl's `snprintf(s, l, …)`.
+            inetNtopWriteUnsigned(&buf, &len, 10, a[0]);
+            inetNtopWriteByte(&buf, &len, '.');
+            inetNtopWriteUnsigned(&buf, &len, 10, a[1]);
+            inetNtopWriteByte(&buf, &len, '.');
+            inetNtopWriteUnsigned(&buf, &len, 10, a[2]);
+            inetNtopWriteByte(&buf, &len, '.');
+            inetNtopWriteUnsigned(&buf, &len, 10, a[3]);
+            buf[len] = 0;
             if (len < l) {
-                s[len] = 0;
+                @memcpy(s[0 .. len + 1], buf[0 .. len + 1]);
                 return s;
             }
         },


### PR DESCRIPTION
`inet_ntop_impl`'s `AF_INET` branch wrote the dotted-quad directly into the caller's destination buffer `s` and only validated `len < l` afterwards. For `inet_ntop(AF_INET, "xxxx", "", 0)` — the canonical ENOSPC error-path case exercised by libc-test's `functional.inet_pton:97` — that meant scribbling on a zero-length buffer (here a read-only string literal) and segfaulting before the function could return NULL / set `errno = ENOSPC`.

## Fix

Switch to the same pattern the `AF_INET6` branch already uses: write into the local 100-byte `buf` first, null-terminate, then bounds-check before copying into `s`. If the result doesn't fit, fall through to the shared `errno = ENOSPC; return null;` tail.

Mirrors musl's [`inet_ntop`](https://git.musl-libc.org/cgit/musl/plain/src/network/inet_ntop.c), which gates the IPv4 path on `snprintf(s, l, "%d.%d.%d.%d", …) < l` and similarly sets ENOSPC on overrun.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.inet_pton` | SIGSEGV at line 97 (`inet_ntop(AF_INET, "xxxx", "", 0)`) | progresses past that case |

`functional.inet_pton` is **still failing** on a separate `inet_ntoa` variadic-ABI bug uncovered by this fix; tracked as a follow-up PR.

No ABI changes.