### PR TITLE
libzigc/stdio: hoist va_list copy out of vfwscanf loop (fixes #583)

### DIFF
--- a/lib/c/stdio.zig
+++ b/lib/c/stdio.zig
@@ -4142,6 +4142,12 @@ fn vfwscanf_impl(f_raw: ?*FILE, fmt: [*:0]const wchar_t, ap: VaList) callconv(.c
     const need_unlock = flock(f);
     _ = fwide_fn(f, 1);
 
+    // Mutable copy of the va_list shared across loop iterations so that
+    // @cVaArg correctly advances state from one conversion to the next.
+    // (Declaring this inside the loop would reset to the first vararg on every
+    // iteration — see vfscanf_impl which uses the same ap_src pattern.)
+    var ap_src = ap;
+
     while (p[0] != 0) : (p += 1) {
         var alloc = false;
 
@@ -4179,7 +4185,6 @@ fn vfwscanf_impl(f_raw: ?*FILE, fmt: [*:0]const wchar_t, ap: VaList) callconv(.c
         }
 
         p += 1;
-        var ap_mut = ap;
         if (wcharAsU32(p[0]) == '*') {
             dest = null;
             p += 1;
@@ -4187,7 +4192,7 @@ fn vfwscanf_impl(f_raw: ?*FILE, fmt: [*:0]const wchar_t, ap: VaList) callconv(.c
             dest = vfwscanfArgN(ap, wcharAsU32(p[0]) - '0');
             p += 2;
         } else {
-            dest = @cVaArg(&ap_mut, ?*anyopaque);
+            dest = @cVaArg(&ap_src, ?*anyopaque);
         }
 
         var width: c_int = 0;


### PR DESCRIPTION
Fixes #583.

## Root cause

`vfwscanf_impl` declared `var ap_mut = ap;` **inside** the format loop. Each
iteration reset `ap_mut` to a fresh copy of the original `va_list`, so
`@cVaArg(&ap_mut, …)` only advanced the local copy — the outer `ap` never
progressed. Every conversion fetched vararg #0, and subsequent output
arguments were never written.

## Why this single bug explains all 13 fwscanf test failures

| Test    | Format                  | Effect with bug                               |
|---------|-------------------------|-----------------------------------------------|
| L46/47  | `L" %n%*d%n"`           | Both `%n` write to `&x`; `y` stays `-1`       |
| L57-60  | `L"%10[^]]%n%10[].]%n"` | All 4 writes target `a`; `x`/`y` stay `-1`. The two `%n` overwrite `a` with `int(7)` then `int(12)` — explains `a = "^L"` (0x0C = 12 little-endian) |
| L82-85  | `L"%lf%n%c %d"`         | All 4 writes target `&u`; `x`/`a`/`y` stay untouched (`a[0]=12` is residue from L60 cascade) |
| L96-98  | `L"%lf%n %i"`           | All 3 writes target `&u`; `x`/`y` stay `-1`   |

## Fix

Hoist the va_list copy out of the loop and rename to `ap_src` to match
[`vfscanf_impl`](https://github.com/ctaggart/zig/blob/libc/0.16.x/lib/c/stdio.zig#L3627),
which has had the correct pattern all along. Musl uses
[`va_arg(ap, void *)`](https://github.com/ctaggart/zig/blob/libc/0.16.x/lib/libc/musl/src/stdio/vfwscanf.c#L140)
directly on the outer `ap` (same semantic).

Three-line change in a single function.

## Verification

- Local: `zig fmt --check` and `zig ast-check` pass.
- (Stage4 build remains blocked by unrelated wprintf f128 ICE — defer to CI.)
- CI: expect `functional.fwscanf` to flip FAIL → PASS, clearing all 13 lines
  above in a single run. Test filter for `functional.fwscanf` is already in
  `.github/workflows/pr-build.yml` (added in #582).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>