### PR TITLE
math: fix spurious UNDERFLOW in log1p family (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -1613,8 +1613,9 @@ fn log1p(x: f64) callconv(.c) f64 {
     if (x < -1.0) return (x - x) / (x - x); // raise FE_INVALID
     const result = math.log1p(x);
     if (result != 0 and result == x) {
-        // tiny x: result is x itself, force INEXACT evaluation
-        forceEval(f64, fpBarrierValue(f64, x) * fpBarrierValue(f64, x));
+        // tiny x: result is x itself, force INEXACT evaluation.
+        // Use 1 + x rather than x * x so tiny normal x does not underflow.
+        forceEval(f64, 1.0 + fpBarrierValue(f64, x));
     }
     return result;
 }
@@ -1624,7 +1625,9 @@ fn log1pf(x: f32) callconv(.c) f32 {
     if (x < -1.0) return (x - x) / (x - x); // raise FE_INVALID
     const result = math.log1p(x);
     if (result != 0 and result == x) {
-        forceEval(f32, fpBarrierValue(f32, x) * fpBarrierValue(f32, x));
+        // tiny x: result is x itself, force INEXACT evaluation.
+        // Use 1 + x rather than x * x so tiny normal x does not underflow.
+        forceEval(f32, 1.0 + fpBarrierValue(f32, x));
     }
     return result;
 }

--- a/lib/std/math/log1p.zig
+++ b/lib/std/math/log1p.zig
@@ -135,8 +135,9 @@ fn log1p_64(x: f64) f64 {
         }
         // |x| < 2^(-53)
         if ((hx << 1) < (0x3CA00000 << 1)) {
+            // underflow if subnormal; no flag for x == 0
             if ((hx & 0x7FF00000) == 0) {
-                math.raiseUnderflow();
+                mem.doNotOptimizeAway(x * x);
             }
             return x;
         }


### PR DESCRIPTION
## Problem

The libc-test math suite for `aarch64-linux-musl` reported spurious `UNDERFLOW` flags from `log1p`/`log1pf`:

- `log1p(0)` expected 0 flags, got `UNDERFLOW|INEXACT`.
- `log1pf(-0x1p-100)` expected `INEXACT`, got `UNDERFLOW|INEXACT` in some optimize modes.

## Root cause

1. `std.math.log1p_64` unconditionally calls `math.raiseUnderflow()` when `|x| < 2^-53` and the high exponent bits are zero (lib/std/math/log1p.zig:138-140). For `x == 0` this raises `UNDERFLOW` even though no underflow occurred.
2. The libzigc `log1p`/`log1pf` wrappers force `INEXACT` via `forceEval(x * x)`. For tiny normal `x` in f32 (e.g. `-0x1p-100`), `x*x = 2^-200` underflows to subnormal/zero in f32, raising spurious `UNDERFLOW`.

## Fix

1. **`lib/std/math/log1p.zig`**: replace `math.raiseUnderflow()` with `mem.doNotOptimizeAway(x * x)` to match `log1p_32`. For `x == 0`, `0*0 = 0` raises no flag. For subnormals the product underflows naturally, raising `UNDERFLOW|INEXACT`.
2. **`lib/c/math.zig`**: replace `forceEval(x * x)` with `forceEval(1.0 + x)` in both `log1p` and `log1pf` wrappers. `1.0 + x` is inexact for any tiny non-zero `x` and never underflows.

## Verification

On aarch64-linux-musl with the libc-test math slice:

- Before: `log1p` 4 failure lines, `log1pf` 1 failure line.
- After: 0 failure lines for both.
- No regressions in other math tests.

Failing test count for the `math.*` slice: **15 → 13** (this PR closes `log1p` and `log1pf`).

## Notes

Part of #526 — drive `pr-libc-test — math` to fully green so it can be promoted to required on `libc/0.16.x`.