### PR TITLE
ci: promote libc-test math slice to required on libc/0.16.x (#526)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,8 +9,7 @@ name: pr-build
 #   - pr-build: ast-check + migration claims + Build stage4.
 #   - pr-libc-test: runs libc-test on the stage4 produced by pr-build.
 #     The native functional/regression slices are temporarily skipped because
-#     they hang on libc/0.16.x; math is temporarily advisory; api remains
-#     required.
+#     they hang on libc/0.16.x; math and api are required.
 #   - pr-cross-compile: cross-compiles a tiny hello.c against libzigc + musl
 #     libc.a for every target in the post-merge QEMU matrix. Catches
 #     arch-specific libzigc compile errors (missing syscall fields,
@@ -409,7 +408,6 @@ jobs:
 
       - name: Run libc-test — math (aarch64-linux-musl, native)
         timeout-minutes: 30
-        continue-on-error: true
         run: |
           set -euo pipefail
           if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi


### PR DESCRIPTION
Closes #526.

The native `math` libc-test slice now passes cleanly on aarch64-linux-musl after the series of fixes tracked in #526. This PR drops `continue-on-error: true` from the `Run libc-test — math` step in `pr-build.yml` so math regressions block PR merges going forward, matching the `api` slice.

## Fix series

| # | PR | Slice | Notes |
|---|---|---|---|
| 1 | #585 | 29→28 | fmaxmag/fminmag NaN propagation |
| 2 | #587 | 28→24 | nearbyint/rint fenv helpers |
| 3 | #588 | 24→16 | scalbn/ldexp family |
| 4 | #589 | 16→15 | log1p/expm1f branchless-select trap |
| 5 | #590 | 15→13 | nextafter FE flags |
| 6 | #591 | 13→11 | nearbyintf INEXACT suppression |
| 7 | #593 | 11→9 | aarch64 fenv groundwork |
| 8 | #594 | 9→8 | scalbn directed rounding |
| 9 | #595 | 8→7 | nearbyint INEXACT mask |
| 10 | #596 | 7→5 | atanh INVALID / DIVBYZERO |
| 11 | #597 | 5→3 | acos INVALID + acosh accuracy |
| 12 | #598 | 3→1 | sinh/sinhf OVERFLOW + UNDERFLOW |
| 13 | #599 | 1→0 | cosh32 spurious OVERFLOW |

## Verification

PR #599's pr-libc-test run had the math step green: https://github.com/ctaggart/zig/actions/runs/26592875261/job/78363158331

This PR's own CI run will be the first one where the math step is required end-to-end.