### PR TITLE
test/libc: re-add 3 regression test skips — hotfix-revert #575

### DIFF
--- a/test/libc.zig
+++ b/test/libc.zig
@@ -81,8 +81,8 @@ pub fn addCases(cases: *tests.LibcContext) void {
     cases.addLibcTestCase("regression/flockfile-list.c", false, .{});
     cases.addLibcTestCase("regression/fpclassify-invalid-ld80.c", true, .{});
     cases.addLibcTestCase("regression/ftello-unflushed-append.c", false, .{});
-    cases.addLibcTestCase("regression/getpwnam_r-crash.c", true, .{});
-    cases.addLibcTestCase("regression/getpwnam_r-errno.c", true, .{});
+    // "regression/getpwnam_r-crash.c": hangs in libzigc — see issue #431
+    // "regression/getpwnam_r-errno.c": hangs in libzigc — see issue #431
     cases.addLibcTestCase("regression/iconv-roundtrips.c", true, .{});
     cases.addLibcTestCase("regression/inet_ntop-v4mapped.c", true, .{});
     cases.addLibcTestCase("regression/inet_pton-empty-last-field.c", true, .{});
@@ -130,7 +130,7 @@ pub fn addCases(cases: *tests.LibcContext) void {
     cases.addLibcTestCase("regression/setvbuf-unget.c", true, .{});
     cases.addLibcTestCase("regression/sigaltstack.c", false, .{});
     cases.addLibcTestCase("regression/sigprocmask-internal.c", false, .{});
-    cases.addLibcTestCase("regression/sigreturn.c", true, .{});
+    // "regression/sigreturn.c": hangs in libzigc — see issue #431
     cases.addLibcTestCase("regression/sscanf-eof.c", true, .{});
     cases.addLibcTestCase("regression/strverscmp.c", true, .{});
     cases.addLibcTestCase("regression/syscall-sign-extend.c", false, .{});


### PR DESCRIPTION
Hotfix-revert of PR #575.

## Why

PR #575 re-enabled `regression/getpwnam_r-crash.c`, `regression/getpwnam_r-errno.c`, and `regression/sigreturn.c` based on a green `test-libc` workflow run (#26238656495). However, the `pr-libc-test` step's regression subset (in `pr-build.yml`) now hangs at `getpwnam_r-crash` and times out after 30 minutes — see run [26240920222](https://github.com/ctaggart/zig/actions/runs/26240920222):

```
##[error]The action 'Run libc-test — regression subset (aarch64-linux-musl, native)' has timed out after 30 minutes.
Terminate orphan process: pid (2752509) (regression.getpwnam_r-crash)
Terminate orphan process: pid (2752881) (regression.getpwnam_r-crash)
Terminate orphan process: pid (2753068) (regression.getpwnam_r-crash)
```

The two harnesses (`test-libc` vs `pr-libc-test`) exercise these tests differently — `test-libc` passes but `pr-libc-test` hangs, masking other regression-subset failures.

## Action

Reverting #575 to restore visibility into the actual #529 triage state. Re-opens #431; the underlying hang must be investigated and fixed properly before re-enabling.

Refs #431, #529.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>