### PR TITLE
libc-test: re-enable regex regressions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -463,8 +463,6 @@ jobs:
             regression.mkstemp-failure
             regression.printf-
             regression.putenv-doublefree
-            regression.regex-
-            regression.regexec-nosub
             regression.rewind-clear-error
             regression.rlimit-open-files
             regression.scanf-


### PR DESCRIPTION
## Summary\n- remove the temporary regex libc-test skip filters from pr-build.yml\n- re-enable regex-bracket-icase, regex-escaped-high-byte, and the rest of the regex regression cluster\n- verified the skipped regex regressions all exit 0 on aarch64-linux-musl via qemu\n\n## Verification\n- regex-backref-0\n- regex-bracket-icase\n- regex-ere-backref\n- regex-escaped-high-byte\n- regex-negated-range\n- regexec-nosub