### PR TITLE
libzigc: migrate math bessel + lgammal to Zig

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -3701,7 +3701,7 @@ fn lgammal80_sin_pi(x_: f80) f80 {
     x *= 0.5;
     x = 2.0 * (x - @floor(x));
     var n: c_int = @intFromFloat(x * 4.0);
-    n = (n + 1) / 2;
+    n = @divTrunc(n + 1, 2);
     x -= @as(f80, @floatFromInt(n)) * 0.5;
     x *= lgammal80_pi;
     return switch (n) {

--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -146,14 +146,14 @@ const powf_impl = struct {
 
         // log2(x) = log1p(z/c-1)/ln2 + log2(c) + k
         const r = z * invc - 1;
-        const y0 = logc + k;
+        const y0_log = logc + k;
 
         // Pipelined polynomial evaluation to approximate log1p(r)/ln2.
         const r2 = r * r;
         var yy = A[0] * r + A[1];
         const p = A[2] * r + A[3];
         const r4 = r2 * r2;
-        var q = A[4] * r + y0;
+        var q = A[4] * r + y0_log;
         q = p * r2 + q;
         yy = yy * r4 + q;
         return yy;
@@ -1153,6 +1153,16 @@ comptime {
         symbol(&lgammaf_, "lgammaf");
         symbol(&lgamma_r, "__lgamma_r");
         symbol(&lgammaf_r, "__lgammaf_r");
+        symbol(&lgammal_, "lgammal");
+        symbol(&lgammal_r_, "__lgammal_r");
+        symbol(&j0, "j0");
+        symbol(&y0, "y0");
+        symbol(&j0f, "j0f");
+        symbol(&y0f, "y0f");
+        symbol(&j1, "j1");
+        symbol(&y1, "y1");
+        symbol(&j1f, "j1f");
+        symbol(&y1f, "y1f");
         symbol(&powl, "powl");
         symbol(&log1pl, "log1pl");
     }
@@ -1188,6 +1198,7 @@ comptime {
     @export(&__signgam, .{ .name = "signgam", .linkage = .weak });
     @export(&lgamma_r, .{ .name = "lgamma_r", .linkage = .weak });
     @export(&lgammaf_r, .{ .name = "lgammaf_r", .linkage = .weak });
+    @export(&lgammal_r_, .{ .name = "lgammal_r", .linkage = .weak });
 }
 
 fn acos(x: f64) callconv(.c) f64 {
@@ -3072,4 +3083,847 @@ fn pow10l(x: c_longdouble) callconv(.c) c_longdouble {
 
 fn sinh(x: f64) callconv(.c) f64 {
     return math.sinh(x);
+}
+
+// migrated from musl/src/math/j0.c
+const bessel_invsqrtpi64: f64 = 5.64189583547756279280e-01;
+const bessel_tpi64: f64 = 6.36619772367581382433e-01;
+
+const j0_R02: f64 = 1.56249999999999947958e-02;
+const j0_R03: f64 = -1.89979294238854721751e-04;
+const j0_R04: f64 = 1.82954049532700665670e-06;
+const j0_R05: f64 = -4.61832688532103189199e-09;
+const j0_S01: f64 = 1.56191029464890010492e-02;
+const j0_S02: f64 = 1.16926784663337450260e-04;
+const j0_S03: f64 = 5.13546550207318111446e-07;
+const j0_S04: f64 = 1.16614003333790000205e-09;
+
+const y0_u00: f64 = -7.38042951086872317523e-02;
+const y0_u01: f64 = 1.76666452509181115538e-01;
+const y0_u02: f64 = -1.38185671945596898896e-02;
+const y0_u03: f64 = 3.47453432093683650238e-04;
+const y0_u04: f64 = -3.81407053724364161125e-06;
+const y0_u05: f64 = 1.95590137035022920206e-08;
+const y0_u06: f64 = -3.98205194132103398453e-11;
+const y0_v01: f64 = 1.27304834834123699328e-02;
+const y0_v02: f64 = 7.60068627350353253702e-05;
+const y0_v03: f64 = 2.59150851840457805467e-07;
+const y0_v04: f64 = 4.41110311332675467403e-10;
+
+const j0_pR8 = [_]f64{ 0.00000000000000000000e+00, -7.03124999999900357484e-02, -8.08167041275349795626e+00, -2.57063105679704847262e+02, -2.48521641009428822144e+03, -5.25304380490729545272e+03 };
+const j0_pS8 = [_]f64{ 1.16534364619668181717e+02, 3.83374475364121826715e+03, 4.05978572648472545552e+04, 1.16752972564375915681e+05, 4.76277284146730962675e+04 };
+const j0_pR5 = [_]f64{ -1.14125464691894502584e-11, -7.03124940873599280078e-02, -4.15961064470587782438e+00, -6.76747652265167261021e+01, -3.31231299649172967747e+02, -3.46433388365604912451e+02 };
+const j0_pS5 = [_]f64{ 6.07539382692300335975e+01, 1.05125230595704579173e+03, 5.97897094333855784498e+03, 9.62544514357774460223e+03, 2.40605815922939109441e+03 };
+const j0_pR3 = [_]f64{ -2.54704601771951915620e-09, -7.03119616381481654654e-02, -2.40903221549529611423e+00, -2.19659774734883086467e+01, -5.80791704701737572236e+01, -3.14479470594888503854e+01 };
+const j0_pS3 = [_]f64{ 3.58560338055209726349e+01, 3.61513983050303863820e+02, 1.19360783792111533330e+03, 1.12799679856907414432e+03, 1.73580930813335754692e+02 };
+const j0_pR2 = [_]f64{ -8.87534333032526411254e-08, -7.03030995483624743247e-02, -1.45073846780952986357e+00, -7.63569613823527770791e+00, -1.11931668860356747786e+01, -3.23364579351335335033e+00 };
+const j0_pS2 = [_]f64{ 2.22202997532088808441e+01, 1.36206794218215208048e+02, 2.70470278658083486789e+02, 1.53875394208320329881e+02, 1.46576176948256193810e+01 };
+
+const j0_qR8 = [_]f64{ 0.00000000000000000000e+00, 7.32421874999935051953e-02, 1.17682064682252693899e+01, 5.57673380256401856059e+02, 8.85919720756468632317e+03, 3.70146267776887834771e+04 };
+const j0_qS8 = [_]f64{ 1.63776026895689824414e+02, 8.09834494656449805916e+03, 1.42538291419120476348e+05, 8.03309257119514397345e+05, 8.40501579819060512818e+05, -3.43899293537866615225e+05 };
+const j0_qR5 = [_]f64{ 1.84085963594515531381e-11, 7.32421766612684765896e-02, 5.83563508962056953777e+00, 1.35111577286449829671e+02, 1.02724376596164097464e+03, 1.98997785864605384631e+03 };
+const j0_qS5 = [_]f64{ 8.27766102236537761883e+01, 2.07781416421392987104e+03, 1.88472887785718085070e+04, 5.67511122894947329769e+04, 3.59767538425114471465e+04, -5.35434275601944773371e+03 };
+const j0_qR3 = [_]f64{ 4.37741014089738620906e-09, 7.32411180042911447163e-02, 3.34423137516170720929e+00, 4.26218440745412650017e+01, 1.70808091340565596283e+02, 1.66733948696651168575e+02 };
+const j0_qS3 = [_]f64{ 4.87588729724587182091e+01, 7.09689221056606015736e+02, 3.70414822620111362994e+03, 6.46042516752568917582e+03, 2.51633368920368957333e+03, -1.49247451836156386662e+02 };
+const j0_qR2 = [_]f64{ 1.50444444886983272379e-07, 7.32234265963079278272e-02, 1.99819174093815998816e+00, 1.44956029347885735348e+01, 3.16662317504781540833e+01, 1.62527075710929267416e+01 };
+const j0_qS2 = [_]f64{ 3.03655848355219184498e+01, 2.69348118608049844624e+02, 8.44783757595320139444e+02, 8.82935845112488550512e+02, 2.12666388511798828631e+02, -5.31095493882666946917e+00 };
+
+fn j0_common(ix: u32, x: f64, y0_: bool) f64 {
+    const s = @sin(x);
+    var c = @cos(x);
+    if (y0_) c = -c;
+    var cc = s + c;
+    if (ix < 0x7fe00000) {
+        var ss = s - c;
+        const z = -@cos(2 * x);
+        if (s * c < 0)
+            cc = z / ss
+        else
+            ss = z / cc;
+        if (ix < 0x48000000) {
+            if (y0_) ss = -ss;
+            cc = j0_pzero(x) * cc - j0_qzero(x) * ss;
+        }
+    }
+    return bessel_invsqrtpi64 * cc / @sqrt(x);
+}
+
+fn j0(x_: f64) callconv(.c) f64 {
+    const bits: u64 = @bitCast(x_);
+    var ix: u32 = @truncate(bits >> 32);
+    ix &= 0x7fffffff;
+
+    if (ix >= 0x7ff00000) return 1 / (x_ * x_);
+    const x = @abs(x_);
+    if (ix >= 0x40000000) return j0_common(ix, x, false);
+    if (ix >= 0x3f200000) {
+        const z = x * x;
+        const r = z * (j0_R02 + z * (j0_R03 + z * (j0_R04 + z * j0_R05)));
+        const s = 1 + z * (j0_S01 + z * (j0_S02 + z * (j0_S03 + z * j0_S04)));
+        return (1 + x / 2) * (1 - x / 2) + z * (r / s);
+    }
+    var y = x;
+    if (ix >= 0x38000000) y = 0.25 * y * y;
+    return 1 - y;
+}
+
+fn y0(x: f64) callconv(.c) f64 {
+    const bits: u64 = @bitCast(x);
+    const ix: u32 = @truncate(bits >> 32);
+    const lx: u32 = @truncate(bits);
+
+    if (((ix << 1) | lx) == 0) return -1 / @as(f64, 0.0);
+    if ((ix >> 31) != 0) return 0 / @as(f64, 0.0);
+    if (ix >= 0x7ff00000) return 1 / x;
+    if (ix >= 0x40000000) return j0_common(ix, x, true);
+    if (ix >= 0x3e400000) {
+        const z = x * x;
+        const u = y0_u00 + z * (y0_u01 + z * (y0_u02 + z * (y0_u03 + z * (y0_u04 + z * (y0_u05 + z * y0_u06)))));
+        const v = 1.0 + z * (y0_v01 + z * (y0_v02 + z * (y0_v03 + z * y0_v04)));
+        return u / v + bessel_tpi64 * (j0(x) * @log(x));
+    }
+    return y0_u00 + bessel_tpi64 * @log(x);
+}
+
+fn j0_pzero(x: f64) f64 {
+    var p: []const f64 = undefined;
+    var q: []const f64 = undefined;
+    const bits: u64 = @bitCast(x);
+    const ix: u32 = @as(u32, @truncate(bits >> 32)) & 0x7fffffff;
+    if (ix >= 0x40200000) {
+        p = j0_pR8[0..];
+        q = j0_pS8[0..];
+    } else if (ix >= 0x40122E8B) {
+        p = j0_pR5[0..];
+        q = j0_pS5[0..];
+    } else if (ix >= 0x4006DB6D) {
+        p = j0_pR3[0..];
+        q = j0_pS3[0..];
+    } else {
+        p = j0_pR2[0..];
+        q = j0_pS2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * q[4]))));
+    return 1.0 + r / s;
+}
+
+fn j0_qzero(x: f64) f64 {
+    var p: []const f64 = undefined;
+    var q: []const f64 = undefined;
+    const bits: u64 = @bitCast(x);
+    const ix: u32 = @as(u32, @truncate(bits >> 32)) & 0x7fffffff;
+    if (ix >= 0x40200000) {
+        p = j0_qR8[0..];
+        q = j0_qS8[0..];
+    } else if (ix >= 0x40122E8B) {
+        p = j0_qR5[0..];
+        q = j0_qS5[0..];
+    } else if (ix >= 0x4006DB6D) {
+        p = j0_qR3[0..];
+        q = j0_qS3[0..];
+    } else {
+        p = j0_qR2[0..];
+        q = j0_qS2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * (q[4] + z * q[5])))));
+    return (-0.125 + r / s) / x;
+}
+
+// migrated from musl/src/math/j0f.c
+const bessel_invsqrtpi32: f32 = 5.6418961287e-01;
+const bessel_tpi32: f32 = 6.3661974669e-01;
+
+const j0f_R02: f32 = 1.5625000000e-02;
+const j0f_R03: f32 = -1.8997929874e-04;
+const j0f_R04: f32 = 1.8295404516e-06;
+const j0f_R05: f32 = -4.6183270541e-09;
+const j0f_S01: f32 = 1.5619102865e-02;
+const j0f_S02: f32 = 1.1692678527e-04;
+const j0f_S03: f32 = 5.1354652442e-07;
+const j0f_S04: f32 = 1.1661400734e-09;
+
+const y0f_u00: f32 = -7.3804296553e-02;
+const y0f_u01: f32 = 1.7666645348e-01;
+const y0f_u02: f32 = -1.3818567619e-02;
+const y0f_u03: f32 = 3.4745343146e-04;
+const y0f_u04: f32 = -3.8140706238e-06;
+const y0f_u05: f32 = 1.9559013964e-08;
+const y0f_u06: f32 = -3.9820518410e-11;
+const y0f_v01: f32 = 1.2730483897e-02;
+const y0f_v02: f32 = 7.6006865129e-05;
+const y0f_v03: f32 = 2.5915085189e-07;
+const y0f_v04: f32 = 4.4111031494e-10;
+
+const j0f_pR8 = [_]f32{ 0.0000000000e+00, -7.0312500000e-02, -8.0816707611e+00, -2.5706311035e+02, -2.4852163086e+03, -5.2530439453e+03 };
+const j0f_pS8 = [_]f32{ 1.1653436279e+02, 3.8337448730e+03, 4.0597855469e+04, 1.1675296875e+05, 4.7627726562e+04 };
+const j0f_pR5 = [_]f32{ -1.1412546255e-11, -7.0312492549e-02, -4.1596107483e+00, -6.7674766541e+01, -3.3123129272e+02, -3.4643338013e+02 };
+const j0f_pS5 = [_]f32{ 6.0753936768e+01, 1.0512523193e+03, 5.9789707031e+03, 9.6254453125e+03, 2.4060581055e+03 };
+const j0f_pR3 = [_]f32{ -2.5470459075e-09, -7.0311963558e-02, -2.4090321064e+00, -2.1965976715e+01, -5.8079170227e+01, -3.1447946548e+01 };
+const j0f_pS3 = [_]f32{ 3.5856033325e+01, 3.6151397705e+02, 1.1936077881e+03, 1.1279968262e+03, 1.7358093262e+02 };
+const j0f_pR2 = [_]f32{ -8.8753431271e-08, -7.0303097367e-02, -1.4507384300e+00, -7.6356959343e+00, -1.1193166733e+01, -3.2336456776e+00 };
+const j0f_pS2 = [_]f32{ 2.2220300674e+01, 1.3620678711e+02, 2.7047027588e+02, 1.5387539673e+02, 1.4657617569e+01 };
+
+const j0f_qR8 = [_]f32{ 0.0000000000e+00, 7.3242187500e-02, 1.1768206596e+01, 5.5767340088e+02, 8.8591972656e+03, 3.7014625000e+04 };
+const j0f_qS8 = [_]f32{ 1.6377603149e+02, 8.0983447266e+03, 1.4253829688e+05, 8.0330925000e+05, 8.4050156250e+05, -3.4389928125e+05 };
+const j0f_qR5 = [_]f32{ 1.8408595828e-11, 7.3242180049e-02, 5.8356351852e+00, 1.3511157227e+02, 1.0272437744e+03, 1.9899779053e+03 };
+const j0f_qS5 = [_]f32{ 8.2776611328e+01, 2.0778142090e+03, 1.8847289062e+04, 5.6751113281e+04, 3.5976753906e+04, -5.3543427734e+03 };
+const j0f_qR3 = [_]f32{ 4.3774099900e-09, 7.3241114616e-02, 3.3442313671e+00, 4.2621845245e+01, 1.7080809021e+02, 1.6673394775e+02 };
+const j0f_qS3 = [_]f32{ 4.8758872986e+01, 7.0968920898e+02, 3.7041481934e+03, 6.4604252930e+03, 2.5163337402e+03, -1.4924745178e+02 };
+const j0f_qR2 = [_]f32{ 1.5044444979e-07, 7.3223426938e-02, 1.9981917143e+00, 1.4495602608e+01, 3.1666231155e+01, 1.6252708435e+01 };
+const j0f_qS2 = [_]f32{ 3.0365585327e+01, 2.6934811401e+02, 8.4478375244e+02, 8.8293585205e+02, 2.1266638184e+02, -5.3109550476e+00 };
+
+fn j0f_common(ix: u32, x: f32, y0_: bool) f32 {
+    const s = @sin(x);
+    var c = @cos(x);
+    if (y0_) c = -c;
+    var cc = s + c;
+    if (ix < 0x7f000000) {
+        var ss = s - c;
+        const z = -@cos(2 * x);
+        if (s * c < 0)
+            cc = z / ss
+        else
+            ss = z / cc;
+        if (ix < 0x58800000) {
+            if (y0_) ss = -ss;
+            cc = j0f_pzero(x) * cc - j0f_qzero(x) * ss;
+        }
+    }
+    return bessel_invsqrtpi32 * cc / @sqrt(x);
+}
+
+fn j0f(x_: f32) callconv(.c) f32 {
+    var ix: u32 = @bitCast(x_);
+    ix &= 0x7fffffff;
+    if (ix >= 0x7f800000) return 1 / (x_ * x_);
+    const x = @abs(x_);
+    if (ix >= 0x40000000) return j0f_common(ix, x, false);
+    if (ix >= 0x3a000000) {
+        const z = x * x;
+        const r = z * (j0f_R02 + z * (j0f_R03 + z * (j0f_R04 + z * j0f_R05)));
+        const s = 1 + z * (j0f_S01 + z * (j0f_S02 + z * (j0f_S03 + z * j0f_S04)));
+        return (1 + x / 2) * (1 - x / 2) + z * (r / s);
+    }
+    var y = x;
+    if (ix >= 0x21800000) y = 0.25 * y * y;
+    return 1 - y;
+}
+
+fn y0f(x: f32) callconv(.c) f32 {
+    const ix: u32 = @bitCast(x);
+    if ((ix & 0x7fffffff) == 0) return -1 / @as(f32, 0.0);
+    if ((ix >> 31) != 0) return 0 / @as(f32, 0.0);
+    if (ix >= 0x7f800000) return 1 / x;
+    if (ix >= 0x40000000) return j0f_common(ix, x, true);
+    if (ix >= 0x39000000) {
+        const z = x * x;
+        const u = y0f_u00 + z * (y0f_u01 + z * (y0f_u02 + z * (y0f_u03 + z * (y0f_u04 + z * (y0f_u05 + z * y0f_u06)))));
+        const v = 1 + z * (y0f_v01 + z * (y0f_v02 + z * (y0f_v03 + z * y0f_v04)));
+        return u / v + bessel_tpi32 * (j0f(x) * @log(x));
+    }
+    return y0f_u00 + bessel_tpi32 * @log(x);
+}
+
+fn j0f_pzero(x: f32) f32 {
+    var p: []const f32 = undefined;
+    var q: []const f32 = undefined;
+    const ix = @as(u32, @bitCast(x)) & 0x7fffffff;
+    if (ix >= 0x41000000) {
+        p = j0f_pR8[0..];
+        q = j0f_pS8[0..];
+    } else if (ix >= 0x409173eb) {
+        p = j0f_pR5[0..];
+        q = j0f_pS5[0..];
+    } else if (ix >= 0x4036d917) {
+        p = j0f_pR3[0..];
+        q = j0f_pS3[0..];
+    } else {
+        p = j0f_pR2[0..];
+        q = j0f_pS2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * q[4]))));
+    return 1.0 + r / s;
+}
+
+fn j0f_qzero(x: f32) f32 {
+    var p: []const f32 = undefined;
+    var q: []const f32 = undefined;
+    const ix = @as(u32, @bitCast(x)) & 0x7fffffff;
+    if (ix >= 0x41000000) {
+        p = j0f_qR8[0..];
+        q = j0f_qS8[0..];
+    } else if (ix >= 0x409173eb) {
+        p = j0f_qR5[0..];
+        q = j0f_qS5[0..];
+    } else if (ix >= 0x4036d917) {
+        p = j0f_qR3[0..];
+        q = j0f_qS3[0..];
+    } else {
+        p = j0f_qR2[0..];
+        q = j0f_qS2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * (q[4] + z * q[5])))));
+    return (-0.125 + r / s) / x;
+}
+
+// migrated from musl/src/math/j1.c
+const j1_r00: f64 = -6.25000000000000000000e-02;
+const j1_r01: f64 = 1.40705666955189706048e-03;
+const j1_r02: f64 = -1.59955631084035597520e-05;
+const j1_r03: f64 = 4.96727999609584448412e-08;
+const j1_s01: f64 = 1.91537599538363460805e-02;
+const j1_s02: f64 = 1.85946785588630915560e-04;
+const j1_s03: f64 = 1.17718464042623683263e-06;
+const j1_s04: f64 = 5.04636257076217042715e-09;
+const j1_s05: f64 = 1.23542274426137913908e-11;
+
+const y1_U0 = [_]f64{ -1.96057090646238940668e-01, 5.04438716639811282616e-02, -1.91256895875763547298e-03, 2.35252600561610495928e-05, -9.19099158039878874504e-08 };
+const y1_V0 = [_]f64{ 1.99167318236649903973e-02, 2.02552581025135171496e-04, 1.35608801097516229404e-06, 6.22741452364621501295e-09, 1.66559246207992079114e-11 };
+
+const j1_pr8 = [_]f64{ 0.00000000000000000000e+00, 1.17187499999988647970e-01, 1.32394806593073575129e+01, 4.12051854307378562225e+02, 3.87474538913960532227e+03, 7.91447954031891731574e+03 };
+const j1_ps8 = [_]f64{ 1.14207370375678408436e+02, 3.65093083420853463394e+03, 3.69562060269033463555e+04, 9.76027935934950801311e+04, 3.08042720627888811578e+04 };
+const j1_pr5 = [_]f64{ 1.31990519556243522749e-11, 1.17187493190614097638e-01, 6.80275127868432871736e+00, 1.08308182990189109773e+02, 5.17636139533199752805e+02, 5.28715201363337541807e+02 };
+const j1_ps5 = [_]f64{ 5.92805987221131331921e+01, 9.91401418733614377743e+02, 5.35326695291487976647e+03, 7.84469031749551231769e+03, 1.50404688810361062679e+03 };
+const j1_pr3 = [_]f64{ 3.02503916137373618024e-09, 1.17186865567253592491e-01, 3.93297750033315640650e+00, 3.51194035591636932736e+01, 9.10550110750781271918e+01, 4.85590685197364919645e+01 };
+const j1_ps3 = [_]f64{ 3.47913095001251519989e+01, 3.36762458747825746741e+02, 1.04687139975775130551e+03, 8.90811346398256432622e+02, 1.03787932439639277504e+02 };
+const j1_pr2 = [_]f64{ 1.07710830106873743082e-07, 1.17176219462683348094e-01, 2.36851496667608785174e+00, 1.22426109148261232917e+01, 1.76939711271687727390e+01, 5.07352312588818499250e+00 };
+const j1_ps2 = [_]f64{ 2.14364859363821409488e+01, 1.25290227168402751090e+02, 2.32276469057162813669e+02, 1.17679373287147100768e+02, 8.36463893371618283368e+00 };
+
+const j1_qr8 = [_]f64{ 0.00000000000000000000e+00, -1.02539062499992714161e-01, -1.62717534544589987888e+01, -7.59601722513950107896e+02, -1.18498066702429587167e+04, -4.84385124285750353010e+04 };
+const j1_qs8 = [_]f64{ 1.61395369700722909556e+02, 7.82538599923348465381e+03, 1.33875336287249578163e+05, 7.19657723683240939863e+05, 6.66601232617776375264e+05, -2.94490264303834643215e+05 };
+const j1_qr5 = [_]f64{ -2.08979931141764104297e-11, -1.02539050241375426231e-01, -8.05644828123936029840e+00, -1.83669607474888380239e+02, -1.37319376065508163265e+03, -2.61244440453215656817e+03 };
+const j1_qs5 = [_]f64{ 8.12765501384335777857e+01, 1.99179873460485964642e+03, 1.74684851924908907677e+04, 4.98514270910352279316e+04, 2.79480751638918118260e+04, -4.71918354795128470869e+03 };
+const j1_qr3 = [_]f64{ -5.07831226461766561369e-09, -1.02537829820837089745e-01, -4.61011581139473403113e+00, -5.78472216562783643212e+01, -2.28244540737631695038e+02, -2.19210128478909325622e+02 };
+const j1_qs3 = [_]f64{ 4.76651550323729509273e+01, 6.73865112676699709482e+02, 3.38015286679526343505e+03, 5.54772909720722782367e+03, 1.90311919338810798763e+03, -1.35201191444307340817e+02 };
+const j1_qr2 = [_]f64{ -1.78381727510958865572e-07, -1.02517042607985553460e-01, -2.75220568278187460720e+00, -1.96636162643703720221e+01, -4.23253133372830490089e+01, -2.13719211703704061733e+01 };
+const j1_qs2 = [_]f64{ 2.95333629060523854548e+01, 2.52981549982190529136e+02, 7.57502834868645436472e+02, 7.39393205320467245656e+02, 1.55949003336666123687e+02, -4.95949898822628210127e+00 };
+
+fn j1_common(ix: u32, x: f64, y1_: bool, sign: bool) f64 {
+    var s = @sin(x);
+    if (y1_) s = -s;
+    const c = @cos(x);
+    var cc = s - c;
+    if (ix < 0x7fe00000) {
+        var ss = -s - c;
+        const z = @cos(2 * x);
+        if (s * c > 0)
+            cc = z / ss
+        else
+            ss = z / cc;
+        if (ix < 0x48000000) {
+            if (y1_) ss = -ss;
+            cc = j1_pone(x) * cc - j1_qone(x) * ss;
+        }
+    }
+    if (sign) cc = -cc;
+    return bessel_invsqrtpi64 * cc / @sqrt(x);
+}
+
+fn j1(x: f64) callconv(.c) f64 {
+    const bits: u64 = @bitCast(x);
+    var ix: u32 = @truncate(bits >> 32);
+    const sign = (ix >> 31) != 0;
+    ix &= 0x7fffffff;
+    if (ix >= 0x7ff00000) return 1 / (x * x);
+    if (ix >= 0x40000000) return j1_common(ix, @abs(x), false, sign);
+    const z = if (ix >= 0x38000000) blk: {
+        const x2 = x * x;
+        const r = x2 * (j1_r00 + x2 * (j1_r01 + x2 * (j1_r02 + x2 * j1_r03)));
+        const s = 1 + x2 * (j1_s01 + x2 * (j1_s02 + x2 * (j1_s03 + x2 * (j1_s04 + x2 * j1_s05))));
+        break :blk r / s;
+    } else x;
+    return (0.5 + z) * x;
+}
+
+fn y1(x: f64) callconv(.c) f64 {
+    const bits: u64 = @bitCast(x);
+    const ix: u32 = @truncate(bits >> 32);
+    const lx: u32 = @truncate(bits);
+    if (((ix << 1) | lx) == 0) return -1 / @as(f64, 0.0);
+    if ((ix >> 31) != 0) return 0 / @as(f64, 0.0);
+    if (ix >= 0x7ff00000) return 1 / x;
+    if (ix >= 0x40000000) return j1_common(ix, x, true, false);
+    if (ix < 0x3c900000) return -bessel_tpi64 / x;
+    const z = x * x;
+    const u = y1_U0[0] + z * (y1_U0[1] + z * (y1_U0[2] + z * (y1_U0[3] + z * y1_U0[4])));
+    const v = 1 + z * (y1_V0[0] + z * (y1_V0[1] + z * (y1_V0[2] + z * (y1_V0[3] + z * y1_V0[4]))));
+    return x * (u / v) + bessel_tpi64 * (j1(x) * @log(x) - 1 / x);
+}
+
+fn j1_pone(x: f64) f64 {
+    var p: []const f64 = undefined;
+    var q: []const f64 = undefined;
+    const ix: u32 = @as(u32, @truncate(@as(u64, @bitCast(x)) >> 32)) & 0x7fffffff;
+    if (ix >= 0x40200000) {
+        p = j1_pr8[0..];
+        q = j1_ps8[0..];
+    } else if (ix >= 0x40122E8B) {
+        p = j1_pr5[0..];
+        q = j1_ps5[0..];
+    } else if (ix >= 0x4006DB6D) {
+        p = j1_pr3[0..];
+        q = j1_ps3[0..];
+    } else {
+        p = j1_pr2[0..];
+        q = j1_ps2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * q[4]))));
+    return 1.0 + r / s;
+}
+
+fn j1_qone(x: f64) f64 {
+    var p: []const f64 = undefined;
+    var q: []const f64 = undefined;
+    const ix: u32 = @as(u32, @truncate(@as(u64, @bitCast(x)) >> 32)) & 0x7fffffff;
+    if (ix >= 0x40200000) {
+        p = j1_qr8[0..];
+        q = j1_qs8[0..];
+    } else if (ix >= 0x40122E8B) {
+        p = j1_qr5[0..];
+        q = j1_qs5[0..];
+    } else if (ix >= 0x4006DB6D) {
+        p = j1_qr3[0..];
+        q = j1_qs3[0..];
+    } else {
+        p = j1_qr2[0..];
+        q = j1_qs2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * (q[4] + z * q[5])))));
+    return (0.375 + r / s) / x;
+}
+
+// migrated from musl/src/math/j1f.c
+const j1f_r00: f32 = -6.2500000000e-02;
+const j1f_r01: f32 = 1.4070566976e-03;
+const j1f_r02: f32 = -1.5995563444e-05;
+const j1f_r03: f32 = 4.9672799207e-08;
+const j1f_s01: f32 = 1.9153760746e-02;
+const j1f_s02: f32 = 1.8594678841e-04;
+const j1f_s03: f32 = 1.1771846857e-06;
+const j1f_s04: f32 = 5.0463624390e-09;
+const j1f_s05: f32 = 1.2354227016e-11;
+
+const y1f_U0 = [_]f32{ -1.9605709612e-01, 5.0443872809e-02, -1.9125689287e-03, 2.3525259166e-05, -9.1909917899e-08 };
+const y1f_V0 = [_]f32{ 1.9916731864e-02, 2.0255257550e-04, 1.3560879779e-06, 6.2274145840e-09, 1.6655924903e-11 };
+
+const j1f_pr8 = [_]f32{ 0.0000000000e+00, 1.1718750000e-01, 1.3239480972e+01, 4.1205184937e+02, 3.8747453613e+03, 7.9144794922e+03 };
+const j1f_ps8 = [_]f32{ 1.1420736694e+02, 3.6509309082e+03, 3.6956207031e+04, 9.7602796875e+04, 3.0804271484e+04 };
+const j1f_pr5 = [_]f32{ 1.3199052094e-11, 1.1718749255e-01, 6.8027510643e+00, 1.0830818176e+02, 5.1763616943e+02, 5.2871520996e+02 };
+const j1f_ps5 = [_]f32{ 5.9280597687e+01, 9.9140142822e+02, 5.3532670898e+03, 7.8446904297e+03, 1.5040468750e+03 };
+const j1f_pr3 = [_]f32{ 3.0250391081e-09, 1.1718686670e-01, 3.9329774380e+00, 3.5119403839e+01, 9.1055007935e+01, 4.8559066772e+01 };
+const j1f_ps3 = [_]f32{ 3.4791309357e+01, 3.3676245117e+02, 1.0468714600e+03, 8.9081134033e+02, 1.0378793335e+02 };
+const j1f_pr2 = [_]f32{ 1.0771083225e-07, 1.1717621982e-01, 2.3685150146e+00, 1.2242610931e+01, 1.7693971634e+01, 5.0735230446e+00 };
+const j1f_ps2 = [_]f32{ 2.1436485291e+01, 1.2529022980e+02, 2.3227647400e+02, 1.1767937469e+02, 8.3646392822e+00 };
+
+const j1f_qr8 = [_]f32{ 0.0000000000e+00, -1.0253906250e-01, -1.6271753311e+01, -7.5960174561e+02, -1.1849806641e+04, -4.8438511719e+04 };
+const j1f_qs8 = [_]f32{ 1.6139537048e+02, 7.8253862305e+03, 1.3387534375e+05, 7.1965775000e+05, 6.6660125000e+05, -2.9449025000e+05 };
+const j1f_qr5 = [_]f32{ -2.0897993405e-11, -1.0253904760e-01, -8.0564479828e+00, -1.8366960144e+02, -1.3731937256e+03, -2.6124443359e+03 };
+const j1f_qs5 = [_]f32{ 8.1276550293e+01, 1.9917987061e+03, 1.7468484375e+04, 4.9851425781e+04, 2.7948074219e+04, -4.7191835938e+03 };
+const j1f_qr3 = [_]f32{ -5.0783124372e-09, -1.0253783315e-01, -4.6101160049e+00, -5.7847221375e+01, -2.2824453735e+02, -2.1921012878e+02 };
+const j1f_qs3 = [_]f32{ 4.7665153503e+01, 6.7386511230e+02, 3.3801528320e+03, 5.5477290039e+03, 1.9031191406e+03, -1.3520118713e+02 };
+const j1f_qr2 = [_]f32{ -1.7838172539e-07, -1.0251704603e-01, -2.7522056103e+00, -1.9663616180e+01, -4.2325313568e+01, -2.1371921539e+01 };
+const j1f_qs2 = [_]f32{ 2.9533363342e+01, 2.5298155212e+02, 7.5750280762e+02, 7.3939318848e+02, 1.5594900513e+02, -4.9594988823e+00 };
+
+fn j1f_common(ix: u32, x: f32, y1_: bool, sign: bool) f32 {
+    var s: f64 = @sin(x);
+    if (y1_) s = -s;
+    const c: f64 = @cos(x);
+    var cc = s - c;
+    if (ix < 0x7f000000) {
+        var ss = -s - c;
+        const z = @cos(2 * @as(f64, x));
+        if (s * c > 0)
+            cc = z / ss
+        else
+            ss = z / cc;
+        if (ix < 0x58800000) {
+            if (y1_) ss = -ss;
+            cc = @as(f64, j1f_pone(x)) * cc - @as(f64, j1f_qone(x)) * ss;
+        }
+    }
+    if (sign) cc = -cc;
+    return @floatCast(@as(f64, bessel_invsqrtpi32) * cc / @sqrt(@as(f64, x)));
+}
+
+fn j1f(x: f32) callconv(.c) f32 {
+    var ix: u32 = @bitCast(x);
+    const sign = (ix >> 31) != 0;
+    ix &= 0x7fffffff;
+    if (ix >= 0x7f800000) return 1 / (x * x);
+    if (ix >= 0x40000000) return j1f_common(ix, @abs(x), false, sign);
+    const z: f32 = if (ix >= 0x39000000) blk: {
+        const x2 = x * x;
+        const r = x2 * (j1f_r00 + x2 * (j1f_r01 + x2 * (j1f_r02 + x2 * j1f_r03)));
+        const s = 1 + x2 * (j1f_s01 + x2 * (j1f_s02 + x2 * (j1f_s03 + x2 * (j1f_s04 + x2 * j1f_s05))));
+        break :blk 0.5 + r / s;
+    } else 0.5;
+    return z * x;
+}
+
+fn y1f(x: f32) callconv(.c) f32 {
+    const ix: u32 = @bitCast(x);
+    if ((ix & 0x7fffffff) == 0) return -1 / @as(f32, 0.0);
+    if ((ix >> 31) != 0) return 0 / @as(f32, 0.0);
+    if (ix >= 0x7f800000) return 1 / x;
+    if (ix >= 0x40000000) return j1f_common(ix, x, true, false);
+    if (ix < 0x33000000) return -bessel_tpi32 / x;
+    const z = x * x;
+    const u = y1f_U0[0] + z * (y1f_U0[1] + z * (y1f_U0[2] + z * (y1f_U0[3] + z * y1f_U0[4])));
+    const v = 1.0 + z * (y1f_V0[0] + z * (y1f_V0[1] + z * (y1f_V0[2] + z * (y1f_V0[3] + z * y1f_V0[4]))));
+    return x * (u / v) + bessel_tpi32 * (j1f(x) * @log(x) - 1.0 / x);
+}
+
+fn j1f_pone(x: f32) f32 {
+    var p: []const f32 = undefined;
+    var q: []const f32 = undefined;
+    const ix = @as(u32, @bitCast(x)) & 0x7fffffff;
+    if (ix >= 0x41000000) {
+        p = j1f_pr8[0..];
+        q = j1f_ps8[0..];
+    } else if (ix >= 0x409173eb) {
+        p = j1f_pr5[0..];
+        q = j1f_ps5[0..];
+    } else if (ix >= 0x4036d917) {
+        p = j1f_pr3[0..];
+        q = j1f_ps3[0..];
+    } else {
+        p = j1f_pr2[0..];
+        q = j1f_ps2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * q[4]))));
+    return 1.0 + r / s;
+}
+
+fn j1f_qone(x: f32) f32 {
+    var p: []const f32 = undefined;
+    var q: []const f32 = undefined;
+    const ix = @as(u32, @bitCast(x)) & 0x7fffffff;
+    if (ix >= 0x41000000) {
+        p = j1f_qr8[0..];
+        q = j1f_qs8[0..];
+    } else if (ix >= 0x409173eb) {
+        p = j1f_qr5[0..];
+        q = j1f_qs5[0..];
+    } else if (ix >= 0x4036d917) {
+        p = j1f_qr3[0..];
+        q = j1f_qs3[0..];
+    } else {
+        p = j1f_qr2[0..];
+        q = j1f_qs2[0..];
+    }
+    const z = 1.0 / (x * x);
+    const r = p[0] + z * (p[1] + z * (p[2] + z * (p[3] + z * (p[4] + z * p[5]))));
+    const s = 1.0 + z * (q[0] + z * (q[1] + z * (q[2] + z * (q[3] + z * (q[4] + z * q[5])))));
+    return (0.375 + r / s) / x;
+}
+
+// migrated from musl/src/math/lgammal.c
+const lgammal80_pi: f80 = 3.14159265358979323846264;
+const lgammal80_a0: f80 = -6.343246574721079391729402781192128239938E2;
+const lgammal80_a1: f80 = 1.856560238672465796768677717168371401378E3;
+const lgammal80_a2: f80 = 2.404733102163746263689288466865843408429E3;
+const lgammal80_a3: f80 = 8.804188795790383497379532868917517596322E2;
+const lgammal80_a4: f80 = 1.135361354097447729740103745999661157426E2;
+const lgammal80_a5: f80 = 3.766956539107615557608581581190400021285E0;
+const lgammal80_b0: f80 = 8.214973713960928795704317259806842490498E3;
+const lgammal80_b1: f80 = 1.026343508841367384879065363925870888012E4;
+const lgammal80_b2: f80 = 4.553337477045763320522762343132210919277E3;
+const lgammal80_b3: f80 = 8.506975785032585797446253359230031874803E2;
+const lgammal80_b4: f80 = 6.042447899703295436820744186992189445813E1;
+const lgammal80_tc: f80 = 1.4616321449683623412626595423257213284682E0;
+const lgammal80_tf: f80 = -1.2148629053584961146050602565082954242826E-1;
+const lgammal80_tt: f80 = 3.3649914684731379602768989080467587736363E-18;
+const lgammal80_g0: f80 = 3.645529916721223331888305293534095553827E-18;
+const lgammal80_g1: f80 = 5.126654642791082497002594216163574795690E3;
+const lgammal80_g2: f80 = 8.828603575854624811911631336122070070327E3;
+const lgammal80_g3: f80 = 5.464186426932117031234820886525701595203E3;
+const lgammal80_g4: f80 = 1.455427403530884193180776558102868592293E3;
+const lgammal80_g5: f80 = 1.541735456969245924860307497029155838446E2;
+const lgammal80_g6: f80 = 4.335498275274822298341872707453445815118E0;
+const lgammal80_h0: f80 = 1.059584930106085509696730443974495979641E4;
+const lgammal80_h1: f80 = 2.147921653490043010629481226937850618860E4;
+const lgammal80_h2: f80 = 1.643014770044524804175197151958100656728E4;
+const lgammal80_h3: f80 = 5.869021995186925517228323497501767586078E3;
+const lgammal80_h4: f80 = 9.764244777714344488787381271643502742293E2;
+const lgammal80_h5: f80 = 6.442485441570592541741092969581997002349E1;
+const lgammal80_u0: f80 = -8.886217500092090678492242071879342025627E1;
+const lgammal80_u1: f80 = 6.840109978129177639438792958320783599310E2;
+const lgammal80_u2: f80 = 2.042626104514127267855588786511809932433E3;
+const lgammal80_u3: f80 = 1.911723903442667422201651063009856064275E3;
+const lgammal80_u4: f80 = 7.447065275665887457628865263491667767695E2;
+const lgammal80_u5: f80 = 1.132256494121790736268471016493103952637E2;
+const lgammal80_u6: f80 = 4.484398885516614191003094714505960972894E0;
+const lgammal80_v0: f80 = 1.150830924194461522996462401210374632929E3;
+const lgammal80_v1: f80 = 3.399692260848747447377972081399737098610E3;
+const lgammal80_v2: f80 = 3.786631705644460255229513563657226008015E3;
+const lgammal80_v3: f80 = 1.966450123004478374557778781564114347876E3;
+const lgammal80_v4: f80 = 4.741359068914069299837355438370682773122E2;
+const lgammal80_v5: f80 = 4.508989649747184050907206782117647852364E1;
+const lgammal80_s0: f80 = 1.454726263410661942989109455292824853344E6;
+const lgammal80_s1: f80 = -3.901428390086348447890408306153378922752E6;
+const lgammal80_s2: f80 = -6.573568698209374121847873064292963089438E6;
+const lgammal80_s3: f80 = -3.319055881485044417245964508099095984643E6;
+const lgammal80_s4: f80 = -7.094891568758439227560184618114707107977E5;
+const lgammal80_s5: f80 = -6.263426646464505837422314539808112478303E4;
+const lgammal80_s6: f80 = -1.684926520999477529949915657519454051529E3;
+const lgammal80_r0: f80 = -1.883978160734303518163008696712983134698E7;
+const lgammal80_r1: f80 = -2.815206082812062064902202753264922306830E7;
+const lgammal80_r2: f80 = -1.600245495251915899081846093343626358398E7;
+const lgammal80_r3: f80 = -4.310526301881305003489257052083370058799E6;
+const lgammal80_r4: f80 = -5.563807682263923279438235987186184968542E5;
+const lgammal80_r5: f80 = -3.027734654434169996032905158145259713083E4;
+const lgammal80_r6: f80 = -4.501995652861105629217250715790764371267E2;
+const lgammal80_w0: f80 = 4.189385332046727417803E-1;
+const lgammal80_w1: f80 = 8.333333333333331447505E-2;
+const lgammal80_w2: f80 = -2.777777777750349603440E-3;
+const lgammal80_w3: f80 = 7.936507795855070755671E-4;
+const lgammal80_w4: f80 = -5.952345851765688514613E-4;
+const lgammal80_w5: f80 = 8.412723297322498080632E-4;
+const lgammal80_w6: f80 = -1.880801938119376907179E-3;
+const lgammal80_w7: f80 = 4.885026142432270781165E-3;
+
+fn lgammal80_sin_pi(x_: f80) f80 {
+    var x = x_;
+    x *= 0.5;
+    x = 2.0 * (x - @floor(x));
+    var n: c_int = @intFromFloat(x * 4.0);
+    n = (n + 1) / 2;
+    x -= @as(f80, @floatFromInt(n)) * 0.5;
+    x *= lgammal80_pi;
+    return switch (n) {
+        0, 4 => @sin(x),
+        1 => @cos(x),
+        2 => @sin(-x),
+        3 => -@cos(x),
+        else => unreachable,
+    };
+}
+
+const lgammal_lanczos = 6.024680040776729583740234375;
+const lgammal_integer_result_table = [_]f64{ std.math.inf(f64), 1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880, 3628800, 39916800, 479001600, 6227020800, 87178291200, 1307674368000, 20922789888000, 355687428096000, 6402373705728000, 121645100408832000, 2432902008176640000, 51090942171709440000 };
+const lgammal_lanczos_num = [_]f64{ 23531376880.410759688572007674451636754734846804940, 42919803642.649098768957899047001988850926355848959, 35711959237.355668049440185451547166705960488635843, 17921034426.037209699919755754458931112671403265390, 6039542586.3520280050642916443072979210699388420708, 1439720407.3117216736632230727949123939715485786772, 248874557.86205415651146038641322942321632125127801, 31426415.585400194380614231628318205362874684987640, 2876370.6289353724412254090516208496135991145378768, 186056.26539522349504029498971604569928220784236328, 8071.6720023658162106380029022722506138218516325024, 210.82427775157934587250973392071336271166969580291, 2.5066282746310002701649081771338373386264310793408 };
+const lgammal_lanczos_den = [_]f64{ 0.0, 39916800.0, 120543840.0, 150917976.0, 105258076.0, 45995730.0, 13339535.0, 2637558.0, 357423.0, 32670.0, 1925.0, 66.0, 1.0 };
+
+fn lgammal_series(comptime T: type, abs: T) T {
+    var num: T = 0;
+    var den: T = 0;
+    if (abs < 8) {
+        var i: usize = 0;
+        while (i < lgammal_lanczos_num.len) : (i += 1) {
+            num = num * abs + @as(T, @floatCast(lgammal_lanczos_num[lgammal_lanczos_num.len - 1 - i]));
+            den = den * abs + @as(T, @floatCast(lgammal_lanczos_den[lgammal_lanczos_den.len - 1 - i]));
+        }
+    } else {
+        var i: usize = 0;
+        while (i < lgammal_lanczos_num.len) : (i += 1) {
+            num = num / abs + @as(T, @floatCast(lgammal_lanczos_num[i]));
+            den = den / abs + @as(T, @floatCast(lgammal_lanczos_den[i]));
+        }
+    }
+    return num / den;
+}
+
+fn lgammal_sinpi_generic(comptime T: type, x: T) T {
+    const xmod2 = @mod(x, 2);
+    const n = (@as(u8, @intFromFloat(4 * xmod2)) + 1) / 2;
+    const y = xmod2 - 0.5 * @as(T, @floatFromInt(n));
+    const pi_t: T = @floatCast(std.math.pi);
+    return switch (n) {
+        0, 4 => @sin(pi_t * y),
+        1 => @cos(pi_t * y),
+        2 => -@sin(pi_t * y),
+        3 => -@cos(pi_t * y),
+        else => unreachable,
+    };
+}
+
+fn lgammal_gamma_generic(comptime T: type, x: T) T {
+    if (x == @trunc(x)) {
+        if (x < 0) return math.nan(T);
+        if (x == 0) return 1 / x;
+        if (x < lgammal_integer_result_table.len) {
+            const i: u8 = @intFromFloat(x);
+            return @floatCast(lgammal_integer_result_table[i]);
+        }
+    }
+    const abs = @abs(x);
+    const lower_bound: T = if (T == f128) -184 else -42;
+    if (x < lower_bound) return if (@mod(x, 2) > 1) -0.0 else 0.0;
+    const upper_bound: T = if (T == f128) 1755 else 36;
+    if (x > upper_bound) return math.inf(T);
+    if (abs < 0x1p-54) return 1 / x;
+
+    const lanczos_minus_half: T = @floatCast(lgammal_lanczos - 0.5);
+    const base = abs + lanczos_minus_half;
+    const exponent = abs - 0.5;
+    const e = if (abs > lanczos_minus_half) base - abs - lanczos_minus_half else base - lanczos_minus_half - abs;
+    const correction = @as(T, @floatCast(lgammal_lanczos)) * e / base;
+    const initial = lgammal_series(T, abs) * @exp(-base);
+
+    if (x < 0) {
+        const pi_t: T = @floatCast(std.math.pi);
+        const reflected = -pi_t / (abs * lgammal_sinpi_generic(T, abs) * initial);
+        const corrected = reflected - reflected * correction;
+        const half_pow = @exp(@log(base) * (0.5 * exponent));
+        return corrected / (half_pow * half_pow);
+    } else {
+        const corrected = initial + initial * correction;
+        const half_pow = @exp(@log(base) * (0.5 * exponent));
+        return corrected * half_pow * half_pow;
+    }
+}
+
+fn lgammal128_r(x: f128, signgamp: *c_int) f128 {
+    signgamp.* = 1;
+    if (math.isNan(x)) return x;
+    if (math.isInf(x)) return x * x;
+    if (x == @trunc(x) and x <= 0) return 1.0 / (x - x);
+    if (x < 0) {
+        const t = lgammal_sinpi_generic(f128, -x);
+        if (t == 0) return 1.0 / (x - x);
+        if (t > 0) signgamp.* = -1;
+    }
+    const abs = @abs(lgammal_gamma_generic(f128, x));
+    if (lgammal_gamma_generic(f128, x) < 0) signgamp.* = -1;
+    return @log(abs);
+}
+
+fn lgammal80_r(x_: f80, signgamp: *c_int) f80 {
+    const bits: u80 = @bitCast(x_);
+    const se: u16 = @truncate(bits >> 64);
+    const m: u64 = @truncate(bits);
+    const ix: u32 = (@as(u32, se & 0x7fff) << 16) | @as(u32, @truncate(m >> 48));
+    const sign = (se >> 15) != 0;
+
+    var x = x_;
+    var r: f80 = undefined;
+    var nadj: f80 = undefined;
+    signgamp.* = 1;
+
+    if (ix >= 0x7fff0000) return x * x;
+    if (ix < 0x3fc08000) {
+        if (sign) {
+            signgamp.* = -1;
+            x = -x;
+        }
+        return -@log(x);
+    }
+    if (sign) {
+        x = -x;
+        var t = lgammal80_sin_pi(x);
+        if (t == 0.0) return 1.0 / (x - x);
+        if (t > 0.0)
+            signgamp.* = -1
+        else
+            t = -t;
+        nadj = @log(lgammal80_pi / (t * x));
+    }
+
+    if ((ix == 0x3fff8000 or ix == 0x40008000) and m == 0) {
+        r = 0;
+    } else if (ix < 0x40008000) {
+        var y: f80 = undefined;
+        var i: c_int = undefined;
+        if (ix <= 0x3ffee666) {
+            r = -@log(x);
+            if (ix >= 0x3ffebb4a) {
+                y = x - 1.0;
+                i = 0;
+            } else if (ix >= 0x3ffced33) {
+                y = x - (lgammal80_tc - 1.0);
+                i = 1;
+            } else {
+                y = x;
+                i = 2;
+            }
+        } else {
+            r = 0.0;
+            if (ix >= 0x3fffdda6) {
+                y = x - 2.0;
+                i = 0;
+            } else if (ix >= 0x3fff9da6) {
+                y = x - lgammal80_tc;
+                i = 1;
+            } else {
+                y = x - 1.0;
+                i = 2;
+            }
+        }
+        switch (i) {
+            0 => {
+                const p1 = lgammal80_a0 + y * (lgammal80_a1 + y * (lgammal80_a2 + y * (lgammal80_a3 + y * (lgammal80_a4 + y * lgammal80_a5))));
+                const p2 = lgammal80_b0 + y * (lgammal80_b1 + y * (lgammal80_b2 + y * (lgammal80_b3 + y * (lgammal80_b4 + y))));
+                r += 0.5 * y + y * p1 / p2;
+            },
+            1 => {
+                const p1 = lgammal80_g0 + y * (lgammal80_g1 + y * (lgammal80_g2 + y * (lgammal80_g3 + y * (lgammal80_g4 + y * (lgammal80_g5 + y * lgammal80_g6)))));
+                const p2 = lgammal80_h0 + y * (lgammal80_h1 + y * (lgammal80_h2 + y * (lgammal80_h3 + y * (lgammal80_h4 + y * (lgammal80_h5 + y)))));
+                const p = lgammal80_tt + y * p1 / p2;
+                r += lgammal80_tf + p;
+            },
+            2 => {
+                const p1 = y * (lgammal80_u0 + y * (lgammal80_u1 + y * (lgammal80_u2 + y * (lgammal80_u3 + y * (lgammal80_u4 + y * (lgammal80_u5 + y * lgammal80_u6))))));
+                const p2 = lgammal80_v0 + y * (lgammal80_v1 + y * (lgammal80_v2 + y * (lgammal80_v3 + y * (lgammal80_v4 + y * (lgammal80_v5 + y)))));
+                r += -0.5 * y + p1 / p2;
+            },
+            else => unreachable,
+        }
+    } else if (ix < 0x40028000) {
+        const i: c_int = @intFromFloat(x);
+        const y = x - @as(f80, @floatFromInt(i));
+        const p = y * (lgammal80_s0 + y * (lgammal80_s1 + y * (lgammal80_s2 + y * (lgammal80_s3 + y * (lgammal80_s4 + y * (lgammal80_s5 + y * lgammal80_s6))))));
+        const q = lgammal80_r0 + y * (lgammal80_r1 + y * (lgammal80_r2 + y * (lgammal80_r3 + y * (lgammal80_r4 + y * (lgammal80_r5 + y * (lgammal80_r6 + y))))));
+        r = 0.5 * y + p / q;
+        var z: f80 = 1.0;
+        if (i >= 3) {
+            z *= y + 2.0;
+            if (i >= 4) z *= y + 3.0;
+            if (i >= 5) z *= y + 4.0;
+            if (i >= 6) z *= y + 5.0;
+            if (i >= 7) z *= y + 6.0;
+            r += @log(z);
+        }
+    } else if (ix < 0x40418000) {
+        const t = @log(x);
+        const z = 1.0 / x;
+        const y = z * z;
+        const w = lgammal80_w0 + z * (lgammal80_w1 + y * (lgammal80_w2 + y * (lgammal80_w3 + y * (lgammal80_w4 + y * (lgammal80_w5 + y * (lgammal80_w6 + y * lgammal80_w7))))));
+        r = (x - 0.5) * (t - 1.0) + w;
+    } else {
+        r = x * (@log(x) - 1.0);
+    }
+    if (sign) r = nadj - r;
+    return r;
+}
+
+fn lgammal_r_(x: c_longdouble, signgamp: *c_int) callconv(.c) c_longdouble {
+    if (@bitSizeOf(c_longdouble) == 64) {
+        return @floatCast(lgamma_r(@floatCast(x), signgamp));
+    }
+    if (@bitSizeOf(c_longdouble) == 80) {
+        return @floatCast(lgammal80_r(@floatCast(x), signgamp));
+    }
+    if (@bitSizeOf(c_longdouble) == 128) {
+        return @floatCast(lgammal128_r(@floatCast(x), signgamp));
+    }
+    signgamp.* = 1;
+    return @floatCast(lgamma_r(@floatCast(x), signgamp));
+}
+
+fn lgammal_(x: c_longdouble) callconv(.c) c_longdouble {
+    return lgammal_r_(x, &__signgam);
 }

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -510,11 +510,11 @@ const src_files = [_][]const u8{
     "musl/src/ldso/x32/dlsym.s",
     "musl/src/ldso/x86_64/dlsym.s",
     "musl/src/ldso/x86_64/tlsdesc.s",
-    "musl/src/math/j0.c",
-    "musl/src/math/j0f.c",
-    "musl/src/math/j1.c",
-    "musl/src/math/j1f.c",
-    "musl/src/math/lgammal.c",
+    //"musl/src/math/j0.c", // migrated to lib/c/math.zig; exports: j0,y0
+    //"musl/src/math/j0f.c", // migrated to lib/c/math.zig; exports: j0f,y0f
+    //"musl/src/math/j1.c", // migrated to lib/c/math.zig; exports: j1,y1
+    //"musl/src/math/j1f.c", // migrated to lib/c/math.zig; exports: j1f,y1f
+    //"musl/src/math/lgammal.c", // migrated to lib/c/math.zig; exports: lgammal,lgammal_r
     //"musl/src/math/erfl.c", // migrated to lib/c/math.zig
     //"musl/src/math/exp10l.c", // migrated to lib/c/math.zig
     //"musl/src/math/expm1.c", // migrated to lib/c/math.zig


### PR DESCRIPTION
## Summary
- migrate musl j0/j0f/j1/j1f to `lib/c/math.zig`
- migrate `lgammal`/`lgammal_r` into `lib/c/math.zig` with `c_longdouble` bit-size gating
- mark the 5 musl math C files as migrated in `src/libs/musl.zig`

## Verification
- `zig fmt --ast-check lib/c/math.zig`
- `python3 scripts/check_musl_migration.py`
- `zig build -Dtarget=aarch64-linux-musl --zig-lib-dir lib`
- `zig build -Dtarget=x86_64-linux-musl --zig-lib-dir lib`
- `zig build -Dtarget=riscv64-linux-musl --zig-lib-dir lib`

Closes #501

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>