### PR TITLE
libzigc/math: fix fdim FE flag bugs from branchless ternary (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -1531,9 +1531,11 @@ fn expm1f(x: f32) callconv(.c) f32 {
 }
 
 fn fdimGeneric(comptime T: type, x: T, y: T) T {
-    if (math.isNan(x)) return math.nan(T);
-    if (math.isNan(y)) return math.nan(T);
-    return if (x > y) x - y else 0;
+    @setFloatMode(.strict);
+    if (math.isNan(x)) return x;
+    if (math.isNan(y)) return y;
+    if (x > y) return x - y;
+    return 0;
 }
 
 fn fdimf(x: f32, y: f32) callconv(.c) f32 {
@@ -1809,16 +1811,7 @@ fn scalbnl(x: c_longdouble, n: c_int) callconv(.c) c_longdouble {
 }
 
 fn fdim(x: f64, y: f64) callconv(.c) f64 {
-    if (math.isNan(x)) {
-        return x;
-    }
-    if (math.isNan(y)) {
-        return y;
-    }
-    if (x > y) {
-        return x - y;
-    }
-    return 0;
+    return fdimGeneric(f64, x, y);
 }
 
 /// Port of musl powf — IEEE 754 conformant single-precision power function.


### PR DESCRIPTION
## Summary

`fdimGeneric` used a ternary `return if (x > y) x - y else 0;` which LLVM lowers to a branchless `select` — evaluating `x - y` **unconditionally** before the select chooses between it and `0`. This raised:
- Spurious **INEXACT** when `x <= y` but `x - y` would have been inexact.
- **INVALID** for `fdim(inf, inf)` and `fdim(-inf, -inf)` since `inf - inf = nan`.

Replace with an explicit `if (x > y) return x - y;` so the subtraction only executes when its result is actually used. Add `@setFloatMode(.strict)` to prevent any future relaxed-FP rewrite from re-introducing the same branchless lowering.

Also fix NaN propagation: `math.nan(T)` constructed a fresh canonical NaN; returning the input NaN (`return x` / `return y`) matches musl's behavior and preserves any sNaN bit pattern. (No test cases exercise this difference, but it's the spec-correct behavior.)

Collapse the redundant explicit-branch f64 `fdim` to call `fdimGeneric` so all three exports share the fixed implementation.

## Verification

aarch64-linux-musl runner, clean cache, stage4:

| Test | Before | After |
|---|---|---|
| math.fdim  | 0 | 0 |
| math.fdimf | 7 (3 spurious INEXACT + 4 INVALID for inf-inf) | **0** |
| math.fdiml | 0 | 0 |

All four optimize modes (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall) pass.

## Context

Part of #526 — driving the libc-test `math` slice to 0 distinct failing tests so it can be promoted from advisory to required on `libc/0.16.x`.

Failing math tests after merge: **15** (down from 16). Same general pattern (branchless-select trap) likely affects other functions; this PR isolates the fdim fix as a small, easily-reviewed change before tackling the remaining FE-flag cluster (log1p, nextafter, expm1f, lrint, nearbyintf).