### PR TITLE
libzigc(spawn): wrap setgid/setuid syscall args for x32 ABI

### DIFF
--- a/lib/c/spawn.zig
+++ b/lib/c/spawn.zig
@@ -329,10 +329,10 @@ fn childImpl(args: *Args) noreturn {
     // multi-threaded synchronised id change that would trash parent state.
     if ((attr.__flags & POSIX_SPAWN_RESETIDS) != 0) {
         const gid_ret: isize = @bitCast(linux.syscall0(.getgid));
-        ret = @bitCast(linux.syscall1(.setgid, @bitCast(gid_ret)));
+        ret = @bitCast(linux.syscall1(.setgid, @as(usize, @bitCast(gid_ret))));
         if (ret == 0) {
             const uid_ret: isize = @bitCast(linux.syscall0(.getuid));
-            ret = @bitCast(linux.syscall1(.setuid, @bitCast(uid_ret)));
+            ret = @bitCast(linux.syscall1(.setuid, @as(usize, @bitCast(uid_ret))));
         }
         if (ret != 0) {
             failExit(p, ret);


### PR DESCRIPTION
Follow-up to #563.

`lib/c/spawn.zig:332,335` still had bare `@bitCast(gid_ret)` / `@bitCast(uid_ret)` where source is a typed `isize` local. On x86_64-linux-muslx32 (ILP32 with u64 syscall args), the inferred destination is u64 but isize is i32 → size mismatch.

Add `@as(usize, ...)` wrap (canonical pattern from lib/c/dirent.zig). My #563 regex matched `@bitCast(@as(isize, EXPR))` but missed `@bitCast(<isize-typed-local>)`.

Caught by post-merge-libc x86_64 [run 26016415334](https://github.com/ctaggart/zig/actions/runs/26016415334) after #563 merged.

Also adds CI gap note for the future: `x86_64-linux-muslx32` should be in pr-cross-compile to catch this pre-merge.