### PR TITLE
math: fix spurious OVERFLOW in expm1 family (#526)

### DIFF
--- a/lib/std/math/expm1.zig
+++ b/lib/std/math/expm1.zig
@@ -29,6 +29,8 @@ pub fn expm1(x: anytype) @TypeOf(x) {
 }
 
 fn expm1_32(x_: f32) f32 {
+    @setFloatMode(.strict);
+
     if (math.isNan(x_))
         return math.nan(f32);
 
@@ -138,14 +140,11 @@ fn expm1_32(x_: f32) f32 {
     const twopk = @as(f32, @bitCast(@as(u32, @intCast((0x7F +% k) << 23))));
 
     if (k < 0 or k > 56) {
-        var y = x - e + 1.0;
+        const y = x - e + 1.0;
         if (k == 128) {
-            y = y * 2.0 * 0x1.0p127;
-        } else {
-            y = y * twopk;
+            return (y * 2.0 * 0x1.0p127) - 1.0;
         }
-
-        return y - 1.0;
+        return (y * twopk) - 1.0;
     }
 
     const uf: f32 = @bitCast(@as(u32, @intCast(0x7F -% k)) << 23);
@@ -157,6 +156,8 @@ fn expm1_32(x_: f32) f32 {
 }
 
 fn expm1_64(x_: f64) f64 {
+    @setFloatMode(.strict);
+
     if (math.isNan(x_))
         return math.nan(f64);
 
@@ -188,6 +189,10 @@ fn expm1_64(x_: f64) f64 {
         // exp1md(-ve) = -1
         if (sign != 0) {
             return -1;
+        }
+        // exp1md(+inf) = +inf without raising OVERFLOW
+        if (math.isPositiveInf(x)) {
+            return x;
         }
         if (x > o_threshold) {
             math.raiseOverflow();
@@ -269,14 +274,11 @@ fn expm1_64(x_: f64) f64 {
     const twopk = @as(f64, @bitCast(@as(u64, @intCast(0x3FF +% k)) << 52));
 
     if (k < 0 or k > 56) {
-        var y = x - e + 1.0;
+        const y = x - e + 1.0;
         if (k == 1024) {
-            y = y * 2.0 * 0x1.0p1023;
-        } else {
-            y = y * twopk;
+            return (y * 2.0 * 0x1.0p1023) - 1.0;
         }
-
-        return y - 1.0;
+        return (y * twopk) - 1.0;
     }
 
     const uf = @as(f64, @bitCast(@as(u64, @intCast(0x3FF -% k)) << 52));


### PR DESCRIPTION
## Problem

On aarch64-linux-musl the libc-test math suite reported spurious `OVERFLOW` from `expm1`/`expm1f`:

- `expm1f(-0x1.0223ap+3) = -0x1.ffd6ep-1`, want `INEXACT`, got `INEXACT|OVERFLOW`.
- `expm1(+inf) = +inf`, want `0` flags, got `INEXACT|OVERFLOW`.

## Root cause

Two distinct FE flag bugs in `lib/std/math/expm1.zig`:

### 1. Branchless-select trap (`expm1_32` and `expm1_64`)

```zig
if (k < 0 or k > 56) {
    var y = x - e + 1.0;
    if (k == 128) {
        y = y * 2.0 * 0x1.0p127;
    } else {
        y = y * twopk;
    }
    return y - 1.0;
}
```

LLVM lowers the inner `if (k == 128)` to a branchless `fcsel`, computing both `y * 2.0 * 2^127` and `y * twopk` unconditionally. For typical reduced inputs (e.g. k = -12 from `expm1f(-0x1.0223ap+3)`) the unselected `y * 2.0 * 2^127` overflows to +inf, raising spurious `OVERFLOW` even though the result is discarded. Disassembly of `.zig-cache/o/.../math.expm1f` confirmed the `fmul s1, s1, s3` (s3 = 0x7F000000 = 2^127) at `math.expm1+0x288` followed by `fcsel s0, s1, s0, eq`.

### 2. `raiseOverflow()` for x = +inf (`expm1_64` only)

```zig
if (x > o_threshold) {
    math.raiseOverflow();
    return math.inf(f64);
}
```

For `x = +inf`, `+inf > o_threshold` is true so `raiseOverflow` is called. But `expm1(+inf) = +inf` is exact — IEEE 754 does not raise OVERFLOW when an infinite input flows through to an infinite output.

(Note: `expm1_32` uses `x *= 0x1.0p127` instead of `math.raiseOverflow`. For x = +inf this is `inf * finite = inf` which IEEE 754 leaves silent, so f32 was already correct on that path.)

## Fix

1. Rewrite the `if (k == 128/1024)` block with explicit early returns so the magnitude-128 multiply only executes on its own branch:
   ```zig
   if (k < 0 or k > 56) {
       const y = x - e + 1.0;
       if (k == 128) return (y * 2.0 * 0x1.0p127) - 1.0;
       return (y * twopk) - 1.0;
   }
   ```
2. Add a `+inf` early return in `expm1_64` before the overflow path.
3. Add `@setFloatMode(.strict)` to both `expm1_32` and `expm1_64` so LLVM treats FE exception side effects as observable, matching the convention from `fdimGeneric` (#589) and the sqrt/rint families (#587).

## Verification

On aarch64-linux-musl with the libc-test math slice:

- Before: `expm1` 5 failure lines, `expm1f` 1 failure line.
- After: 0 failure lines for both, all 4 optimize modes pass.
- No regressions in other math tests.

Failing test count for the `math.*` slice: **13 → 11** (this PR closes `expm1` and `expm1f`).

## Notes

Part of #526 — drive `pr-libc-test — math` to fully green so it can be promoted to required on `libc/0.16.x`. This is the third instance of the branchless-select trap fixed this series (after `fdimGeneric` in #589). Future audits of FP code with `if (cond) expr_a else expr_b` patterns should restructure to explicit returns whenever both arms perform arithmetic.