### PR TITLE
math: raise FE_INVALID from lrint/llrint on nan/inf/oob (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -3122,11 +3122,18 @@ fn scalb(x: f64, fn_: f64) callconv(.c) f64 {
 }
 
 fn intFromFloat(comptime I: type, x: anytype) I {
+    @setFloatMode(.strict);
     const F = @TypeOf(x);
-    if (math.isNan(x) or !math.isFinite(x)) return math.minInt(I);
+    if (math.isNan(x) or !math.isFinite(x)) {
+        math.raiseInvalid();
+        return math.minInt(I);
+    }
     const upper: F = @floatFromInt(@as(comptime_int, math.maxInt(I)) + 1);
     const lower: F = @floatFromInt(math.minInt(I));
-    if (x >= upper or x < lower) return math.minInt(I);
+    if (x >= upper or x < lower) {
+        math.raiseInvalid();
+        return math.minInt(I);
+    }
     return @intFromFloat(x);
 }
 


### PR DESCRIPTION
## Bug

The shared `intFromFloat` helper in `lib/c/math.zig` short-circuits with an early return of `math.minInt(I)` whenever the input is NaN, infinite, or outside the integer range. Both branches returned silently without raising any FE flag, so libc-test reports:

```
lrint(nan)=0,   want INVALID got 0
lrint(inf)=0,   want INVALID got 0
lrint(-inf)=0,  want INVALID got 0
```

The finite-out-of-range cases (`0x1p+100`, `-0x1p+100`) happened to pass already because LLVM lowered the comptime-bounded select into an unconditional `fcvtzs` whose hardware path traps INVALID; the NaN/inf cases are caught by the `isNan` / `!isFinite` check earlier and skip `fcvtzs` entirely.

## Fix

Add `math.raiseInvalid()` (volatile `0.0 / 0.0`) to both early-return branches in `intFromFloat`. `raiseInvalid` reliably raises INVALID even when the input itself is a qNaN — the obvious `(x - x) / (x - x)` idiom does **not**, because qNaN − qNaN propagates as qNaN with no flag.

This touches only the shared helper, which is consumed by `lrint` (f64) and `llrint` (f64). `lrintf`/`lrintl`/`llrintf`/`llrintl` use `@intFromFloat(rintGeneric(...))` directly and already work via the `fcvtzs` hardware path.

## Verification

```
zig build test-libc -Dlibc-test-path=… -Dtest-target-filter=aarch64-linux-musl -Dtest-filter=math.lrint
```

All 12 combinations (`lrint`, `lrintf`, `lrintl` × Debug / ReleaseSafe / ReleaseFast / ReleaseSmall) pass. The broader `math.` slice on aarch64-linux-musl drops from 9 → 8 distinct failing tests (#526 progression).