### PR TITLE
libzigc/math: fix __fpclassifyl f128 branch dropping qNaN bit (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -2970,7 +2970,10 @@ fn __fpclassifyl(x: c_longdouble) callconv(.c) c_int {
             const ux: u128 = @bitCast(x);
             const e: u32 = @truncate((ux >> 112) & 0x7fff);
             if (e == 0) break :blk if ((ux << 1) != 0) @as(c_int, 3) else @as(c_int, 2);
-            if (e == 0x7fff) break :blk if ((ux << 17) != 0) @as(c_int, 0) else @as(c_int, 1);
+            // Shift away the sign bit (1) + exponent bits (15) = 16, leaving
+            // all 112 mantissa bits. Shifting by 17 would drop bit 111 — the
+            // qNaN bit — and misclassify canonical qNaN as FP_INFINITE.
+            if (e == 0x7fff) break :blk if ((ux << 16) != 0) @as(c_int, 0) else @as(c_int, 1);
             break :blk @as(c_int, 4);
         },
         else => unreachable,


### PR DESCRIPTION
## Summary

The 128-bit branch of `__fpclassifyl` in `lib/c/math.zig` shifted left by 17
to test the mantissa, which also discarded bit 111 — the qNaN bit. A
canonical quiet NaN (\`0x7fff_8000_..._0000\`) was therefore classified as
\`FP_INFINITE\`, so musl's \`isnan(long double)\` macro
(\`lib/libc/include/generic-musl/math.h:78-81\`, which falls through to
\`__fpclassifyl == FP_NAN\` for non-float/non-double types) returned 0 on
every Zig-produced NaN that round-tripped through \`long double\`.

binary128 layout: sign (bit 127), exponent (bits 112..126, 15 bits),
mantissa (bits 0..111, 112 bits). Shifting left by 16 drops only the sign +
exponent and leaves all 112 mantissa bits available for the non-zero test.

## Impact

\`mtest.h:checkcr\` (libc-test) promotes the test's \`double\` result to
\`long double\` and calls \`isnan(y)\`. With the bug, every test case whose
result was a canonical qNaN logged \`want nan got nan\` once per row. The
latest pr-build run on \`libc/0.16.x\` (26495393193) has **4244** such
lines across ~70 distinct math tests (\`trunc\`, \`fabs\`, \`fabsf\`,
\`copysign\`, \`copysignf\`, \`isless\`, \`fpclassify\`, …).

## Verification

\`__fpclassify\` (f64) and \`__fpclassifyf\` (f32) already use the
correct shifts (12 and 9 respectively) and match musl's reference.
Only the 128-bit branch was wrong; the f80 branch uses a different
structure (explicit integer-bit check) and is unaffected.

## Plan context

This is Step 1 of the issue #526 promotion plan. After this lands, the
math slice still has the category-3 (real result mismatches) and
category-4 (FP exception flags) failures to drive down before \`Run
libc-test — math\` can have \`continue-on-error: true\` removed.

Refs #526