### PR TITLE
libzigc(spawn): explicit @as(usize, ...) wrap on bitCast for x32 ABI

### DIFF
--- a/lib/c/spawn.zig
+++ b/lib/c/spawn.zig
@@ -207,14 +207,14 @@ fn sysDup2(old: c_int, new: c_int) isize {
     if (have_sys_dup2) {
         return @bitCast(linux.syscall2(
             .dup2,
-            @bitCast(@as(isize, old)),
-            @bitCast(@as(isize, new)),
+            @as(usize, @bitCast(@as(isize, old))),
+            @as(usize, @bitCast(@as(isize, new))),
         ));
     } else {
         return @bitCast(linux.syscall3(
             .dup3,
-            @bitCast(@as(isize, old)),
-            @bitCast(@as(isize, new)),
+            @as(usize, @bitCast(@as(isize, old))),
+            @as(usize, @bitCast(@as(isize, new))),
             0,
         ));
     }
@@ -232,7 +232,7 @@ fn sysOpen(path: [*:0]const u8, flags: c_int, mode: linux.mode_t) isize {
     } else {
         return @bitCast(linux.syscall4(
             .openat,
-            @bitCast(@as(isize, linux.AT.FDCWD)),
+            @as(usize, @bitCast(@as(isize, linux.AT.FDCWD))),
             @intFromPtr(path),
             fl,
             mode,
@@ -241,13 +241,13 @@ fn sysOpen(path: [*:0]const u8, flags: c_int, mode: linux.mode_t) isize {
 }
 
 fn sysClose(fd: c_int) isize {
-    return @bitCast(linux.syscall1(.close, @bitCast(@as(isize, fd))));
+    return @bitCast(linux.syscall1(.close, @as(usize, @bitCast(@as(isize, fd)))));
 }
 
 fn sysWrite(fd: c_int, buf: *const anyopaque, count: usize) isize {
     return @bitCast(linux.syscall3(
         .write,
-        @bitCast(@as(isize, fd)),
+        @as(usize, @bitCast(@as(isize, fd))),
         @intFromPtr(buf),
         count,
     ));
@@ -258,14 +258,14 @@ fn sysFcntl(fd: c_int, cmd: c_int, arg: usize) isize {
     const SYS_fcntl_compat = if (@hasField(linux.SYS, "fcntl")) linux.SYS.fcntl else linux.SYS.fcntl64;
     return @bitCast(linux.syscall3(
         SYS_fcntl_compat,
-        @bitCast(@as(isize, fd)),
-        @bitCast(@as(isize, cmd)),
+        @as(usize, @bitCast(@as(isize, fd))),
+        @as(usize, @bitCast(@as(isize, cmd))),
         arg,
     ));
 }
 
 fn sysDup(fd: c_int) isize {
-    return @bitCast(linux.syscall1(.dup, @bitCast(@as(isize, fd))));
+    return @bitCast(linux.syscall1(.dup, @as(usize, @bitCast(@as(isize, fd)))));
 }
 
 // The child function runs on the parent's stack via CLONE_VM|CLONE_VFORK,
@@ -318,7 +318,7 @@ fn childImpl(args: *Args) noreturn {
         ret = @bitCast(linux.syscall2(
             .setpgid,
             0,
-            @bitCast(@as(isize, attr.__pgrp)),
+            @as(usize, @bitCast(@as(isize, attr.__pgrp))),
         ));
         if (ret != 0) {
             failExit(p, ret);
@@ -401,7 +401,7 @@ fn childImpl(args: *Args) noreturn {
                     FDOP_FCHDIR => {
                         ret = @bitCast(linux.syscall1(
                             .fchdir,
-                            @bitCast(@as(isize, o.fd)),
+                            @as(usize, @bitCast(@as(isize, o.fd))),
                         ));
                         if (ret < 0) failExit(p, ret);
                     },


### PR DESCRIPTION
Fix x86_64-linux-muslx32 build regression introduced by #560.

`@bitCast(@as(isize, fd))` without an explicit destination type fails on x32 because the syscall arg is u64 (64-bit) while isize is i32:

    @bitCast size mismatch: destination type 'u64' has 64 bits but source
    type 'isize' has 32 bits

Wrap with `@as(usize, ...)` so @bitCast goes isize→usize (both 32-bit on x32), then Zig implicit-widens usize→u64 for the syscall arg. Matches the canonical pattern in lib/c/dirent.zig:106 and lib/c/linux.zig.

Caught by post-merge-libc x86_64 ([run 25999088782](https://github.com/ctaggart/zig/actions/runs/25999088782)); pr-cross-compile does not include x32 in its matrix.

Affected call sites: sysDup2 (×2), sysOpen (1), sysClose, sysWrite, sysFcntl (×2), sysDup, setpgid arg, and the fdop FDOP_DUP2 path.