### PR TITLE
test/libc: re-enable 3 regression tests previously hanging (#431)

### DIFF
--- a/test/libc.zig
+++ b/test/libc.zig
@@ -81,8 +81,8 @@ pub fn addCases(cases: *tests.LibcContext) void {
     cases.addLibcTestCase("regression/flockfile-list.c", false, .{});
     cases.addLibcTestCase("regression/fpclassify-invalid-ld80.c", true, .{});
     cases.addLibcTestCase("regression/ftello-unflushed-append.c", false, .{});
-    // "regression/getpwnam_r-crash.c": hangs in libzigc — see issue #431
-    // "regression/getpwnam_r-errno.c": hangs in libzigc — see issue #431
+    cases.addLibcTestCase("regression/getpwnam_r-crash.c", true, .{});
+    cases.addLibcTestCase("regression/getpwnam_r-errno.c", true, .{});
     cases.addLibcTestCase("regression/iconv-roundtrips.c", true, .{});
     cases.addLibcTestCase("regression/inet_ntop-v4mapped.c", true, .{});
     cases.addLibcTestCase("regression/inet_pton-empty-last-field.c", true, .{});
@@ -130,7 +130,7 @@ pub fn addCases(cases: *tests.LibcContext) void {
     cases.addLibcTestCase("regression/setvbuf-unget.c", true, .{});
     cases.addLibcTestCase("regression/sigaltstack.c", false, .{});
     cases.addLibcTestCase("regression/sigprocmask-internal.c", false, .{});
-    // "regression/sigreturn.c": hangs in libzigc — see issue #431
+    cases.addLibcTestCase("regression/sigreturn.c", true, .{});
     cases.addLibcTestCase("regression/sscanf-eof.c", true, .{});
     cases.addLibcTestCase("regression/strverscmp.c", true, .{});
     cases.addLibcTestCase("regression/syscall-sign-extend.c", false, .{});


### PR DESCRIPTION
Re-enables the three `regression/` tests that were commented out in #432 because they were hanging at 99% CPU under libzigc:

- `regression/sigreturn.c`
- `regression/getpwnam_r-crash.c`
- `regression/getpwnam_r-errno.c`

## Verification

Probe run [test-libc 26238656495](https://github.com/ctaggart/zig/actions/runs/26238656495) on `probe-431` (same diff as this PR) — all 10 arches green:

| arch | result |
|---|---|
| x86_64 / x86 / aarch64 / arm / thumb / riscv / powerpc / s390x / loongarch64 / wasm32 | ✅ |

Plus local aarch64-linux-musl native runs of all three: each exits 0 cleanly.

The hang was likely fixed by the sigaction re-migration that landed after the #420 mass revert mentioned in #431.

Closes #431