### PR TITLE
math: handle scalbn(±0, n) and exact-subnormal flag in libzigc (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -953,8 +953,8 @@ fn scalbnWithFlags(comptime T: type, x: T, n: i32) T {
             const mant_bits = math.floatMantissaBits(T);
             const repr: TBits = @bitCast(result);
             const exp_field = (repr << 1) >> (mant_bits + 1);
-            if (exp_field == 0 and result != x) {
-                // subnormal result, force UNDERFLOW|INEXACT
+            if (exp_field == 0 and result != x and scalbnSubnormalInexact(T, x, n)) {
+                // inexact subnormal result, force UNDERFLOW|INEXACT
                 const bits = @typeInfo(T).float.bits;
                 const tiny: T = if (bits <= 32) 0x1p-95 else if (bits <= 64) 0x1p-767 else 0x1p-16382;
                 forceEval(T, fpBarrierValue(T, tiny) * tiny);
@@ -962,6 +962,39 @@ fn scalbnWithFlags(comptime T: type, x: T, n: i32) T {
         }
     }
     return result;
+}
+
+// Returns true if scalbn(x, n) lost precision producing a subnormal result.
+// Caller guarantees x is finite nonzero and result is subnormal.
+// IEEE 754 only raises the underflow flag when a tiny result is inexact.
+fn scalbnSubnormalInexact(comptime T: type, x: T, n: i32) bool {
+    const TBits = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
+    const total_bits = @typeInfo(T).float.bits;
+    const mant_bits = math.floatMantissaBits(T);
+    const fract_bits = math.floatFractionalBits(T);
+    const exp_bits: u16 = total_bits - mant_bits - 1;
+    const exp_bias: i32 = (@as(i32, 1) << @as(u5, @intCast(exp_bits - 1))) - 1;
+    const exp_min: i32 = 1 - exp_bias;
+    const fract_mask: TBits = (@as(TBits, 1) << fract_bits) - 1;
+    const exp_mask: TBits = (@as(TBits, 1) << exp_bits) - 1;
+
+    const repr_x: TBits = @bitCast(x);
+    const exp_x_biased: i32 = @intCast((repr_x >> mant_bits) & exp_mask);
+    const frac_x: TBits = repr_x & fract_mask;
+
+    // Build the full significand. For f80 the integer bit is explicit (bit
+    // `fract_bits`); for other IEEE binary formats it is implicit.
+    const significand: TBits = if (exp_x_biased == 0)
+        frac_x
+    else
+        (@as(TBits, 1) << fract_bits) | frac_x;
+
+    const ctz_sig: i32 = @intCast(@ctz(significand));
+    // Right shift applied to the significand to fit into the subnormal mantissa.
+    // For normal x: shift = exp_min - e_x - n  where e_x = exp_x_biased - exp_bias.
+    // For subnormal x: shift = -n (both x and result share the subnormal exponent).
+    const shift: i32 = if (exp_x_biased == 0) -n else exp_min - (exp_x_biased - exp_bias) - n;
+    return shift > ctz_sig;
 }
 
 fn __math_divzero(sign: u32) callconv(.c) f64 {

--- a/lib/std/math/ldexp.zig
+++ b/lib/std/math/ldexp.zig
@@ -22,6 +22,9 @@ pub fn ldexp(x: anytype, n: i32) @TypeOf(x) {
     if (math.isNan(x) or !math.isFinite(x))
         return x;
 
+    if (x == 0)
+        return x;
+
     var exponent: i32 = @as(i32, @intCast((repr << 1) >> (mantissa_bits + 1)));
     if (exponent == 0)
         exponent += (@as(i32, exponent_bits) + @intFromBool(T == f80)) - @clz(repr << 1);
@@ -135,6 +138,12 @@ test ldexp {
         try expect(ldexp(math.inf(T), min_exponent) == math.inf(T));
         try expect(ldexp(-math.inf(T), math.maxInt(i32)) == -math.inf(T));
         try expect(ldexp(-math.inf(T), math.minInt(i32)) == -math.inf(T));
+
+        // zero -> zero (regardless of n)
+        try expect(ldexp(@as(T, 0.0), math.maxInt(i32)) == 0.0);
+        try expect(ldexp(@as(T, 0.0), math.minInt(i32)) == 0.0);
+        try expect(@as(std.meta.Int(.unsigned, @bitSizeOf(T)), @bitCast(ldexp(@as(T, -0.0), math.maxInt(i32)))) ==
+            @as(std.meta.Int(.unsigned, @bitSizeOf(T)), @bitCast(@as(T, -0.0))));
 
         // extremely large n
         try expect(ldexp(math.floatMax(T), math.maxInt(i32)) == math.inf(T));


### PR DESCRIPTION
Refs #526.

Two related bugs in the scalbn/ldexp family on aarch64-linux-musl libc-test that share the same call path through `scalbnWithFlags`.

## 1. `scalbn(±0, huge_n) → ±inf`

`std.math.ldexp` (and its alias `scalbn`) fell through its main code path for input zero. With `repr = 0`, the recomputed exponent became the bit-width of the type (via `@clz(0)`), and a huge positive `n` then triggered the overflow path, returning ±inf instead of preserving zero.

Fix: add an early `if (x == 0) return x;` after the existing NaN/inf guard. `ldexp(±0, n) = ±0` for any `n`, with the original sign of zero preserved.

Includes new test coverage in `lib/std/math/ldexp.zig`:
```zig
// zero -> zero (regardless of n)
try expect(ldexp(@as(T, 0.0), math.maxInt(i32)) == 0.0);
try expect(ldexp(@as(T, 0.0), math.minInt(i32)) == 0.0);
// negative zero preserves sign
```

## 2. `scalbn(0x1p+1023, -2097) → 0x1p-1074` raising spurious `UNDERFLOW`

IEEE 754 only raises the underflow flag when a tiny result is **inexact**. The libzigc `scalbnWithFlags` wrapper was raising `UNDERFLOW|INEXACT` for every subnormal result, even when the input was a pure power of two scaled exactly into the subnormal range.

Fix: add `scalbnSubnormalInexact()` that detects exactness by comparing the trailing-zero count of x's full significand against the right-shift amount applied to fit into the subnormal mantissa:

```
shift = exp_min - e_x - n     (normal x)
shift = -n                    (subnormal x)
inexact iff shift > @ctz(significand)
```

Handles f80's explicit integer bit by using `floatFractionalBits` rather than `floatMantissaBits` for the implicit-leading-1 placement.

## Test slice impact

`aarch64-linux-musl` libc-test math: **24 → 16 distinct failing tests**. Newly passing across all four opt levels (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall):

- `scalbn`, `scalbnf`
- `scalb`, `scalbf`
- `scalbln`, `scalblnf`
- `ldexp`, `ldexpf`