### PR TITLE
ci(pr-build): isolate Zig global/local cache per workspace

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,6 +44,13 @@ env:
   TARGET: aarch64-linux-musl
   MCPU: baseline
   CACHE_ROOT: /runner/_cache/pr-build
+  # Per-workspace Zig caches so concurrent pr-build jobs on the same
+  # self-hosted runner host can't clobber each other's `~/.cache/zig/`.
+  # `${GITHUB_WORKSPACE}` is unique per runner work-slot (e.g.
+  # `/runner/runner-3/_work/zig/zig`), so two jobs running on different
+  # runner slots get fully isolated caches.
+  ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-global-cache
+  ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache
 
 jobs:
   trust-check:


### PR DESCRIPTION
Concurrent pr-build jobs on the same self-hosted runner host previously shared `~/.cache/zig/`. When two jobs raced on the stage4 build, one would wipe the other's cache mid-compile:

    error: cache directory '/home/azureuser/.cache/zig/z/' unexpectedly
    removed during compiler execution

Observed on **PR #551** (run [25962508030](https://github.com/ctaggart/zig/actions/runs/25962508030)) while PR #552/#553 stage4 builds were in flight.

Fix: workflow-level `ZIG_GLOBAL_CACHE_DIR` / `ZIG_LOCAL_CACHE_DIR` set to `${{ github.workspace }}/.zig-{global-,}cache`. The workspace path is unique per runner work-slot (e.g. `/runner/runner-3/_work/zig/zig`), so two concurrent jobs land on disjoint paths.

Stage4 caches under `$CACHE_ROOT/stage4-<key>` are unaffected — that keying already isolates per source-hash and publish is atomic.