### PR TITLE
libzigc/math: fix asinh(±inf) stack overflow in log_pure recursion (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -1991,6 +1991,11 @@ fn log1p_wide(comptime T: type, x: T) T {
 /// Compute log(x) for x > 0 using frexp range reduction + log1p_wide.
 /// Uses only basic arithmetic — no @log.
 fn log_pure(comptime T: type, x: T) T {
+    // log(+inf) = +inf, log(nan) = nan. Without this guard, frexp(inf) yields
+    // a non-finite significand, the |x|>0.5 branch in log1p_wide re-enters
+    // log_pure(+inf), and the two helpers recurse until the stack overflows
+    // (issue #526: asinh(±inf) SEGV).
+    if (!math.isFinite(x)) return x;
     const fr = math.frexp(x);
     var sig = fr.significand;
     var exp_val = fr.exponent;


### PR DESCRIPTION
Towards #526.

## Bug

`asinh(±inf)` SEGVs on all opt levels (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall) in the libc-test math slice on aarch64-linux-musl.

Trace:
- `asinh_(inf)` hits the `e >= 0x3FF + 26` branch and calls `log_pure(f128, inf)`.
- `log_pure(inf)` → `math.frexp(inf)` returns `{ significand = inf, exponent = 0 }`.
- `k = 0`, so `log_pure` returns `log1p_wide(f128, inf - 1.0)` i.e. `log1p_wide(f128, inf)`.
- `log1p_wide`'s `x > 0.5` fast path forwards to `log_pure(f128, 1 + inf) = log_pure(f128, inf)`.
- Infinite mutual recursion → stack overflow → SEGV.

## Fix

Guard `log_pure` with an early non-finite return:

```zig
if (!math.isFinite(x)) return x;
```

`log(+inf) = +inf` and `log(nan) = nan`, so propagating the input is the correct mathematical answer for both. Both in-tree callers (`asinh_`, `asinhl_impl`) only ever pass positive values to `log_pure`, so we never need to consider `log_pure(-inf)`.

## Verification

Locally on the aarch64 runner with prebuilt stage4:

```
$ zig build test-libc -Dlibc-test-path=$CACHE -Dtest-target-filter=aarch64-linux-musl \
    -Dtest-filter=math.asinh --summary failures
# (no failures)
```

Re-running the full math slice (`-Dtest-filter=math`):

| Metric | Before | After |
| --- | --- | --- |
| SEGVs | 4 (asinh × {Debug,ReleaseFast,ReleaseSafe,ReleaseSmall}) | **0** |
| Distinct failing tests | 29 | **28** |

No regressions; `asinh` drops cleanly from the list.

## Towards promoting the math slice

Per the [post-#585 refresh](https://github.com/ctaggart/zig/issues/526#issuecomment-4553273135), this clears the last hard-crash blocker. The next high-leverage fix (per the plan in #526) is honoring `fesetround` in `sqrt`/`sqrtf`/`rint`/`rintf`/`nearbyintf`/`lrint`, which represents ~460 of the remaining ~1585 value-mismatch lines.
