### PR TITLE
ci: always run check-migration-claims on PRs

### DIFF
--- a/.github/workflows/lint-libc-migration.yml
+++ b/.github/workflows/lint-libc-migration.yml
@@ -14,14 +14,6 @@ on:
       - .github/workflows/lint-libc-migration.yml
       - .github/workflows/pr-build.yml
   pull_request:
-    paths:
-      - src/libs/musl.zig
-      - lib/c/**
-      - test/libc.zig
-      - test/src/Libc.zig
-      - scripts/check_musl_migration.py
-      - .github/workflows/lint-libc-migration.yml
-      - .github/workflows/pr-build.yml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

The `libc/0.16.x` branch protection rule requires the `check-migration-claims` status:

```
requiredStatusCheckContexts: ["ci-required", "check-migration-claims"]
```

But the workflow that produces that check (`.github/workflows/lint-libc-migration.yml`) has a `paths:` filter on its `pull_request` trigger restricting it to changes in `src/libs/musl.zig`, `lib/c/**`, `test/libc.zig`, `test/src/Libc.zig`, and a couple of scripts/workflows.

When a PR only touches files outside that list (for example `lib/std/math/expm1.zig` in #591), GitHub skips the workflow entirely and never reports a status for `check-migration-claims`. Branch protection then blocks the merge indefinitely with `mergeStateStatus: BLOCKED`, even though every other required check is green. `workflow_dispatch` runs do not attach status to PR head SHAs and cannot unblock such PRs.

This will hit every upcoming #526 PR that only touches `lib/std/math/**` (sinh, coshf, acosh, atanh, …).

## Fix

Drop the `paths:` filter from the `pull_request` trigger so `check-migration-claims` always reports a status. The job runs in ~15-20s and is harmless on PRs without migration claim changes — the script just walks `src/libs/musl.zig` and verifies the "migrated to" annotations are consistent.

The `push` trigger keeps its `paths:` filter, since branch pushes can land via merge after the PR check has already gated.

## Notes

Part of #526 work. Unblocks #591 (`math: fix spurious OVERFLOW in expm1 family`) and future PRs in the series that only touch the standard library.