### PR TITLE
math: fix acosf FE_INVALID and acosh accuracy near 1 (#526)

### DIFF
--- a/lib/c/math.zig
+++ b/lib/c/math.zig
@@ -1241,17 +1241,29 @@ comptime {
 }
 
 fn acos(x: f64) callconv(.c) f64 {
-    if (@abs(x) > 1.0) return (x - x) / (x - x); // raise FE_INVALID
-    return math.acos(x);
+    return acosWithFlags(f64, x);
 }
 
 fn acosf(x: f32) callconv(.c) f32 {
-    if (@abs(x) > 1.0) return (x - x) / (x - x); // raise FE_INVALID
-    return math.acos(x);
+    return acosWithFlags(f32, x);
 }
 
 fn acoshf(x: f32) callconv(.c) f32 {
     return math.acosh(x);
+}
+
+/// libc semantics for acos: |x| > 1 raises FE_INVALID and returns NaN.
+/// Using `(x-x)/(x-x)` in a branch is risky because LLVM can speculate the
+/// 0/0 across the comparison via `select`, raising INVALID even for |x|<=1.
+/// Use the explicit `math.raiseInvalid()` helper which uses volatile loads.
+fn acosWithFlags(comptime T: type, x: T) T {
+    @setFloatMode(.strict);
+    if (math.isNan(x)) return x;
+    if (@abs(x) > 1.0) {
+        math.raiseInvalid();
+        return math.nan(T);
+    }
+    return math.acos(x);
 }
 
 fn asin(x: f64) callconv(.c) f64 {
@@ -2073,14 +2085,34 @@ fn rintl(x: c_longdouble) callconv(.c) c_longdouble {
 }
 
 fn acosh_(x: f64) callconv(.c) f64 {
-    return math.acosh(x);
+    return acoshWithBetterArg(x);
 }
 
 fn acoshl_(x: c_longdouble) callconv(.c) c_longdouble {
     return switch (@typeInfo(c_longdouble).float.bits) {
-        64 => math.acosh(@as(f64, @bitCast(x))),
-        else => @floatCast(math.acosh(@as(f64, @floatCast(x)))),
+        64 => acoshWithBetterArg(@as(f64, @bitCast(x))),
+        else => @floatCast(acoshWithBetterArg(@as(f64, @floatCast(x)))),
     };
+}
+
+/// acosh(x) for f64. For 1 <= x < 2 the standard formula
+/// `log1p(h + sqrt(h*h + 2*h))` has up to ~2 ULP error because the addition
+/// `h + sqrt(...)` rounds, and log1p amplifies that rounding error. Recover the
+/// dropped low bits with a Dekker 2-sum and apply the first-order correction
+/// `arg_lo / (1 + arg_hi)` to log1p, bringing the result within ~1 ULP.
+fn acoshWithBetterArg(x: f64) f64 {
+    @setFloatMode(.strict);
+    const u: u64 = @bitCast(x);
+    const e: u11 = @intCast((u >> 52) & 0x7FF);
+    if (e < 0x3FF + 1) {
+        const h = x - 1;
+        const s = @sqrt(h * h + 2 * h);
+        const arg_hi = h + s;
+        const bb = arg_hi - h;
+        const arg_lo = (h - (arg_hi - bb)) + (s - bb);
+        return math.log1p(arg_hi) + arg_lo / (1.0 + arg_hi);
+    }
+    return math.acosh(x);
 }
 
 fn asinhf_(x: f32) callconv(.c) f32 {


### PR DESCRIPTION
Refs #526.

## acosf — FE_INVALID at |x| = 1

The previous wrapper used `(x - x) / (x - x)` inside an `if (@abs(x) > 1.0)` branch to raise `FE_INVALID`. LLVM lowered the branch as a `select`, computing the 0/0 unconditionally — even for `|x| <= 1`. The 7 failing libc-test cases were all at `x = ±1.0` where `acosf` should return `0` or `π` with no `INVALID` flag.

Replace with an explicit `acosWithFlags(T, x)` helper that uses `math.raiseInvalid()` (volatile-load 0/0) under `@setFloatMode(.strict)`. Wired acos/acosf through it.

## acosh — ~1.7-1.9 ULP error for 1 <= x < 2

`std.math.acosh` for `1 <= x < 2` evaluates `log1p(h + sqrt(h*h + 2*h))` where `h = x - 1`. The `h + sqrt(...)` addition rounds to nearest, and that rounding error feeds through `log1p`, accumulating to ~1.7-1.9 ULP final error on 13 inputs in `special/acosh.h`. `libc-test`'s round-to-nearest tolerance is 1.5 ULP, so all 13 fail.

Add a Dekker 2-sum to recover the dropped low bits, then apply the first-order correction `arg_lo / (1 + arg_hi)` to `log1p`:

```zig
const h = x - 1;
const s = @sqrt(h * h + 2 * h);
const arg_hi = h + s;
const bb = arg_hi - h;
const arg_lo = (h - (arg_hi - bb)) + (s - bb);
return math.log1p(arg_hi) + arg_lo / (1.0 + arg_hi);
```

Final error drops to ~0.9 ULP — under tolerance. Confirmed against all 13 hard cases.

## Slice

`math` slice on aarch64-linux-musl: 5 → 3 failures (coshf, sinh, sinhf remain).