### PR TITLE
ci(release): minisign-sign release assets + add ai README

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to build and upload assets to (e.g. 0.16.0-libc.8cae962)'
+        description: 'Release tag to build and upload assets to (e.g. 0.16.0-libc.5)'
         required: true
         type: string
 
@@ -242,6 +242,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout (for scripts/sign-asset.exp)
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -251,11 +254,47 @@ jobs:
       - name: List assets
         run: ls -lh dist/
 
+      - name: Sign archives with minisign (per-asset .minisig sidecars)
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD:   ${{ secrets.MINISIGN_PASSWORD }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y minisign expect
+          # Write secret key file with 0600. The runner workspace is
+          # ephemeral; the trap removes it before the step exits.
+          umask 077
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > dist/minisign.key
+          trap 'rm -f dist/minisign.key' EXIT
+          cd dist
+          shopt -s nullglob
+          for asset in zig-*.tar.xz zig-*.zip; do
+            comment="timestamp:$(date +%s) file:${asset} commit:${GITHUB_SHA} tag:${TAG}"
+            echo "signing ${asset} (trusted comment: ${comment})"
+            expect ../scripts/sign-asset.exp "$asset" "$comment"
+          done
+          ls -la *.minisig
+
+      - name: Ensure release exists (create as draft if missing)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --prerelease \
+              --notes "libzigc build of Zig at tag \`$TAG\`. Verify with minisign — see project README for the public key."
+          fi
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
         run: |
-          gh release upload "$TAG" dist/* \
+          gh release upload "$TAG" dist/zig-*.tar.xz dist/zig-*.tar.xz.sha256 dist/zig-*.zip dist/zig-*.zip.sha256 dist/zig-*.minisig \
             --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# ctaggart/zig — `ai` branch
+
+This branch hosts fork-specific infrastructure for the [ctaggart/zig](https://github.com/ctaggart/zig)
+libzigc effort:
+
+- `.github/workflows/` — release builds, libc tests, agentic helpers
+- `scripts/` — supporting Python and expect scripts
+
+The actual source code lives on `libc/0.16.x` (the release-track branch).
+
+## Verifying release assets
+
+Releases tagged `0.16.0-libc.<N>` are signed with [minisign](https://jedisct1.github.io/minisign/).
+Every `zig-<target>-<tag>.tar.xz` / `.zip` has a sibling `.minisig` file.
+
+Public key:
+
+```
+untrusted comment: minisign public key C11B8F39A02400AE
+RWSuACSgOY8bwS0fMGytTyBlrVQsUtK/6ydxuOT/OjzlnFx2go0w1DX5
+```
+
+Verify an asset:
+
+```sh
+TAG=0.16.0-libc.5
+ASSET=zig-x86_64-linux-${TAG}.tar.xz
+curl -LO "https://github.com/ctaggart/zig/releases/download/${TAG}/${ASSET}"
+curl -LO "https://github.com/ctaggart/zig/releases/download/${TAG}/${ASSET}.minisig"
+minisign -V -P 'RWSuACSgOY8bwS0fMGytTyBlrVQsUtK/6ydxuOT/OjzlnFx2go0w1DX5' \
+  -m "$ASSET"
+```
+
+Or with [`ghr`](https://github.com/cataggart/ghr):
+
+```sh
+ghr install ctaggart/zig@0.16.0-libc.5 RWSuACSgOY8bwS0fMGytTyBlrVQsUtK/6ydxuOT/OjzlnFx2go0w1DX5
+```

--- a/scripts/sign-asset.exp
+++ b/scripts/sign-asset.exp
@@ -1,0 +1,45 @@
+#!/usr/bin/env expect
+# Drive `minisign -S` non-interactively in CI: reads the passphrase
+# from the MINISIGN_PASSWORD environment variable instead of /dev/tty
+# (which is how upstream minisign always prompts for it).
+#
+# Usage: expect scripts/sign-asset.exp <asset> <trusted-comment>
+#
+# Requires:
+#   * `minisign` and `expect` on PATH
+#   * `minisign.key` in the current working directory
+#   * MINISIGN_PASSWORD env var set to the secret-key passphrase
+
+if {$argc != 2} {
+    puts stderr "usage: sign-asset.exp <asset> <trusted-comment>"
+    exit 64
+}
+
+set asset   [lindex $argv 0]
+set comment [lindex $argv 1]
+set timeout 30
+
+# Don't echo minisign's output (which would include the prompt) onto the
+# job log. The trusted comment is logged separately by the caller.
+log_user 0
+
+spawn minisign -S -s minisign.key -m $asset -t $comment
+
+expect {
+    "Password:" {
+        send -- "$env(MINISIGN_PASSWORD)\r"
+    }
+    timeout {
+        puts stderr "timeout waiting for minisign password prompt"
+        exit 2
+    }
+    eof {
+        puts stderr "minisign exited before prompting for a password"
+        exit 2
+    }
+}
+
+expect eof
+catch wait result
+# Propagate minisign's exit status so a signature failure fails the job.
+exit [lindex $result 3]


### PR DESCRIPTION
Mirrors the cataggar/ghr minisign signing flow.

## Changes

**`.github/workflows/build-release.yml`** — `release` job now:
- Checks out repo so `scripts/sign-asset.exp` is available.
- Installs `minisign` + `expect`.
- Signs every `zig-*.tar.xz` / `zig-*.zip` with `MINISIGN_SECRET_KEY` (passphrase via `MINISIGN_PASSWORD`).
- Auto-creates the GitHub release (prerelease) if it doesn't exist — so dispatching the workflow is the only post-tag step needed.
- Uploads `.minisig` sidecars alongside `.sha256`.

**`scripts/sign-asset.exp`** (new, 44 lines) — Drives `minisign -S` non-interactively via `MINISIGN_PASSWORD` env var. Copied from `cataggar/ghr`.

**`README.md`** (new) — Branch readme with the minisign public key and verification instructions. Public key:

```
RWSuACSgOY8bwS0fMGytTyBlrVQsUtK/6ydxuOT/OjzlnFx2go0w1DX5
```

**Naming convention** — input description now shows `0.16.0-libc.5` (simple counter) instead of `0.16.0-libc.8cae962` (commit SHA).

## Secrets

Already configured on `ctaggart/zig`:
- `MINISIGN_SECRET_KEY`
- `MINISIGN_PASSWORD`

## Next step after merge

```sh
git -C /work/zig checkout libc/0.16.x && git pull origin libc/0.16.x
git tag -a 0.16.0-libc.5 -m 0.16.0-libc.5
git push origin 0.16.0-libc.5
gh workflow run build-release.yml --repo ctaggart/zig --ref ai -f tag=0.16.0-libc.5
```