### PR TITLE
std.math: fix cosh32 raising spurious OVERFLOW for tiny x (#526)

### DIFF
--- a/lib/std/math/cosh.zig
+++ b/lib/std/math/cosh.zig
@@ -36,7 +36,9 @@ fn cosh32(x: f32) f32 {
     // |x| < log(2)
     if (ux < 0x3F317217) {
         if (ux < 0x3F800000 - (12 << 23)) {
-            math.raiseOverflow();
+            if (x != 0) {
+                math.raiseInexact();
+            }
             return 1.0;
         }
         const t = math.expm1(ax);


### PR DESCRIPTION
cosh32's tiny-x early-return called `math.raiseOverflow()` unconditionally. Two bugs:

1. Wrong flag — should be **INEXACT**, not OVERFLOW. `cosh(tiny x) = 1 + x²/2 + …` rounds to exactly 1.0; inexact, not overflowing.
2. `cosh(±0) = 1` is **exact** — no flag should be raised at all.

`cosh64` already has the correct logic. Mirror it.

## Test impact

Fixes 107 libc-test `math/coshf.c` failures on aarch64-linux-musl, all of the form:
```
want INEXACT got INEXACT|OVERFLOW   (98 cases)
want 0       got INEXACT|OVERFLOW   (9 cases, cosh(±0))
```

Brings the failing libc-test math-slice from **1 → 0** on aarch64-linux-musl. This was the last remaining failure tracked in #526.

## Verification (aarch64-linux-musl)

All 4 rounding modes for `math.coshf` now exit 0 with empty output. `math.cosh` and `math.coshl` remain unaffected.