### PR TITLE
network: fix inet_ntoa returning "0.0.0.0" for all addresses on aarch64

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -812,9 +812,30 @@ fn inet_netof_impl(in: in_addr) callconv(.c) in_addr_t {
 
 var inet_ntoa_buf: [16]u8 = undefined;
 
-fn inet_ntoa_impl(in: in_addr) callconv(.c) [*]u8 {
-    const a: *const [4]u8 = @ptrCast(&in);
-    _ = c.snprintf(&inet_ntoa_buf, inet_ntoa_buf.len, "%d.%d.%d.%d", a[0], a[1], a[2], a[3]);
+fn inet_ntoa_impl(in: in_addr_t) callconv(.c) [*]u8 {
+    // The previous version went through `snprintf("%d.%d.%d.%d", a[0],
+    // a[1], a[2], a[3])`, but Zig does not apply C's default-argument
+    // promotion to variadic args: each `u8` was passed in its natural
+    // 1-byte width while libc's `snprintf` read 4 bytes per `%d`,
+    // producing `0.0.0.0` for every nonzero address on aarch64.
+    //
+    // Take the address as a plain `in_addr_t` (u32) rather than the
+    // `in_addr` extern struct wrapper. A struct{u32} value parameter
+    // is supposed to match the u32 ABI on aarch64, but the optimiser
+    // wasn't preserving the argument bits through the struct param
+    // (it folded `inet_ntoa_impl` to a constant `0.0.0.0` store).
+    // The C declaration `inet_ntoa(struct in_addr)` and `inet_ntoa(uint32_t)`
+    // both pass the value in the low 32 bits of x0, so the C ABI is
+    // unchanged.
+    var len: usize = 0;
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in)));
+    inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 8)));
+    inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 16)));
+    inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 24)));
+    inet_ntoa_buf[len] = 0;
     return &inet_ntoa_buf;
 }
 


### PR DESCRIPTION
`inet_ntoa_impl` went through libc's `snprintf("%d.%d.%d.%d", a[0], a[1], a[2], a[3])` to format the four bytes of the address, with `a` being `@ptrCast(&in)` of the `extern struct { s_addr: u32 }` value parameter. Two compounding issues caused every call to return `"0.0.0.0"` on aarch64-linux-musl regardless of input:

- Zig does **not** apply C's default-argument promotion to variadic args, so each `u8` byte was passed in its natural 1-byte ABI slot while libc's `snprintf` read `sizeof(int)` bytes per `%d`.
- On top of that, the optimiser folded the whole function to a constant `"0.0.0.0\0"` store: `@ptrCast(&in)` on a register-passed `extern struct { u32 }` value parameter did not reliably preserve the argument bits through the indirection, and the compiler was free to assume the byte loads produced zero. (Reproducible with several variants: `@bitCast(in.s_addr)`, `var local = in;`, etc. — all collapsed to a constant `0.0.0.0\0` store in the generated assembly.)

## Fix

Fix both at once by:

- Taking the parameter as a plain `in_addr_t` (the same `u32` that's the sole field of `struct in_addr`); on aarch64 both `inet_ntoa(struct in_addr)` and `inet_ntoa(uint32_t)` pass the value in the low 32 bits of `x0`, so the C ABI is unchanged for the exported `inet_ntoa` symbol.
- Extracting the four bytes with explicit shifts and rendering via the same `inetNtopWriteUnsigned` / `inetNtopWriteByte` helpers that `inet_ntop_impl` already uses, avoiding any variadic-call ABI question.

## Test results (aarch64-linux-musl, native libc-test)

| Test family | Before | After |
|---|---|---|
| `functional.inet_pton` | `inet_ntoa(<"7f000001">) returned 0.0.0.0, want 127.0.0.1` (every case) | ✅ PASS (all 4 modes, **with** #549) |
| `regression.inet_ntop-v4mapped` | PASS | PASS (no regression) |

Stacked on **#549** (`network: fix inet_ntop AF_INET overrun on undersized destination`): without that fix, `functional.inet_pton` SEGVs at line 97 before reaching the `inet_ntoa` cases at line 102+. Either order of merge works; the two together clear `functional.inet_pton` fully.

No symbol or behavioural change visible to callers of the exported `inet_ntoa`.