### PR TITLE
libzigc: implement aarch64 fenv and honor rounding modes in sqrt/rint (#526)

### DIFF
--- a/lib/c/fenv.zig
+++ b/lib/c/fenv.zig
@@ -62,9 +62,23 @@ const isArmHardFloat = switch (builtin.abi) {
     else => false,
 };
 
+const isAarch64 = switch (builtin.cpu.arch) {
+    .aarch64, .aarch64_be => true,
+    else => false,
+};
+
 const ARM_FE_ALL_EXCEPT: c_int = 0x1f;
 const ARM_FE_ROUND_MASK: c_uint = 0xc00000;
 const ARM_FE_DFL_ENV = @as(usize, std.math.maxInt(usize));
+
+const AARCH64_FE_ALL_EXCEPT: c_uint = 0x1f;
+const AARCH64_FE_ROUND_MASK: c_uint = 0xc00000;
+const AARCH64_FE_DFL_ENV = @as(usize, std.math.maxInt(usize));
+
+const aarch64_fenv_t = extern struct {
+    __fpcr: c_uint,
+    __fpsr: c_uint,
+};
 
 const FE_ALL_EXCEPT: c_int = switch (builtin.cpu.arch) {
     .x86_64, .x86, .hexagon => 0x3f,
@@ -148,7 +162,15 @@ const FE_DOWNWARD: ?c_int = switch (builtin.cpu.arch) {
 
 comptime {
     if (builtin.link_libc) {
-        if (isArmHardFloat) {
+        if (isAarch64) {
+            symbol(&aarch64_feclearexcept, "feclearexcept");
+            symbol(&aarch64_feraiseexcept, "feraiseexcept");
+            symbol(&aarch64_fetestexcept, "fetestexcept");
+            symbol(&aarch64_fegetround, "fegetround");
+            symbol(&aarch64___fesetround, "__fesetround");
+            symbol(&aarch64_fegetenv, "fegetenv");
+            symbol(&aarch64_fesetenv, "fesetenv");
+        } else if (isArmHardFloat) {
             symbol(&arm_feclearexcept, "feclearexcept");
             symbol(&arm_feraiseexcept, "feraiseexcept");
             symbol(&arm_fetestexcept, "fetestexcept");
@@ -468,6 +490,84 @@ fn arm_fesetenv(envp: *const c_ulong) callconv(.c) c_int {
     return 0;
 }
 
+fn aarch64_get_fpcr() c_uint {
+    var fpcr: u64 = undefined;
+    asm volatile ("mrs %[fpcr], fpcr"
+        : [fpcr] "=r" (fpcr),
+    );
+    return @truncate(fpcr);
+}
+
+fn aarch64_set_fpcr(fpcr: c_uint) void {
+    asm volatile ("msr fpcr, %[fpcr]"
+        :
+        : [fpcr] "r" (@as(u64, fpcr)),
+    );
+}
+
+fn aarch64_get_fpsr() c_uint {
+    var fpsr: u64 = undefined;
+    asm volatile ("mrs %[fpsr], fpsr"
+        : [fpsr] "=r" (fpsr),
+    );
+    return @truncate(fpsr);
+}
+
+fn aarch64_set_fpsr(fpsr: c_uint) void {
+    asm volatile ("msr fpsr, %[fpsr]"
+        :
+        : [fpsr] "r" (@as(u64, fpsr)),
+    );
+}
+
+fn aarch64_feclearexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & AARCH64_FE_ALL_EXCEPT;
+    aarch64_set_fpsr(aarch64_get_fpsr() & ~exceptions);
+    return 0;
+}
+
+fn aarch64_feraiseexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & AARCH64_FE_ALL_EXCEPT;
+    aarch64_set_fpsr(aarch64_get_fpsr() | exceptions);
+    return 0;
+}
+
+fn aarch64_fetestexcept(mask: c_int) callconv(.c) c_int {
+    const exceptions = @as(c_uint, @bitCast(mask)) & AARCH64_FE_ALL_EXCEPT;
+    return @intCast(aarch64_get_fpsr() & exceptions);
+}
+
+fn aarch64_fegetround() callconv(.c) c_int {
+    return @intCast(aarch64_get_fpcr() & AARCH64_FE_ROUND_MASK);
+}
+
+fn aarch64___fesetround(r: c_int) callconv(.c) c_int {
+    var fpcr = aarch64_get_fpcr();
+    fpcr &= ~AARCH64_FE_ROUND_MASK;
+    fpcr |= @as(c_uint, @bitCast(r)) & AARCH64_FE_ROUND_MASK;
+    aarch64_set_fpcr(fpcr);
+    return 0;
+}
+
+fn aarch64_fegetenv(envp: *aarch64_fenv_t) callconv(.c) c_int {
+    envp.* = .{
+        .__fpcr = aarch64_get_fpcr(),
+        .__fpsr = aarch64_get_fpsr(),
+    };
+    return 0;
+}
+
+fn aarch64_fesetenv(envp: *const aarch64_fenv_t) callconv(.c) c_int {
+    if (@intFromPtr(envp) == AARCH64_FE_DFL_ENV) {
+        aarch64_set_fpcr(0);
+        aarch64_set_fpsr(0);
+    } else {
+        aarch64_set_fpcr(envp.__fpcr);
+        aarch64_set_fpsr(envp.__fpsr);
+    }
+    return 0;
+}
+
 fn riscv_sf_feclearexcept(mask: c_int) callconv(.c) c_int {
     _ = mask;
     return 0;
@@ -507,36 +607,43 @@ fn riscv_sf_fesetenv(envp: *const anyopaque) callconv(.c) c_int {
 // strong definitions that override these at link time.
 
 fn feclearexcept(mask: c_int) callconv(.c) c_int {
+    if (isAarch64) return aarch64_feclearexcept(mask);
     if (isArmHardFloat) return arm_feclearexcept(mask);
     return 0;
 }
 
 fn feraiseexcept(mask: c_int) callconv(.c) c_int {
+    if (isAarch64) return aarch64_feraiseexcept(mask);
     if (isArmHardFloat) return arm_feraiseexcept(mask);
     return 0;
 }
 
 fn fetestexcept(mask: c_int) callconv(.c) c_int {
+    if (isAarch64) return aarch64_fetestexcept(mask);
     if (isArmHardFloat) return arm_fetestexcept(mask);
     return 0;
 }
 
 fn fegetround() callconv(.c) c_int {
+    if (isAarch64) return aarch64_fegetround();
     if (isArmHardFloat) return arm_fegetround();
     return FE_TONEAREST;
 }
 
 fn __fesetround(r: c_int) callconv(.c) c_int {
+    if (isAarch64) return aarch64___fesetround(r);
     if (isArmHardFloat) return arm___fesetround(r);
     return 0;
 }
 
 fn fegetenv(envp: *anyopaque) callconv(.c) c_int {
+    if (isAarch64) return aarch64_fegetenv(@ptrCast(@alignCast(envp)));
     if (isArmHardFloat) return arm_fegetenv(@ptrCast(@alignCast(envp)));
     return 0;
 }
 
 fn fesetenv(envp: *const anyopaque) callconv(.c) c_int {
+    if (isAarch64) return aarch64_fesetenv(@ptrCast(@alignCast(envp)));
     if (isArmHardFloat) return arm_fesetenv(@ptrCast(@alignCast(envp)));
     return 0;
 }

--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -1445,6 +1445,7 @@ fn pow10f(x: f32) callconv(.c) f32 {
 }
 
 fn rint(x: f64) callconv(.c) f64 {
+    @setFloatMode(.strict);
     const toint: f64 = 1.0 / @as(f64, math.floatEps(f64));
     const a: u64 = @bitCast(x);
     const e = a >> 52 & 0x7ff;
@@ -1659,6 +1660,7 @@ fn nexttowardl(x: c_longdouble, y: c_longdouble) callconv(.c) c_longdouble {
 
 /// Generic rint for any IEEE 754 float type.
 fn rintGeneric(comptime T: type, x: T) T {
+    @setFloatMode(.strict);
     const toint: T = 1.0 / math.floatEps(T);
     const FloatBits = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
     const mant_bits = math.floatMantissaBits(T);
@@ -1911,6 +1913,7 @@ fn significandf_(x: f32) callconv(.c) f32 {
 }
 
 fn rintf(x: f32) callconv(.c) f32 {
+    @setFloatMode(.strict);
     const toint: f32 = 1.0 / @as(f32, math.floatEps(f32));
     const a: u32 = @bitCast(x);
     const e = a >> 23 & 0xff;
@@ -1932,6 +1935,7 @@ fn rintf(x: f32) callconv(.c) f32 {
 }
 
 fn rintl(x: c_longdouble) callconv(.c) c_longdouble {
+    @setFloatMode(.strict);
     const toint: c_longdouble = 1.0 / @as(c_longdouble, math.floatEps(c_longdouble));
 
     // NaN or already-integer (includes Inf since Inf >= toint)

--- a/lib/compiler_rt/sqrt.zig
+++ b/lib/compiler_rt/sqrt.zig
@@ -27,6 +27,7 @@ comptime {
 }
 
 pub fn __sqrth(x: f16) callconv(.c) f16 {
+    @setFloatMode(.strict);
     var ix: u16 = @bitCast(x);
     var top = ix >> 10;
 
@@ -92,6 +93,11 @@ pub fn __sqrth(x: f16) callconv(.c) f16 {
 }
 
 pub fn sqrtf(x: f32) callconv(.c) f32 {
+    // The "y + t" step below depends on strict IEEE-754 add semantics so that the
+    // current rounding mode (FE_UPWARD/FE_DOWNWARD/FE_TOWARDZERO) can adjust
+    // the round-to-nearest result `y` by adding a sub-ULP value `t`.
+    // Without strict mode, optimized builds collapse `y + t` to `y`.
+    @setFloatMode(.strict);
     var ix: u32 = @bitCast(x);
 
     if (ix < @as(u32, @bitCast(@as(f32, 0x1p-126))) or @as(u32, @bitCast(std.math.inf(f32))) <= ix) {
@@ -146,6 +152,11 @@ pub fn sqrtf(x: f32) callconv(.c) f32 {
 }
 
 pub fn sqrt(x: f64) callconv(.c) f64 {
+    // The "y + t" step below depends on strict IEEE-754 add semantics so that the
+    // current rounding mode (FE_UPWARD/FE_DOWNWARD/FE_TOWARDZERO) can adjust
+    // the round-to-nearest result `y` by adding a sub-ULP value `t`.
+    // Without strict mode, optimized builds collapse `y + t` to `y`.
+    @setFloatMode(.strict);
     var ix: u64 = @bitCast(x);
     var top = ix >> 52;
 
@@ -283,6 +294,7 @@ pub fn sqrt(x: f64) callconv(.c) f64 {
 }
 
 pub fn __sqrtx(x: f80) callconv(.c) f80 {
+    @setFloatMode(.strict);
     var ix: u80 = @bitCast(x);
     var top = ix >> 64;
 
@@ -380,6 +392,7 @@ pub fn __sqrtx(x: f80) callconv(.c) f80 {
 }
 
 pub fn sqrtq(x: f128) callconv(.c) f128 {
+    @setFloatMode(.strict);
     var ix: u128 = @bitCast(x);
     var top = ix >> 112;
 


### PR DESCRIPTION
Refs #526.

## Root cause

Previously the fenv generic fallback in `lib/c/fenv.zig` was a no-op on aarch64-linux-musl: there was no aarch64-specific implementation, only 32-bit ARM (`isArmHardFloat`) and a few others. `fesetround(FE_UPWARD/FE_DOWNWARD/FE_TOWARDZERO)` silently returned 0 without touching FPCR, so even the aarch64 hardware `fsqrt` instruction — which honors FPCR — saw a zero rounding field and produced round-to-nearest results in every mode.

## Fix

**`lib/c/fenv.zig`** — add an aarch64 implementation of `feclearexcept`/`feraiseexcept`/`fetestexcept`/`fegetround`/`__fesetround`/`fegetenv`/`fesetenv`. These read/write FPCR and FPSR via `mrs`/`msr` inline asm.

Layout follows musl `arch/aarch64/bits/fenv.h`:
- `FE_TONEAREST = 0`, `FE_UPWARD = 0x400000`, `FE_DOWNWARD = 0x800000`, `FE_TOWARDZERO = 0xc00000` in FPCR bits 22-23.
- Exception flags in FPSR bits 0-4 (`FE_ALL_EXCEPT = 0x1f`).
- `fenv_t` is `extern struct { __fpcr: c_uint, __fpsr: c_uint }`.

Dispatch is wired through both the existing `comptime` symbol-registration block (so the exported strong symbols point at the aarch64 versions on aarch64 targets) and the per-function generic fallbacks (so internal Zig callers like `__flt_rounds`, `fesetexceptflag`, `feholdexcept`, `feupdateenv` also work on aarch64).

**`lib/compiler_rt/sqrt.zig`** — add `@setFloatMode(.strict)` to `sqrt`, `sqrtf`, `__sqrth`, `__sqrtx`, `sqrtq`. The musl-derived algorithm computes the round-to-nearest result `y` and then a sub-ULP correction `t` based on the residual, returning `y + t`. Under `.optimized` float mode, LLVM is allowed to apply fast-math reassociation that collapses `y + t` (where `t` is tiny) back to `y`, defeating the directed-rounding correction.

**`lib/c/math.zig`** — add `@setFloatMode(.strict)` to `rint`, `rintf`, `rintl`, `rintGeneric`. These all use the standard `x ± toint - toint` round-to-integer-in-current-mode trick, which is algebraically `x` and so similarly vulnerable to optimizer collapse.

## Test slice impact (aarch64-linux-musl libc-test math)

Before this PR, `sqrt`, `sqrtf`, `rint`, `rintf` failed under all opt levels (UCB lines mismatched in directed rounding modes). After this PR they all pass:

```
$ .zig-cache/o/.../math.sqrt   # 0 failure lines
$ .zig-cache/o/.../math.sqrtf  # 0 failure lines
$ .zig-cache/o/.../math.rint   # 0 failure lines
$ .zig-cache/o/.../math.rintf  # 0 failure lines
```

Remaining math test failures (`lrint` raising no `FE_INVALID` on nan/inf, `nearbyintf` incorrectly raising `FE_INEXACT`, plus various transcendental UCB cases) are separate fp-exception-flag issues and will be addressed in follow-up PRs.