### PR TITLE
libzigc: migrate stdio vfprintf to Zig

### DIFF
--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -89,7 +89,7 @@ const SwCookie = extern struct {
     l: usize,
 };
 const strerror_fn = @extern(*const fn (c_int) callconv(.c) [*:0]const u8, .{ .name = "strerror" });
-const vfprintf_fn = @extern(*const fn (?*FILE, [*:0]const u8, VaList) callconv(.c) c_int, .{ .name = "vfprintf" });
+// vfprintf is implemented in Zig below as `vfprintf_impl`.
 const vfwprintf_fn = @extern(*const fn (?*FILE, [*:0]const wchar_t, VaList) callconv(.c) c_int, .{ .name = "vfwprintf" });
 const memchr_fn = @extern(*const fn (?[*]const u8, c_int, usize) callconv(.c) ?[*]u8, .{ .name = "memchr" });
 const lseek_fn = @extern(*const fn (c_int, i64, c_int) callconv(.c) i64, .{ .name = "__lseek" });
@@ -281,6 +281,7 @@ comptime {
         symbol(&perror_impl, "perror");
         // #243 fix enables by-value VaList; all v-prefix stdio wrappers now migrated.
         symbol(&vprintf_impl, "vprintf");
+        symbol(&vfprintf_impl, "vfprintf");
         symbol(&vfscanf_impl, "vfscanf");
         symbol(&vfscanf_impl, "__isoc99_vfscanf");
         symbol(&vscanf_impl, "vscanf");
@@ -1773,7 +1774,7 @@ fn vdprintf_impl(fd: c_int, fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
     f.buf = @ptrCast(@constCast(fmt));
     f.buf_size = 0;
     f.lock = -1;
-    return vfprintf_fn(@ptrCast(&f), fmt, ap);
+    return vfprintf_impl(@ptrCast(&f), fmt, ap);
 }
 
 /// getdelim.c: ssize_t getdelim(char **restrict s, size_t *restrict n, int delim, FILE *restrict f)
@@ -1883,6 +1884,1159 @@ fn setErrno(e: std.os.linux.E) void {
     std.c._errno().* = @intCast(@intFromEnum(e));
 }
 
+// === vfprintf (from musl src/stdio/vfprintf.c) ===========================
+
+/// Bit positions for modifier flags (all fall within 31 codepoints of space).
+const ALT_FORM_BIT: c_uint = 1 << ('#' - ' ');
+const ZERO_PAD_BIT: c_uint = 1 << ('0' - ' ');
+const LEFT_ADJ_BIT: c_uint = 1 << ('-' - ' ');
+const PAD_POS_BIT: c_uint = 1 << (' ' - ' ');
+const MARK_POS_BIT: c_uint = 1 << ('+' - ' ');
+const GROUPED_BIT: c_uint = 1 << ('\'' - ' ');
+const FLAGMASK: c_uint = ALT_FORM_BIT | ZERO_PAD_BIT | LEFT_ADJ_BIT | PAD_POS_BIT | MARK_POS_BIT | GROUPED_BIT;
+
+/// State machine type-classes used by the printf format-spec state table.
+const PF_BARE: u8 = 0;
+const PF_LPRE: u8 = 1;
+const PF_LLPRE: u8 = 2;
+const PF_HPRE: u8 = 3;
+const PF_HHPRE: u8 = 4;
+const PF_BIGLPRE: u8 = 5;
+const PF_ZTPRE: u8 = 6;
+const PF_JPRE: u8 = 7;
+const PF_STOP: u8 = 8;
+const PF_PTR: u8 = 9;
+const PF_INT: u8 = 10;
+const PF_UINT: u8 = 11;
+const PF_ULLONG: u8 = 12;
+const PF_LONG: u8 = 13;
+const PF_ULONG: u8 = 14;
+const PF_SHORT: u8 = 15;
+const PF_USHORT: u8 = 16;
+const PF_CHAR: u8 = 17;
+const PF_UCHAR: u8 = 18;
+const PF_LLONG: u8 = 19;
+const PF_SIZET: u8 = 20;
+const PF_IMAX: u8 = 21;
+const PF_UMAX: u8 = 22;
+const PF_PDIFF: u8 = 23;
+const PF_UIPTR: u8 = 24;
+const PF_DBL: u8 = 25;
+const PF_LDBL: u8 = 26;
+const PF_NOARG: u8 = 27;
+
+const NL_ARGMAX: usize = 9;
+
+const PrintfArg = extern union {
+    i: c_ulonglong,
+    f: c_longdouble,
+    p: ?*anyopaque,
+};
+
+/// `LDBL_MANT_DIG`, `LDBL_MAX_EXP`, `LDBL_EPSILON` mirroring musl's
+/// arch/*/bits/float.h values, derived from the c_longdouble bit width.
+const LDBL_MANT_DIG: comptime_int = switch (@bitSizeOf(c_longdouble)) {
+    64 => 53,
+    80 => 64,
+    128 => 113,
+    else => @compileError("unsupported c_longdouble bit size"),
+};
+const LDBL_MAX_EXP: comptime_int = switch (@bitSizeOf(c_longdouble)) {
+    64 => 1024,
+    80, 128 => 16384,
+    else => @compileError("unsupported c_longdouble bit size"),
+};
+const LDBL_EPSILON: c_longdouble = switch (@bitSizeOf(c_longdouble)) {
+    64 => 2.22044604925031308085e-16,
+    80 => 1.0842021724855044340e-19,
+    128 => 1.92592994438723585305597794258492732e-34,
+    else => @compileError("unsupported c_longdouble bit size"),
+};
+
+const PF_STATES_W: comptime_int = 'z' - 'A' + 1;
+
+/// `states[][]` table from musl: maps (current state, next character) to
+/// either the next prefix state or a terminal type-class.
+const pf_states: [8][PF_STATES_W]u8 = blk: {
+    @setEvalBranchQuota(50000);
+    var t: [8][PF_STATES_W]u8 = [_][PF_STATES_W]u8{[_]u8{0} ** PF_STATES_W} ** 8;
+    // 0: bare
+    t[0]['d' - 'A'] = PF_INT;
+    t[0]['i' - 'A'] = PF_INT;
+    t[0]['o' - 'A'] = PF_UINT;
+    t[0]['u' - 'A'] = PF_UINT;
+    t[0]['x' - 'A'] = PF_UINT;
+    t[0]['X' - 'A'] = PF_UINT;
+    t[0]['e' - 'A'] = PF_DBL;
+    t[0]['f' - 'A'] = PF_DBL;
+    t[0]['g' - 'A'] = PF_DBL;
+    t[0]['a' - 'A'] = PF_DBL;
+    t[0]['E' - 'A'] = PF_DBL;
+    t[0]['F' - 'A'] = PF_DBL;
+    t[0]['G' - 'A'] = PF_DBL;
+    t[0]['A' - 'A'] = PF_DBL;
+    t[0]['c' - 'A'] = PF_INT;
+    t[0]['C' - 'A'] = PF_UINT;
+    t[0]['s' - 'A'] = PF_PTR;
+    t[0]['S' - 'A'] = PF_PTR;
+    t[0]['p' - 'A'] = PF_UIPTR;
+    t[0]['n' - 'A'] = PF_PTR;
+    t[0]['m' - 'A'] = PF_NOARG;
+    t[0]['l' - 'A'] = PF_LPRE;
+    t[0]['h' - 'A'] = PF_HPRE;
+    t[0]['L' - 'A'] = PF_BIGLPRE;
+    t[0]['z' - 'A'] = PF_ZTPRE;
+    t[0]['j' - 'A'] = PF_JPRE;
+    t[0]['t' - 'A'] = PF_ZTPRE;
+    // 1: l-prefixed
+    t[1]['d' - 'A'] = PF_LONG;
+    t[1]['i' - 'A'] = PF_LONG;
+    t[1]['o' - 'A'] = PF_ULONG;
+    t[1]['u' - 'A'] = PF_ULONG;
+    t[1]['x' - 'A'] = PF_ULONG;
+    t[1]['X' - 'A'] = PF_ULONG;
+    t[1]['e' - 'A'] = PF_DBL;
+    t[1]['f' - 'A'] = PF_DBL;
+    t[1]['g' - 'A'] = PF_DBL;
+    t[1]['a' - 'A'] = PF_DBL;
+    t[1]['E' - 'A'] = PF_DBL;
+    t[1]['F' - 'A'] = PF_DBL;
+    t[1]['G' - 'A'] = PF_DBL;
+    t[1]['A' - 'A'] = PF_DBL;
+    t[1]['c' - 'A'] = PF_UINT;
+    t[1]['s' - 'A'] = PF_PTR;
+    t[1]['n' - 'A'] = PF_PTR;
+    t[1]['l' - 'A'] = PF_LLPRE;
+    // 2: ll-prefixed
+    t[2]['d' - 'A'] = PF_LLONG;
+    t[2]['i' - 'A'] = PF_LLONG;
+    t[2]['o' - 'A'] = PF_ULLONG;
+    t[2]['u' - 'A'] = PF_ULLONG;
+    t[2]['x' - 'A'] = PF_ULLONG;
+    t[2]['X' - 'A'] = PF_ULLONG;
+    t[2]['n' - 'A'] = PF_PTR;
+    // 3: h-prefixed
+    t[3]['d' - 'A'] = PF_SHORT;
+    t[3]['i' - 'A'] = PF_SHORT;
+    t[3]['o' - 'A'] = PF_USHORT;
+    t[3]['u' - 'A'] = PF_USHORT;
+    t[3]['x' - 'A'] = PF_USHORT;
+    t[3]['X' - 'A'] = PF_USHORT;
+    t[3]['n' - 'A'] = PF_PTR;
+    t[3]['h' - 'A'] = PF_HHPRE;
+    // 4: hh-prefixed
+    t[4]['d' - 'A'] = PF_CHAR;
+    t[4]['i' - 'A'] = PF_CHAR;
+    t[4]['o' - 'A'] = PF_UCHAR;
+    t[4]['u' - 'A'] = PF_UCHAR;
+    t[4]['x' - 'A'] = PF_UCHAR;
+    t[4]['X' - 'A'] = PF_UCHAR;
+    t[4]['n' - 'A'] = PF_PTR;
+    // 5: L-prefixed
+    t[5]['e' - 'A'] = PF_LDBL;
+    t[5]['f' - 'A'] = PF_LDBL;
+    t[5]['g' - 'A'] = PF_LDBL;
+    t[5]['a' - 'A'] = PF_LDBL;
+    t[5]['E' - 'A'] = PF_LDBL;
+    t[5]['F' - 'A'] = PF_LDBL;
+    t[5]['G' - 'A'] = PF_LDBL;
+    t[5]['A' - 'A'] = PF_LDBL;
+    t[5]['n' - 'A'] = PF_PTR;
+    // 6: z- or t-prefixed
+    t[6]['d' - 'A'] = PF_PDIFF;
+    t[6]['i' - 'A'] = PF_PDIFF;
+    t[6]['o' - 'A'] = PF_SIZET;
+    t[6]['u' - 'A'] = PF_SIZET;
+    t[6]['x' - 'A'] = PF_SIZET;
+    t[6]['X' - 'A'] = PF_SIZET;
+    t[6]['n' - 'A'] = PF_PTR;
+    // 7: j-prefixed
+    t[7]['d' - 'A'] = PF_IMAX;
+    t[7]['i' - 'A'] = PF_IMAX;
+    t[7]['o' - 'A'] = PF_UMAX;
+    t[7]['u' - 'A'] = PF_UMAX;
+    t[7]['x' - 'A'] = PF_UMAX;
+    t[7]['X' - 'A'] = PF_UMAX;
+    t[7]['n' - 'A'] = PF_PTR;
+    break :blk t;
+};
+
+/// musl OOB(x): (unsigned)(x)-'A' > 'z'-'A'
+inline fn pf_oob(c: u8) bool {
+    return @as(c_uint, c) -% 'A' > 'z' - 'A';
+}
+
+fn pop_arg(arg: *PrintfArg, ty: u8, ap: *VaList) callconv(.c) void {
+    switch (ty) {
+        PF_PTR => arg.p = @cVaArg(ap, ?*anyopaque),
+        PF_INT => arg.i = @bitCast(@as(c_longlong, @cVaArg(ap, c_int))),
+        PF_UINT => arg.i = @cVaArg(ap, c_uint),
+        PF_LONG => arg.i = @bitCast(@as(c_longlong, @cVaArg(ap, c_long))),
+        PF_ULONG => arg.i = @cVaArg(ap, c_ulong),
+        PF_ULLONG => arg.i = @cVaArg(ap, c_ulonglong),
+        PF_SHORT => arg.i = @bitCast(@as(c_longlong, @as(c_short, @truncate(@cVaArg(ap, c_int))))),
+        PF_USHORT => arg.i = @as(c_ushort, @truncate(@as(c_uint, @bitCast(@cVaArg(ap, c_int))))),
+        PF_CHAR => arg.i = @bitCast(@as(c_longlong, @as(i8, @truncate(@cVaArg(ap, c_int))))),
+        PF_UCHAR => arg.i = @as(u8, @truncate(@as(c_uint, @bitCast(@cVaArg(ap, c_int))))),
+        PF_LLONG => arg.i = @bitCast(@cVaArg(ap, c_longlong)),
+        PF_SIZET => arg.i = @cVaArg(ap, usize),
+        PF_IMAX => arg.i = @bitCast(@cVaArg(ap, c_longlong)),
+        PF_UMAX => arg.i = @cVaArg(ap, c_ulonglong),
+        PF_PDIFF => arg.i = @bitCast(@as(c_longlong, @cVaArg(ap, isize))),
+        PF_UIPTR => arg.i = @intFromPtr(@cVaArg(ap, ?*anyopaque)),
+        PF_DBL => arg.f = @floatCast(@cVaArg(ap, f64)),
+        PF_LDBL => arg.f = @cVaArg(ap, c_longdouble),
+        else => {},
+    }
+}
+
+/// musl `out`: write only when stream is not in error state.
+inline fn pf_out(f: ?*FILE, s: [*]const u8, l: usize) void {
+    if (f) |ff| {
+        if (ff.flags & F_ERR == 0) _ = __fwritex(s, l, ff);
+    }
+}
+
+/// musl `pad`: emit (w-l) copies of `c` unless LEFT_ADJ/ZERO_PAD set, or already wide enough.
+fn pf_pad(f: ?*FILE, c: u8, w: c_int, l_in: c_int, fl: c_uint) void {
+    var l = l_in;
+    if ((fl & (LEFT_ADJ_BIT | ZERO_PAD_BIT)) != 0 or l >= w) return;
+    l = w - l;
+    var buf: [256]u8 = undefined;
+    const fill: usize = @intCast(@min(l, @as(c_int, buf.len)));
+    @memset(buf[0..fill], c);
+    while (l >= buf.len) : (l -= buf.len) pf_out(f, &buf, buf.len);
+    pf_out(f, &buf, @intCast(l));
+}
+
+const pf_xdigits: [16]u8 = "0123456789ABCDEF".*;
+
+/// Write hex digits of x backwards into the buffer ending at `s_end`.
+fn fmt_x(x: c_ulonglong, s_end: [*]u8, lower: c_int) [*]u8 {
+    var s = s_end;
+    var v = x;
+    while (v != 0) : (v >>= 4) {
+        s -= 1;
+        s[0] = pf_xdigits[@as(usize, @intCast(v & 15))] | @as(u8, @intCast(lower));
+    }
+    return s;
+}
+
+fn fmt_o(x: c_ulonglong, s_end: [*]u8) [*]u8 {
+    var s = s_end;
+    var v = x;
+    while (v != 0) : (v >>= 3) {
+        s -= 1;
+        s[0] = '0' + @as(u8, @intCast(v & 7));
+    }
+    return s;
+}
+
+fn fmt_u(x: c_ulonglong, s_end: [*]u8) [*]u8 {
+    var s = s_end;
+    var v = x;
+    // Reduce above ULONG_MAX using c_ulonglong division.
+    while (v > std.math.maxInt(c_ulong)) : (v /= 10) {
+        s -= 1;
+        s[0] = '0' + @as(u8, @intCast(v % 10));
+    }
+    var y: c_ulong = @intCast(v);
+    while (y != 0) : (y /= 10) {
+        s -= 1;
+        s[0] = '0' + @as(u8, @intCast(y % 10));
+    }
+    return s;
+}
+
+/// Floating-point formatter (musl `fmt_fp`). Returns the printed length,
+/// or -1 on overflow (errno is NOT set here; caller checks).
+fn fmt_fp(f: ?*FILE, y_in: c_longdouble, w: c_int, p_in: c_int, fl_in: c_uint, t_in: c_int) c_int {
+    var y = y_in;
+    var p = p_in;
+    const fl = fl_in;
+    var t = t_in;
+
+    // Mantissa expansion + exponent expansion words.
+    const big_words: comptime_int = (LDBL_MANT_DIG + 28) / 29 + 1 + (LDBL_MAX_EXP + LDBL_MANT_DIG + 28 + 8) / 9;
+    var big: [big_words]u32 = undefined;
+    var a: [*]u32 = undefined;
+    var d: [*]u32 = undefined;
+    var r: [*]u32 = undefined;
+    var z: [*]u32 = undefined;
+    var e2: c_int = 0;
+    var e: c_int = undefined;
+    var i: c_int = undefined;
+    var j: c_int = undefined;
+    var l: c_int = undefined;
+    var buf: [9 + LDBL_MANT_DIG / 4]u8 = undefined;
+    var s: [*]u8 = undefined;
+    var prefix: [*]const u8 = "-0X+0X 0X-0x+0x 0x";
+    var pl: c_int = undefined;
+    var ebuf0: [3 * @sizeOf(c_int)]u8 = undefined;
+    const ebuf: [*]u8 = @as([*]u8, &ebuf0) + ebuf0.len;
+    var estr: [*]u8 = undefined;
+
+    pl = 1;
+    if (std.math.signbit(y)) {
+        y = -y;
+    } else if ((fl & MARK_POS_BIT) != 0) {
+        prefix += 3;
+    } else if ((fl & PAD_POS_BIT) != 0) {
+        prefix += 6;
+    } else {
+        prefix += 1;
+        pl = 0;
+    }
+
+    if (!std.math.isFinite(y)) {
+        const lower_inf: [*]const u8 = "inf";
+        const upper_inf: [*]const u8 = "INF";
+        const lower_nan: [*]const u8 = "nan";
+        const upper_nan: [*]const u8 = "NAN";
+        var sptr: [*]const u8 = if ((t & 32) != 0) lower_inf else upper_inf;
+        if (std.math.isNan(y)) sptr = if ((t & 32) != 0) lower_nan else upper_nan;
+        pf_pad(f, ' ', w, 3 + pl, fl & ~ZERO_PAD_BIT);
+        pf_out(f, prefix, @intCast(pl));
+        pf_out(f, sptr, 3);
+        pf_pad(f, ' ', w, 3 + pl, fl ^ LEFT_ADJ_BIT);
+        return @max(w, 3 + pl);
+    }
+
+    {
+        const fr = std.math.frexp(y);
+        y = fr.significand * 2;
+        e2 = fr.exponent;
+    }
+    if (y != 0) e2 -= 1;
+
+    if ((t | 32) == 'a') {
+        var round: c_longdouble = 8.0;
+        var re: c_int = undefined;
+
+        if ((t & 32) != 0) prefix += 9;
+        pl += 2;
+
+        if (p < 0 or p >= LDBL_MANT_DIG / 4 - 1) {
+            re = 0;
+        } else {
+            re = LDBL_MANT_DIG / 4 - 1 - p;
+        }
+
+        if (re != 0) {
+            round *= @as(c_longdouble, @floatFromInt(@as(c_int, 1) << (LDBL_MANT_DIG % 4)));
+            while (re != 0) : (re -= 1) round *= 16;
+            if (prefix[0] == '-') {
+                y = -y;
+                y -= round;
+                y += round;
+                y = -y;
+            } else {
+                y += round;
+                y -= round;
+            }
+        }
+
+        estr = fmt_u(@bitCast(@as(c_longlong, if (e2 < 0) -e2 else e2)), ebuf);
+        if (estr == ebuf) {
+            estr -= 1;
+            estr[0] = '0';
+        }
+        estr -= 1;
+        estr[0] = if (e2 < 0) '-' else '+';
+        estr -= 1;
+        estr[0] = @as(u8, @intCast(t)) + ('p' - 'a');
+
+        s = &buf;
+        while (true) {
+            const ix: c_int = @intFromFloat(y);
+            s[0] = pf_xdigits[@as(usize, @intCast(ix))] | @as(u8, @intCast(t & 32));
+            s += 1;
+            y = 16 * (y - @as(c_longdouble, @floatFromInt(ix)));
+            if (@intFromPtr(s) - @intFromPtr(&buf) == 1 and (y != 0 or p > 0 or (fl & ALT_FORM_BIT) != 0)) {
+                s[0] = '.';
+                s += 1;
+            }
+            if (y == 0) break;
+        }
+
+        const ebuf_minus_estr: c_int = @intCast(@intFromPtr(ebuf) - @intFromPtr(estr));
+        if (p > std.math.maxInt(c_int) - 2 - ebuf_minus_estr - pl) return -1;
+        const sbuf_diff: c_int = @intCast(@intFromPtr(s) - @intFromPtr(&buf));
+        if (p != 0 and sbuf_diff - 2 < p) {
+            l = (p + 2) + ebuf_minus_estr;
+        } else {
+            l = sbuf_diff + ebuf_minus_estr;
+        }
+
+        pf_pad(f, ' ', w, pl + l, fl);
+        pf_out(f, prefix, @intCast(pl));
+        pf_pad(f, '0', w, pl + l, fl ^ ZERO_PAD_BIT);
+        pf_out(f, &buf, @intCast(sbuf_diff));
+        pf_pad(f, '0', l - ebuf_minus_estr - sbuf_diff, 0, 0);
+        pf_out(f, estr, @intCast(ebuf_minus_estr));
+        pf_pad(f, ' ', w, pl + l, fl ^ LEFT_ADJ_BIT);
+        return @max(w, pl + l);
+    }
+    if (p < 0) p = 6;
+
+    if (y != 0) {
+        y *= 0x1p28;
+        e2 -= 28;
+    }
+
+    if (e2 < 0) {
+        a = &big;
+        r = a;
+        z = a;
+    } else {
+        const off: usize = big.len - LDBL_MANT_DIG - 1;
+        a = @as([*]u32, &big) + off;
+        r = a;
+        z = a;
+    }
+
+    while (true) {
+        z[0] = @intFromFloat(y);
+        const zv: c_longdouble = @floatFromInt(z[0]);
+        z += 1;
+        y = 1000000000 * (y - zv);
+        if (y == 0) break;
+    }
+
+    while (e2 > 0) {
+        var carry: u32 = 0;
+        const sh: c_int = @min(@as(c_int, 29), e2);
+        d = z - 1;
+        while (@intFromPtr(d) >= @intFromPtr(a)) : (d -= 1) {
+            const x: u64 = (@as(u64, d[0]) << @intCast(sh)) + carry;
+            d[0] = @intCast(x % 1000000000);
+            carry = @intCast(x / 1000000000);
+            if (d == a) break;
+        }
+        if (carry != 0) {
+            a -= 1;
+            a[0] = carry;
+        }
+        while (@intFromPtr(z) > @intFromPtr(a) and (z - 1)[0] == 0) z -= 1;
+        e2 -= sh;
+    }
+    while (e2 < 0) {
+        var carry: u32 = 0;
+        const sh: c_int = @min(@as(c_int, 9), -e2);
+        const need: c_int = 1 + @divFloor(p + @as(c_int, LDBL_MANT_DIG / 3) + 8, 9);
+        d = a;
+        while (@intFromPtr(d) < @intFromPtr(z)) : (d += 1) {
+            const mask: u32 = (@as(u32, 1) << @intCast(sh)) - 1;
+            const rm: u32 = d[0] & mask;
+            d[0] = (d[0] >> @intCast(sh)) + carry;
+            carry = (@as(u32, 1000000000) >> @intCast(sh)) * rm;
+        }
+        if (a[0] == 0) a += 1;
+        if (carry != 0) {
+            z[0] = carry;
+            z += 1;
+        }
+        const b: [*]u32 = if ((t | 32) == 'f') r else a;
+        const zb_diff: c_int = @intCast(@as(isize, @bitCast(@intFromPtr(z) -% @intFromPtr(b))) >> 2);
+        if (zb_diff > need) z = b + @as(usize, @intCast(need));
+        e2 += sh;
+    }
+
+    if (@intFromPtr(a) < @intFromPtr(z)) {
+        i = 10;
+        e = 9 * @as(c_int, @intCast(@as(isize, @bitCast(@intFromPtr(r) -% @intFromPtr(a))) >> 2));
+        while (a[0] >= @as(u32, @intCast(i))) : ({
+            i *= 10;
+            e += 1;
+        }) {}
+    } else {
+        e = 0;
+    }
+
+    // Perform rounding: j is precision after the radix (possibly negative).
+    {
+        const f_match: c_int = @intFromBool((t | 32) != 'f');
+        const g_match: c_int = @intFromBool((t | 32) == 'g' and p != 0);
+        j = p - f_match * e - g_match;
+    }
+    {
+        const z_r_minus_one: c_int = @intCast(@as(isize, @bitCast(@intFromPtr(z) -% @intFromPtr(r))) >> 2);
+        if (j < 9 * (z_r_minus_one - 1)) {
+            // We avoid C's broken division of negative numbers
+            const j_off: c_int = @divTrunc(j + 9 * @as(c_int, LDBL_MAX_EXP), 9) - @as(c_int, LDBL_MAX_EXP);
+            d = r + 1 + @as(usize, @intCast(j_off));
+            var jj: c_int = j + 9 * @as(c_int, LDBL_MAX_EXP);
+            jj = @mod(jj, 9);
+            i = 10;
+            jj += 1;
+            while (jj < 9) : ({
+                i *= 10;
+                jj += 1;
+            }) {}
+            const x: u32 = d[0] % @as(u32, @intCast(i));
+            // Are there any significant digits past j?
+            if (x != 0 or (d + 1) != z) {
+                var round: c_longdouble = 2 / LDBL_EPSILON;
+                var small: c_longdouble = undefined;
+                if (((d[0] / @as(u32, @intCast(i))) & 1) != 0 or
+                    (i == 1000000000 and @intFromPtr(d) > @intFromPtr(a) and ((d - 1)[0] & 1) != 0))
+                {
+                    round += 2;
+                }
+                if (x < @as(u32, @intCast(i)) / 2) {
+                    small = 0x0.8p0;
+                } else if (x == @as(u32, @intCast(i)) / 2 and (d + 1) == z) {
+                    small = 0x1.0p0;
+                } else {
+                    small = 0x1.8p0;
+                }
+                if (pl != 0 and prefix[0] == '-') {
+                    round *= -1;
+                    small *= -1;
+                }
+                d[0] -= x;
+                // Decide whether to round by probing round+small
+                if (round + small != round) {
+                    d[0] = d[0] + @as(u32, @intCast(i));
+                    while (d[0] > 999999999) {
+                        d[0] = 0;
+                        d -= 1;
+                        if (@intFromPtr(d) < @intFromPtr(a)) {
+                            a -= 1;
+                            a[0] = 0;
+                            d = a;
+                        }
+                        d[0] += 1;
+                    }
+                    i = 10;
+                    e = 9 * @as(c_int, @intCast(@as(isize, @bitCast(@intFromPtr(r) -% @intFromPtr(a))) >> 2));
+                    while (a[0] >= @as(u32, @intCast(i))) : ({
+                        i *= 10;
+                        e += 1;
+                    }) {}
+                }
+            }
+            if (@intFromPtr(z) > @intFromPtr(d + 1)) z = d + 1;
+        }
+    }
+    while (@intFromPtr(z) > @intFromPtr(a) and (z - 1)[0] == 0) z -= 1;
+
+    if ((t | 32) == 'g') {
+        if (p == 0) p += 1;
+        if (p > e and e >= -4) {
+            t -= 1;
+            p -= e + 1;
+        } else {
+            t -= 2;
+            p -= 1;
+        }
+        if ((fl & ALT_FORM_BIT) == 0) {
+            // Count trailing zeros in last place
+            const z_r_minus_one: c_int = @intCast(@as(isize, @bitCast(@intFromPtr(z) -% @intFromPtr(r))) >> 2);
+            if (@intFromPtr(z) > @intFromPtr(a) and (z - 1)[0] != 0) {
+                i = 10;
+                j = 0;
+                while ((z - 1)[0] % @as(u32, @intCast(i)) == 0) : ({
+                    i *= 10;
+                    j += 1;
+                }) {}
+            } else {
+                j = 9;
+            }
+            if ((t | 32) == 'f') {
+                p = @min(p, @max(@as(c_int, 0), 9 * (z_r_minus_one - 1) - j));
+            } else {
+                p = @min(p, @max(@as(c_int, 0), 9 * (z_r_minus_one - 1) + e - j));
+            }
+        }
+    }
+    {
+        const extra: c_int = @intFromBool(p != 0 or (fl & ALT_FORM_BIT) != 0);
+        if (p > std.math.maxInt(c_int) - 1 - extra) return -1;
+        l = 1 + p + extra;
+    }
+    if ((t | 32) == 'f') {
+        if (e > std.math.maxInt(c_int) - l) return -1;
+        if (e > 0) l += e;
+    } else {
+        estr = fmt_u(@bitCast(@as(c_longlong, if (e < 0) -e else e)), ebuf);
+        while (@intFromPtr(ebuf) - @intFromPtr(estr) < 2) {
+            estr -= 1;
+            estr[0] = '0';
+        }
+        estr -= 1;
+        estr[0] = if (e < 0) '-' else '+';
+        estr -= 1;
+        estr[0] = @intCast(t);
+        const eb_diff: c_int = @intCast(@intFromPtr(ebuf) - @intFromPtr(estr));
+        if (eb_diff > std.math.maxInt(c_int) - l) return -1;
+        l += eb_diff;
+    }
+
+    if (l > std.math.maxInt(c_int) - pl) return -1;
+    pf_pad(f, ' ', w, pl + l, fl);
+    pf_out(f, prefix, @intCast(pl));
+    pf_pad(f, '0', w, pl + l, fl ^ ZERO_PAD_BIT);
+
+    if ((t | 32) == 'f') {
+        if (@intFromPtr(a) > @intFromPtr(r)) a = r;
+        d = a;
+        while (@intFromPtr(d) <= @intFromPtr(r)) : (d += 1) {
+            var sp: [*]u8 = fmt_u(d[0], @as([*]u8, &buf) + 9);
+            if (d != a) {
+                while (@intFromPtr(sp) > @intFromPtr(&buf)) {
+                    sp -= 1;
+                    sp[0] = '0';
+                }
+            } else if (sp == @as([*]u8, &buf) + 9) {
+                sp -= 1;
+                sp[0] = '0';
+            }
+            pf_out(f, sp, @intFromPtr(&buf) + 9 - @intFromPtr(sp));
+        }
+        if (p != 0 or (fl & ALT_FORM_BIT) != 0) pf_out(f, ".", 1);
+        while (@intFromPtr(d) < @intFromPtr(z) and p > 0) : ({
+            d += 1;
+            p -= 9;
+        }) {
+            var sp: [*]u8 = fmt_u(d[0], @as([*]u8, &buf) + 9);
+            while (@intFromPtr(sp) > @intFromPtr(&buf)) {
+                sp -= 1;
+                sp[0] = '0';
+            }
+            pf_out(f, sp, @intCast(@min(@as(c_int, 9), p)));
+        }
+        pf_pad(f, '0', p + 9, 9, 0);
+    } else {
+        if (@intFromPtr(z) <= @intFromPtr(a)) z = a + 1;
+        d = a;
+        while (@intFromPtr(d) < @intFromPtr(z) and p >= 0) : (d += 1) {
+            var sp: [*]u8 = fmt_u(d[0], @as([*]u8, &buf) + 9);
+            if (sp == @as([*]u8, &buf) + 9) {
+                sp -= 1;
+                sp[0] = '0';
+            }
+            if (d != a) {
+                while (@intFromPtr(sp) > @intFromPtr(&buf)) {
+                    sp -= 1;
+                    sp[0] = '0';
+                }
+            } else {
+                pf_out(f, sp, 1);
+                sp += 1;
+                if (p > 0 or (fl & ALT_FORM_BIT) != 0) pf_out(f, ".", 1);
+            }
+            const remain: usize = @intFromPtr(&buf) + 9 - @intFromPtr(sp);
+            const emit: usize = @min(remain, @as(usize, @intCast(@max(@as(c_int, 0), p))));
+            pf_out(f, sp, emit);
+            p -= @intCast(remain);
+        }
+        pf_pad(f, '0', p + 18, 18, 0);
+        const eb_diff: usize = @intFromPtr(ebuf) - @intFromPtr(estr);
+        pf_out(f, estr, eb_diff);
+    }
+
+    pf_pad(f, ' ', w, pl + l, fl ^ LEFT_ADJ_BIT);
+    return @max(w, pl + l);
+}
+
+fn pf_getint(sp: *[*]const u8) c_int {
+    var i: c_int = 0;
+    while (true) {
+        const c = sp.*[0];
+        if (c < '0' or c > '9') break;
+        const digit: c_int = @as(c_int, c) - '0';
+        if (@as(c_uint, @bitCast(i)) > std.math.maxInt(c_int) / 10 or
+            digit > std.math.maxInt(c_int) - 10 * i)
+        {
+            i = -1;
+        } else {
+            i = 10 * i + digit;
+        }
+        sp.* += 1;
+    }
+    return i;
+}
+
+/// musl printf_core: walks the format string, either counting positional
+/// arg classes (when `f == null`) or emitting formatted output to `f`.
+fn printf_core(
+    f: ?*FILE,
+    fmt_arg: [*:0]const u8,
+    ap: *VaList,
+    nl_arg: *[NL_ARGMAX + 1]PrintfArg,
+    nl_type: *[NL_ARGMAX + 1]c_int,
+) callconv(.c) c_int {
+    var s: [*]const u8 = fmt_arg;
+    var l10n: c_uint = 0;
+    var fl: c_uint = undefined;
+    var w: c_int = undefined;
+    var p: c_int = undefined;
+    var xp: c_int = undefined;
+    var arg: PrintfArg = std.mem.zeroes(PrintfArg);
+    var argpos: c_int = undefined;
+    var st: u8 = undefined;
+    var ps: u8 = undefined;
+    var cnt: c_int = 0;
+    var l: c_int = 0;
+    var i: usize = undefined;
+    var buf: [@sizeOf(c_ulonglong) * 3]u8 = undefined;
+    var prefix: [*]const u8 = undefined;
+    var t: c_int = undefined;
+    var pl: c_int = undefined;
+    var wc: [2]wchar_t = undefined;
+    var ws: [*]const wchar_t = undefined;
+    var mb: [4]u8 = undefined;
+    var a: [*]u8 = undefined;
+    var zp: [*]u8 = undefined;
+
+    while (true) {
+        // Detect output count overflow.
+        if (l > std.math.maxInt(c_int) - cnt) {
+            setErrno(.OVERFLOW);
+            return -1;
+        }
+
+        // Update output count, end loop when fmt is exhausted.
+        cnt += l;
+        if (s[0] == 0) break;
+
+        // Handle literal text and %% format specifiers.
+        const a_lit = s;
+        while (s[0] != 0 and s[0] != '%') s += 1;
+        var z_lit = s;
+        while (s[0] == '%' and s[1] == '%') {
+            z_lit += 1;
+            s += 2;
+        }
+        const lit_len: isize = @intCast(@intFromPtr(z_lit) - @intFromPtr(a_lit));
+        if (lit_len > std.math.maxInt(c_int) - cnt) {
+            setErrno(.OVERFLOW);
+            return -1;
+        }
+        l = @intCast(lit_len);
+        if (f != null) pf_out(f, a_lit, @intCast(l));
+        if (l != 0) continue;
+
+        if (s[1] >= '0' and s[1] <= '9' and s[2] == '$') {
+            l10n = 1;
+            argpos = @as(c_int, s[1]) - '0';
+            s += 3;
+        } else {
+            argpos = -1;
+            s += 1;
+        }
+
+        // Read modifier flags.
+        fl = 0;
+        while (true) {
+            const c = s[0];
+            const bit: c_uint = @as(c_uint, c) -% ' ';
+            if (bit >= 32) break;
+            if ((FLAGMASK & (@as(c_uint, 1) << @as(u5, @intCast(bit)))) == 0) break;
+            fl |= @as(c_uint, 1) << @as(u5, @intCast(bit));
+            s += 1;
+        }
+
+        // Read field width.
+        if (s[0] == '*') {
+            if (s[1] >= '0' and s[1] <= '9' and s[2] == '$') {
+                l10n = 1;
+                if (f == null) {
+                    nl_type[s[1] - '0'] = PF_INT;
+                    w = 0;
+                } else {
+                    w = @intCast(nl_arg[s[1] - '0'].i);
+                }
+                s += 3;
+            } else if (l10n == 0) {
+                w = if (f != null) @cVaArg(ap, c_int) else 0;
+                s += 1;
+            } else {
+                setErrno(.INVAL);
+                return -1;
+            }
+            if (w < 0) {
+                fl |= LEFT_ADJ_BIT;
+                w = -w;
+            }
+        } else {
+            w = pf_getint(&s);
+            if (w < 0) {
+                setErrno(.OVERFLOW);
+                return -1;
+            }
+        }
+
+        // Read precision.
+        if (s[0] == '.' and s[1] == '*') {
+            if (s[2] >= '0' and s[2] <= '9' and s[3] == '$') {
+                if (f == null) {
+                    nl_type[s[2] - '0'] = PF_INT;
+                    p = 0;
+                } else {
+                    p = @intCast(nl_arg[s[2] - '0'].i);
+                }
+                s += 4;
+            } else if (l10n == 0) {
+                p = if (f != null) @cVaArg(ap, c_int) else 0;
+                s += 2;
+            } else {
+                setErrno(.INVAL);
+                return -1;
+            }
+            xp = @intFromBool(p >= 0);
+        } else if (s[0] == '.') {
+            s += 1;
+            p = pf_getint(&s);
+            xp = 1;
+        } else {
+            p = -1;
+            xp = 0;
+        }
+
+        // Format specifier state machine.
+        st = 0;
+        while (true) {
+            if (pf_oob(s[0])) {
+                setErrno(.INVAL);
+                return -1;
+            }
+            ps = st;
+            const idx: usize = @as(usize, s[0]) - 'A';
+            s += 1;
+            st = pf_states[st][idx];
+            if (st - 1 >= PF_STOP) break;
+        }
+        if (st == 0) {
+            setErrno(.INVAL);
+            return -1;
+        }
+
+        // Check validity of argument type (nl/normal).
+        if (st == PF_NOARG) {
+            if (argpos >= 0) {
+                setErrno(.INVAL);
+                return -1;
+            }
+        } else {
+            if (argpos >= 0) {
+                if (f == null) {
+                    nl_type[@as(usize, @intCast(argpos))] = st;
+                } else {
+                    arg = nl_arg[@as(usize, @intCast(argpos))];
+                }
+            } else if (f != null) {
+                pop_arg(&arg, st, ap);
+            } else {
+                return 0;
+            }
+        }
+
+        if (f == null) continue;
+        const ff = f.?;
+
+        // Do not process any new directives once in error state.
+        if (ff.flags & F_ERR != 0) return -1;
+
+        zp = @as([*]u8, &buf) + buf.len;
+        prefix = "-+   0X0x";
+        pl = 0;
+        t = @as(c_int, (s - 1)[0]);
+
+        // Transform ls,lc -> S,C
+        if (ps != 0 and (t & 15) == 3) t &= ~@as(c_int, 32);
+
+        // - and 0 flags are mutually exclusive
+        if ((fl & LEFT_ADJ_BIT) != 0) fl &= ~ZERO_PAD_BIT;
+
+        // The big switch. Done as a labeled block so we can jump to common tail.
+        var skip_common: bool = false;
+        sw: {
+            if (t == 'n') {
+                const p_dest: ?*anyopaque = arg.p;
+                if (p_dest) |pd| {
+                    switch (ps) {
+                        PF_BARE => @as(*c_int, @ptrCast(@alignCast(pd))).* = cnt,
+                        PF_LPRE => @as(*c_long, @ptrCast(@alignCast(pd))).* = cnt,
+                        PF_LLPRE => @as(*c_longlong, @ptrCast(@alignCast(pd))).* = cnt,
+                        PF_HPRE => @as(*c_ushort, @ptrCast(@alignCast(pd))).* = @truncate(@as(c_uint, @bitCast(cnt))),
+                        PF_HHPRE => @as(*u8, @ptrCast(@alignCast(pd))).* = @truncate(@as(c_uint, @bitCast(cnt))),
+                        PF_ZTPRE => @as(*usize, @ptrCast(@alignCast(pd))).* = @intCast(cnt),
+                        PF_JPRE => @as(*c_ulonglong, @ptrCast(@alignCast(pd))).* = @intCast(cnt),
+                        else => {},
+                    }
+                }
+                skip_common = true;
+                break :sw;
+            }
+            if (t == 'p') {
+                p = @max(p, 2 * @as(c_int, @sizeOf(usize)));
+                t = 'x';
+                fl |= ALT_FORM_BIT;
+            }
+            if (t == 'x' or t == 'X') {
+                a = fmt_x(arg.i, zp, t & 32);
+                if (arg.i != 0 and (fl & ALT_FORM_BIT) != 0) {
+                    prefix += @as(usize, @intCast(@as(c_uint, @bitCast(t)) >> 4));
+                    pl = 2;
+                }
+            } else if (t == 'o') {
+                a = fmt_o(arg.i, zp);
+                const a_len: c_int = @intCast(@intFromPtr(zp) - @intFromPtr(a));
+                if ((fl & ALT_FORM_BIT) != 0 and p < a_len + 1) p = a_len + 1;
+            } else if (t == 'd' or t == 'i') {
+                pl = 1;
+                if (arg.i > @as(c_ulonglong, std.math.maxInt(c_longlong))) {
+                    arg.i = 0 -% arg.i;
+                } else if ((fl & MARK_POS_BIT) != 0) {
+                    prefix += 1;
+                } else if ((fl & PAD_POS_BIT) != 0) {
+                    prefix += 2;
+                } else {
+                    pl = 0;
+                }
+                a = fmt_u(arg.i, zp);
+            } else if (t == 'u') {
+                a = fmt_u(arg.i, zp);
+            } else if (t == 'c' or t == 'C') {
+                // 'C' with arg.i==0 falls through to narrow 'c' handling.
+                if (t == 'C' and arg.i != 0) {
+                    wc[0] = @intCast(arg.i);
+                    wc[1] = 0;
+                    arg.p = @ptrCast(&wc);
+                    p = -1;
+                }
+                if (t == 'c' or arg.i == 0) {
+                    zp -= 1;
+                    p = 1;
+                    a = zp;
+                    a[0] = @truncate(arg.i);
+                    fl &= ~ZERO_PAD_BIT;
+                } else {
+                    // 'C' with non-zero falls through to 'S' handling below.
+                    ws = @ptrCast(@alignCast(arg.p));
+                    i = 0;
+                    l = 0;
+                    while (true) {
+                        if (i >= @as(usize, @intCast(@max(@as(c_int, 0), p))) and p >= 0) break;
+                        if (ws[0] == 0) break;
+                        const wl: c_int = wctomb_fn(&mb, ws[0]);
+                        ws += 1;
+                        if (wl < 0) {
+                            l = wl;
+                            break;
+                        }
+                        if (p >= 0 and wl > p - @as(c_int, @intCast(i))) break;
+                        l = wl;
+                        i += @as(usize, @intCast(wl));
+                    }
+                    if (l < 0) return -1;
+                    if (i > std.math.maxInt(c_int)) {
+                        setErrno(.OVERFLOW);
+                        return -1;
+                    }
+                    p = @intCast(i);
+                    pf_pad(f, ' ', w, p, fl);
+                    ws = @ptrCast(@alignCast(arg.p));
+                    i = 0;
+                    while (i < @as(usize, @intCast(p)) and ws[0] != 0) {
+                        const wl: c_int = wctomb_fn(&mb, ws[0]);
+                        ws += 1;
+                        if (i + @as(usize, @intCast(wl)) > @as(usize, @intCast(p))) break;
+                        pf_out(f, &mb, @intCast(wl));
+                        i += @as(usize, @intCast(wl));
+                    }
+                    pf_pad(f, ' ', w, p, fl ^ LEFT_ADJ_BIT);
+                    l = if (w > p) w else p;
+                    skip_common = true;
+                    break :sw;
+                }
+            } else if (t == 's' or t == 'm') {
+                a = if (t == 'm')
+                    @constCast(strerror_fn(std.c._errno().*))
+                else if (arg.p != null)
+                    @ptrCast(@alignCast(arg.p))
+                else
+                    @ptrCast(@constCast(@as([*]const u8, "(null)")));
+                const limit: usize = if (p < 0) std.math.maxInt(c_int) else @as(usize, @intCast(p));
+                const nlen = strnlen(a, limit);
+                const z_ptr: [*]u8 = a + nlen;
+                if (p < 0 and z_ptr[0] != 0) {
+                    setErrno(.OVERFLOW);
+                    return -1;
+                }
+                p = @intCast(@intFromPtr(z_ptr) - @intFromPtr(a));
+                zp = z_ptr;
+                fl &= ~ZERO_PAD_BIT;
+            } else if (t == 'S') {
+                ws = @ptrCast(@alignCast(arg.p));
+                i = 0;
+                l = 0;
+                while (true) {
+                    if (p >= 0 and i >= @as(usize, @intCast(p))) break;
+                    if (ws[0] == 0) break;
+                    const wl: c_int = wctomb_fn(&mb, ws[0]);
+                    ws += 1;
+                    if (wl < 0) {
+                        l = wl;
+                        break;
+                    }
+                    if (p >= 0 and wl > p - @as(c_int, @intCast(i))) break;
+                    l = wl;
+                    i += @as(usize, @intCast(wl));
+                }
+                if (l < 0) return -1;
+                if (i > std.math.maxInt(c_int)) {
+                    setErrno(.OVERFLOW);
+                    return -1;
+                }
+                p = @intCast(i);
+                pf_pad(f, ' ', w, p, fl);
+                ws = @ptrCast(@alignCast(arg.p));
+                i = 0;
+                while (i < @as(usize, @intCast(p)) and ws[0] != 0) {
+                    const wl: c_int = wctomb_fn(&mb, ws[0]);
+                    ws += 1;
+                    if (i + @as(usize, @intCast(wl)) > @as(usize, @intCast(p))) break;
+                    pf_out(f, &mb, @intCast(wl));
+                    i += @as(usize, @intCast(wl));
+                }
+                pf_pad(f, ' ', w, p, fl ^ LEFT_ADJ_BIT);
+                l = if (w > p) w else p;
+                skip_common = true;
+                break :sw;
+            } else switch (t) {
+                'e', 'f', 'g', 'a', 'E', 'F', 'G', 'A' => {
+                    if (xp != 0 and p < 0) {
+                        setErrno(.OVERFLOW);
+                        return -1;
+                    }
+                    l = fmt_fp(f, arg.f, w, p, fl, t);
+                    if (l < 0) {
+                        setErrno(.OVERFLOW);
+                        return -1;
+                    }
+                    skip_common = true;
+                    break :sw;
+                },
+                else => {},
+            }
+
+            // Tail logic shared by x/X/o/d/i/u/c/C(narrow)/s/m.
+            if (t == 'x' or t == 'X' or t == 'o' or t == 'd' or t == 'i' or t == 'u') {
+                if (xp != 0 and p < 0) {
+                    setErrno(.OVERFLOW);
+                    return -1;
+                }
+                if (xp != 0) fl &= ~ZERO_PAD_BIT;
+                if (arg.i == 0 and p == 0) {
+                    a = zp;
+                } else {
+                    const az_diff: c_int = @intCast(@intFromPtr(zp) - @intFromPtr(a));
+                    const bump: c_int = @intFromBool(arg.i == 0);
+                    p = @max(p, az_diff + bump);
+                }
+            }
+        }
+
+        if (skip_common) continue;
+
+        const a_len: c_int = @intCast(@intFromPtr(zp) - @intFromPtr(a));
+        if (p < a_len) p = a_len;
+        if (p > std.math.maxInt(c_int) - pl) {
+            setErrno(.OVERFLOW);
+            return -1;
+        }
+        if (w < pl + p) w = pl + p;
+        if (w > std.math.maxInt(c_int) - cnt) {
+            setErrno(.OVERFLOW);
+            return -1;
+        }
+
+        pf_pad(f, ' ', w, pl + p, fl);
+        pf_out(f, prefix, @intCast(pl));
+        pf_pad(f, '0', w, pl + p, fl ^ ZERO_PAD_BIT);
+        pf_pad(f, '0', p, a_len, 0);
+        pf_out(f, a, @intCast(a_len));
+        pf_pad(f, ' ', w, pl + p, fl ^ LEFT_ADJ_BIT);
+
+        l = w;
+    }
+
+    if (f != null) return cnt;
+    if (l10n == 0) return 0;
+
+    var k: usize = 1;
+    while (k <= NL_ARGMAX and nl_type[k] != 0) : (k += 1) {
+        pop_arg(&nl_arg[k], @intCast(nl_type[k]), ap);
+    }
+    while (k <= NL_ARGMAX and nl_type[k] == 0) : (k += 1) {}
+    if (k <= NL_ARGMAX) {
+        setErrno(.INVAL);
+        return -1;
+    }
+    return 1;
+}
+
+inline fn strnlen(s: [*]const u8, n: usize) usize {
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        if (s[i] == 0) break;
+    }
+    return i;
+}
+
+/// vfprintf.c: int vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap)
+fn vfprintf_impl(f_opt: ?*FILE, fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
+    const f = f_opt.?;
+    var ap_src = ap;
+    var ap2 = @cVaCopy(&ap_src);
+    var nl_type: [NL_ARGMAX + 1]c_int = [_]c_int{0} ** (NL_ARGMAX + 1);
+    var nl_arg: [NL_ARGMAX + 1]PrintfArg = undefined;
+    var internal_buf: [80]u8 = undefined;
+    var saved_buf: ?[*]u8 = null;
+    var ret: c_int = undefined;
+
+    if (printf_core(null, fmt, &ap2, &nl_arg, &nl_type) < 0) {
+        @cVaEnd(&ap2);
+        return -1;
+    }
+
+    const need_unlock = flock(f);
+    const olderr: c_uint = f.flags & F_ERR;
+    f.flags &= ~F_ERR;
+    if (f.buf_size == 0) {
+        saved_buf = f.buf;
+        f.buf = &internal_buf;
+        f.buf_size = internal_buf.len;
+        f.wpos = null;
+        f.wbase = null;
+        f.wend = null;
+    }
+    if (f.wend == null and towrite_impl(f) != 0) {
+        ret = -1;
+    } else {
+        ret = printf_core(f, fmt, &ap2, &nl_arg, &nl_type);
+    }
+    if (saved_buf) |sb| {
+        _ = f.write_fn.?(f, @ptrCast(fmt), 0);
+        if (f.wpos == null) ret = -1;
+        f.buf = sb;
+        f.buf_size = 0;
+        f.wpos = null;
+        f.wbase = null;
+        f.wend = null;
+    }
+    if (f.flags & F_ERR != 0) ret = -1;
+    f.flags |= olderr;
+    funlock(f, need_unlock);
+    @cVaEnd(&ap2);
+    return ret;
+}
+
+// === end of vfprintf ===
+
 fn sn_write(f: *FILE, s: [*]const u8, l: usize) callconv(.c) usize {
     const c: *SnCookie = @ptrCast(@alignCast(f.cookie.?));
     const wbase = f.wbase orelse @as([*]u8, @ptrCast(@constCast(s)));
@@ -1921,7 +3075,7 @@ fn vsnprintf_impl(s: [*]u8, n: usize, fmt: [*:0]const u8, ap: VaList) callconv(.
     f.buf = &buf;
     f.cookie = @ptrCast(&c);
     c.s[0] = 0;
-    return vfprintf_fn(@ptrCast(&f), fmt, ap);
+    return vfprintf_impl(@ptrCast(&f), fmt, ap);
 }
 
 /// vsprintf.c: int vsprintf(char *restrict s, const char *restrict fmt, va_list ap)
@@ -2808,7 +3962,7 @@ fn vwscanf_impl(fmt: [*:0]const wchar_t, ap: VaList) callconv(.c) c_int {
 
 /// vprintf.c: int vprintf(const char *restrict fmt, va_list ap)
 fn vprintf_impl(fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
-    return vfprintf_fn(stdout_ext.*, fmt, ap);
+    return vfprintf_impl(stdout_ext.*, fmt, ap);
 }
 
 /// vscanf.c: int vscanf(const char *restrict fmt, va_list ap)
@@ -2822,14 +3976,14 @@ fn vscanf_impl(fmt: [*:0]const u8, ap: VaList) callconv(.c) c_int {
 fn printf_impl(fmt: [*:0]const u8, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfprintf_fn(stdout_ext.*, fmt, ap);
+    return vfprintf_impl(stdout_ext.*, fmt, ap);
 }
 
 /// fprintf.c
 fn fprintf_impl(f: ?*FILE, fmt: [*:0]const u8, ...) callconv(.c) c_int {
     var ap = @cVaStart();
     defer @cVaEnd(&ap);
-    return vfprintf_fn(f, fmt, ap);
+    return vfprintf_impl(f, fmt, ap);
 }
 
 /// sprintf.c

--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -2392,9 +2392,13 @@ fn fmt_fp(f: ?*FILE, y_in: c_longdouble, w: c_int, p_in: c_int, fl_in: c_uint, t
     {
         const z_r_minus_one: c_int = @intCast(@as(isize, @bitCast(@intFromPtr(z) -% @intFromPtr(r))) >> 2);
         if (j < 9 * (z_r_minus_one - 1)) {
-            // We avoid C's broken division of negative numbers
+            // We avoid C's broken division of negative numbers.
+            // j_off can be negative: musl's `r + 1 + j_off` is signed
+            // pointer arithmetic, so do the same in Zig (offset r as isize).
             const j_off: c_int = @divTrunc(j + 9 * @as(c_int, LDBL_MAX_EXP), 9) - @as(c_int, LDBL_MAX_EXP);
-            d = r + 1 + @as(usize, @intCast(j_off));
+            const d_addr: isize = @as(isize, @bitCast(@intFromPtr(r))) +
+                (@as(isize, 1) + @as(isize, j_off)) * @sizeOf(u32);
+            d = @ptrFromInt(@as(usize, @bitCast(d_addr)));
             var jj: c_int = j + 9 * @as(c_int, LDBL_MAX_EXP);
             jj = @mod(jj, 9);
             i = 10;

--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -2066,6 +2066,36 @@ inline fn pf_oob(c: u8) bool {
     return @as(c_uint, c) -% 'A' > 'z' - 'A';
 }
 
+/// Manual `va_arg(*ap, long double)` for x86_64 SysV. Zig's self-hosted
+/// x86_64 backend does not yet implement c_va_arg for the X87+X87UP class
+/// combination that c_longdouble (x86_fp80) falls into on SysV; see
+/// `src/codegen/x86_64/CodeGen.zig::airVaArg` ("TODO implement c_va_arg
+/// for c_longdouble on SysV"). On SysV, long double is MEMORY class and
+/// always passed via the overflow_arg_area in 16-byte aligned, 16-byte
+/// slots, so we open-code the load and pointer bump here.
+fn vaArgLongDoubleX86_64SysV(ap: *VaList) c_longdouble {
+    const va: *std.builtin.VaListX86_64 = ap;
+    const raw = @intFromPtr(va.overflow_arg_area);
+    const aligned = std.mem.alignForward(usize, raw, 16);
+    const v = @as(*c_longdouble, @ptrFromInt(aligned)).*;
+    va.overflow_arg_area = @ptrFromInt(aligned + 16);
+    return v;
+}
+
+fn vaArgLongDoubleBuiltin(ap: *VaList) c_longdouble {
+    return @cVaArg(ap, c_longdouble);
+}
+
+const vaArgLongDouble: fn (ap: *VaList) c_longdouble = blk: {
+    if (builtin.cpu.arch == .x86_64 and
+        builtin.os.tag != .windows and
+        builtin.os.tag != .uefi)
+    {
+        break :blk vaArgLongDoubleX86_64SysV;
+    }
+    break :blk vaArgLongDoubleBuiltin;
+};
+
 fn pop_arg(arg: *PrintfArg, ty: u8, ap: *VaList) callconv(.c) void {
     switch (ty) {
         PF_PTR => arg.p = @cVaArg(ap, ?*anyopaque),
@@ -2085,7 +2115,7 @@ fn pop_arg(arg: *PrintfArg, ty: u8, ap: *VaList) callconv(.c) void {
         PF_PDIFF => arg.i = @bitCast(@as(c_longlong, @cVaArg(ap, isize))),
         PF_UIPTR => arg.i = @intFromPtr(@cVaArg(ap, ?*anyopaque)),
         PF_DBL => arg.f = @floatCast(@cVaArg(ap, f64)),
-        PF_LDBL => arg.f = @cVaArg(ap, c_longdouble),
+        PF_LDBL => arg.f = vaArgLongDouble(ap),
         else => {},
     }
 }
@@ -2808,9 +2838,10 @@ fn printf_core(
                     p = -1;
                 }
                 if (t == 'c' or arg.i == 0) {
-                    zp -= 1;
+                    // musl: *(a = z - (p = 1)) = arg.i;
+                    // Do NOT mutate zp so the common tail's `a_len = zp - a` is 1.
                     p = 1;
-                    a = zp;
+                    a = zp - 1;
                     a[0] = @truncate(arg.i);
                     fl &= ~ZERO_PAD_BIT;
                 } else {

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -734,7 +734,7 @@ const src_files = [_][]const u8{
     //"musl/src/stdio/ungetwc.c", // migrated to lib/c/stdio.zig
     // "musl/src/stdio/vasprintf.c", // migrated to Zig (vasprintf_impl)
     // "musl/src/stdio/vdprintf.c", // migrated to Zig (vdprintf_impl)
-    "musl/src/stdio/vfprintf.c",
+    //"musl/src/stdio/vfprintf.c", // migrated to lib/c/stdio.zig
     //"musl/src/stdio/vfscanf.c", // migrated to lib/c/stdio.zig
     "musl/src/stdio/vfwprintf.c",
     //"musl/src/stdio/vfwscanf.c", // migrated to lib/c/stdio.zig


### PR DESCRIPTION
Closes #320.

Migrates the variadic-printf core (703 LoC) from musl C to Zig in lib/c/stdio.zig. Replaces the existing `vfprintf_fn` extern that vprintf/vsprintf/vsnprintf/vdprintf/vasprintf/vswprintf/vwprintf currently delegate to.

Algorithm ported verbatim: pop_arg dispatch (18 type classes), fmt_fp float formatting with %e/%f/%g/%a, fmt_x/fmt_o/fmt_u integer formatters, getint width/precision parser, the states[] finite-state machine over the format string.

Critical regression tests:
- functional.printf-*, functional.snprintf, functional.swprintf, functional.fprintf
- regression.printf-1e9-oob, regression.scanf-bytes-consumed