### PR TITLE
ci: promote functional+regression libc-test subsets to required (closes #529)

### DIFF
--- a/.github/libc-test-subsets/functional.txt
+++ b/.github/libc-test-subsets/functional.txt
@@ -1,0 +1,47 @@
+# Curated subset of functional libc-test sources used by pr-build.yml and
+# post-merge-libc.yml on libc/0.16.x. Each non-blank, non-comment line is a
+# substring filter passed as -Dtest-filter=<line> (see test/src/Libc.zig).
+#
+# Categories intentionally excluded while libzigc migration is in flight:
+#   - pthread_*    (mutex/cond/cancel/rwlock/tsd/robust still in flux)
+#   - sem_*        (POSIX semaphores depend on pthread internals)
+#   - ipc_*        (SysV msg/sem/shm need kernel + cleanup)
+#   - dlopen*      (dynamic linking not exercised by static link)
+#   - tls_*        (TLS migration tracked in #491)
+#   - spawn, popen, vfork (fork/exec/vfork)
+#   - iconv*       (iconv_open not exported from libzigc; tracked in #532)
+functional.argv
+functional.basename
+functional.clocale_mbfuncs
+functional.clock_gettime
+functional.crypt
+functional.dirent
+functional.dirname
+functional.env
+functional.fcntl
+functional.fdopen
+functional.fnmatch
+functional.fscanf
+functional.fwscanf
+functional.inet_pton
+functional.mbc
+functional.memstream
+functional.mntent
+functional.qsort
+functional.random
+functional.search
+functional.scanf
+functional.setjmp
+functional.snprintf
+functional.socket
+functional.sscanf
+functional.stat
+functional.str
+functional.swprintf
+functional.tgmath
+functional.time
+functional.udiv
+functional.ungetc
+functional.utime
+functional.wcsstr
+functional.wcstol

--- a/.github/libc-test-subsets/regression.txt
+++ b/.github/libc-test-subsets/regression.txt
@@ -1,0 +1,42 @@
+# Curated subset of regression libc-test sources used by pr-build.yml and
+# post-merge-libc.yml on libc/0.16.x. Each non-blank, non-comment line is a
+# substring filter passed as -Dtest-filter=<line> (see test/src/Libc.zig).
+#
+# Mirrors the functional-subset exclusion list (pthread/sem/tls/raise-race/
+# iconv/spawn/popen/vfork).
+regression.daemon-failure
+regression.dn_expand-
+regression.execle-env
+regression.fflush-exit
+regression.fgets-eof
+regression.fgetwc-buffering
+regression.flockfile-list
+regression.fpclassify-invalid-ld80
+regression.ftello-unflushed-append
+regression.getpwnam_r-
+regression.inet_
+regression.iswspace-null
+regression.lrand48-signextend
+regression.lseek-large
+regression.malloc-
+regression.mbsrtowcs-overflow
+regression.memmem-
+regression.mkdtemp-failure
+regression.mkstemp-failure
+regression.printf-
+regression.putenv-doublefree
+regression.rewind-clear-error
+regression.rlimit-open-files
+regression.scanf-
+regression.setenv-oom
+regression.setvbuf-unget
+regression.sigaltstack
+regression.sigprocmask-internal
+regression.sigreturn
+regression.sscanf-eof
+regression.statvfs
+regression.strverscmp
+regression.syscall-sign-extend
+regression.uselocale-0
+regression.wcsncpy-read-overflow
+regression.wcsstr-false-negative

--- a/.github/workflows/post-merge-libc.yml
+++ b/.github/workflows/post-merge-libc.yml
@@ -31,16 +31,35 @@ jobs:
     uses: ./.github/workflows/test-libc.yml
     with:
       branch: ${{ github.sha }}
-      # The full libc-test suite currently has known-hanging functional and
-      # regression slices on libc/0.16.x. Keep post-merge validation bounded
-      # by running the API slice across the target matrix; broken targets stay
-      # advisory in test-libc.yml until fixed.
+      # api runs on the full target matrix (aarch64 + qemu fan-out).
       test-filter: api
       targets: all
 
+  test-functional-aarch64:
+    name: post-merge test-libc functional subset on libc/0.16.x HEAD
+    uses: ./.github/workflows/test-libc.yml
+    with:
+      branch: ${{ github.sha }}
+      # Curated functional subset from .github/libc-test-subsets/functional.txt.
+      # Triaged green on native aarch64 only (see #529); other targets are
+      # not validated under qemu yet.
+      test-filters-file: .github/libc-test-subsets/functional.txt
+      targets: aarch64
+
+  test-regression-aarch64:
+    name: post-merge test-libc regression subset on libc/0.16.x HEAD
+    uses: ./.github/workflows/test-libc.yml
+    with:
+      branch: ${{ github.sha }}
+      # Curated regression subset from .github/libc-test-subsets/regression.txt.
+      # Triaged green on native aarch64 only (see #529); other targets are
+      # not validated under qemu yet.
+      test-filters-file: .github/libc-test-subsets/regression.txt
+      targets: aarch64
+
   on-failure:
     name: notify on test failure
-    needs: test-api
+    needs: [test-api, test-functional-aarch64, test-regression-aarch64]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +73,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEAD_SHA: ${{ github.sha }}
+          API_RESULT: ${{ needs.test-api.result }}
+          FUNC_RESULT: ${{ needs.test-functional-aarch64.result }}
+          REG_RESULT: ${{ needs.test-regression-aarch64.result }}
         run: |
           set -euo pipefail
           short_sha="${HEAD_SHA:0:12}"
@@ -61,10 +83,17 @@ jobs:
           author="$(git log -1 --pretty=%an "$HEAD_SHA")"
           merge_pr="$(printf '%s' "$subject" | sed -nE 's/.*\(#([0-9]+)\)$/\1/p')"
 
-          title="post-merge test-libc API failure on libc/0.16.x @ ${short_sha}"
-          body=$(cat <<EOF
-          The post-merge \`test-libc\` API matrix failed against \`libc/0.16.x\` after a merge.
+          failed_slices=()
+          [ "$API_RESULT"  = "failure" ] && failed_slices+=("api")
+          [ "$FUNC_RESULT" = "failure" ] && failed_slices+=("functional (aarch64)")
+          [ "$REG_RESULT"  = "failure" ] && failed_slices+=("regression (aarch64)")
+          slices_csv="$(IFS=, ; echo "${failed_slices[*]}")"
 
+          title="post-merge test-libc failure (${slices_csv:-unknown}) on libc/0.16.x @ ${short_sha}"
+          body=$(cat <<EOF
+          The post-merge \`test-libc\` run failed against \`libc/0.16.x\` after a merge.
+
+          - Failed slices: \`${slices_csv:-unknown}\`
           - Commit: [\`${short_sha}\`](${{ github.server_url }}/${{ github.repository }}/commit/${HEAD_SHA})
           - Subject: \`${subject}\`
           - Author: ${author}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,8 +8,10 @@ name: pr-build
 # Jobs:
 #   - pr-build: ast-check + migration claims + Build stage4.
 #   - pr-libc-test: runs libc-test on the stage4 produced by pr-build.
-#     The native functional/regression slices are temporarily skipped because
-#     they hang on libc/0.16.x; math and api are required.
+#     api, math and the curated functional/regression subsets
+#     (.github/libc-test-subsets/) are all required. Tests outside those
+#     subsets (pthread/sem/tls/raise-race/iconv/spawn/popen/vfork) are still
+#     excluded while the underlying libzigc migrations are in flight.
 #   - pr-cross-compile: cross-compiles a tiny hello.c against libzigc + musl
 #     libc.a for every target in the post-merge QEMU matrix. Catches
 #     arch-specific libzigc compile errors (missing syscall fields,
@@ -329,60 +331,18 @@ jobs:
 
       - name: Run libc-test — functional subset (aarch64-linux-musl, native)
         timeout-minutes: 30
-        continue-on-error: true
         run: |
           set -euo pipefail
           if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
           if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
           ulimit -c 0 2>/dev/null || true
-          # Curated subset of functional libc-test sources to avoid known-hanging
-          # areas while libzigc migration is in flight. Excluded by category:
-          #   - pthread_*    (mutex/cond/cancel/rwlock/tsd/robust still in flux)
-          #   - sem_*        (POSIX semaphores depend on pthread internals)
-          #   - ipc_*        (SysV msg/sem/shm need kernel + cleanup)
-          #   - dlopen*      (dynamic linking not exercised by static link)
-          #   - tls_*        (TLS migration tracked in #491)
-          #   - spawn, popen, vfork (fork/exec/vfork)
-          # Each filter is a substring match (see test/src/Libc.zig).
-          filters=(
-            functional.argv
-            functional.basename
-            functional.clocale_mbfuncs
-            functional.clock_gettime
-            functional.crypt
-            functional.dirent
-            functional.dirname
-            functional.env
-            functional.fcntl
-            functional.fdopen
-            functional.fnmatch
-            functional.fscanf
-            functional.fwscanf
-            functional.inet_pton
-            functional.mbc
-            functional.memstream
-            functional.mntent
-            functional.qsort
-            functional.random
-            functional.search
-            functional.scanf
-            functional.setjmp
-            functional.snprintf
-            functional.socket
-            functional.sscanf
-            functional.stat
-            functional.str
-            functional.swprintf
-            functional.tgmath
-            functional.time
-            functional.udiv
-            functional.ungetc
-            functional.utime
-            functional.wcsstr
-            functional.wcstol
-          )
+          # Curated subset filters live in .github/libc-test-subsets/functional.txt
+          # so pr-build and post-merge-libc share one source of truth.
           args=()
-          for f in "${filters[@]}"; do args+=("-Dtest-filter=$f"); done
+          while IFS= read -r f; do
+            case "$f" in ''|\#*) continue;; esac
+            args+=("-Dtest-filter=$f")
+          done < .github/libc-test-subsets/functional.txt
           "$STAGE4/bin/zig" build test-libc \
               --zig-lib-dir lib \
               -Dlibc-test-path="$CACHE_ROOT/libc-test" \
@@ -423,55 +383,18 @@ jobs:
 
       - name: Run libc-test — regression subset (aarch64-linux-musl, native)
         timeout-minutes: 30
-        continue-on-error: true
         run: |
           set -euo pipefail
           if [ "$(ulimit -u)" -lt 32768 ]; then ulimit -u 32768 2>/dev/null || true; fi
           if [ "$(ulimit -n)" -lt 32768 ]; then ulimit -n 32768 2>/dev/null || true; fi
           ulimit -c 0 2>/dev/null || true
-          # Curated subset of regression libc-test sources mirroring the
-          # functional-subset exclusion list (pthread/sem/tls/raise-race).
-          # Each filter is a substring match (see test/src/Libc.zig).
-          filters=(
-            regression.daemon-failure
-            regression.dn_expand-
-            regression.execle-env
-            regression.fflush-exit
-            regression.fgets-eof
-            regression.fgetwc-buffering
-            regression.flockfile-list
-            regression.fpclassify-invalid-ld80
-            regression.ftello-unflushed-append
-            regression.getpwnam_r-
-            regression.inet_
-            regression.iswspace-null
-            regression.lrand48-signextend
-            regression.lseek-large
-            regression.malloc-
-            regression.mbsrtowcs-overflow
-            regression.memmem-
-            regression.mkdtemp-failure
-            regression.mkstemp-failure
-            regression.printf-
-            regression.putenv-doublefree
-            regression.rewind-clear-error
-            regression.rlimit-open-files
-            regression.scanf-
-            regression.setenv-oom
-            regression.setvbuf-unget
-            regression.sigaltstack
-            regression.sigprocmask-internal
-            regression.sigreturn
-            regression.sscanf-eof
-            regression.statvfs
-            regression.strverscmp
-            regression.syscall-sign-extend
-            regression.uselocale-0
-            regression.wcsncpy-read-overflow
-            regression.wcsstr-false-negative
-          )
+          # Curated subset filters live in .github/libc-test-subsets/regression.txt
+          # so pr-build and post-merge-libc share one source of truth.
           args=()
-          for f in "${filters[@]}"; do args+=("-Dtest-filter=$f"); done
+          while IFS= read -r f; do
+            case "$f" in ''|\#*) continue;; esac
+            args+=("-Dtest-filter=$f")
+          done < .github/libc-test-subsets/regression.txt
           "$STAGE4/bin/zig" build test-libc \
               --zig-lib-dir lib \
               -Dlibc-test-path="$CACHE_ROOT/libc-test" \

--- a/.github/workflows/test-libc.yml
+++ b/.github/workflows/test-libc.yml
@@ -27,6 +27,15 @@ on:
         required: false
         default: ''
         type: string
+      test-filters-file:
+        description: |
+          Path (relative to the repo root) of a newline-delimited file of
+          substring filters. When set, each non-blank, non-comment line is
+          passed as its own -Dtest-filter=<line>; the scalar test-filter
+          input is ignored.
+        required: false
+        default: ''
+        type: string
       targets:
         description: 'Target groups to test (comma-separated, or "all")'
         required: false
@@ -115,7 +124,7 @@ jobs:
     needs: build-stage4
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    continue-on-error: ${{ matrix.allow_failure && inputs.test-filter != 'api' }}
+    continue-on-error: ${{ matrix.allow_failure && inputs.test-filter != 'api' && inputs.test-filters-file == '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -221,7 +230,10 @@ jobs:
 
           # Use -j1 for thread/pthread tests to avoid runner thread exhaustion
           FILTER="${{ inputs.test-filter }}"
-          if echo "$FILTER" | grep -qi "thread"; then
+          FILTERS_FILE="${{ inputs.test-filters-file }}"
+          if [ -n "$FILTERS_FILE" ] && echo "$FILTERS_FILE" | grep -qi "thread"; then
+            JOBS=1
+          elif echo "$FILTER" | grep -qi "thread"; then
             JOBS=1
           else
             JOBS=2
@@ -229,10 +241,22 @@ jobs:
 
           ARGS=(
             -Dlibc-test-path="$HOME/libc-test"
-            -Dtest-filter="$FILTER"
             -j$JOBS
             --summary all
           )
+
+          if [ -n "$FILTERS_FILE" ]; then
+            if [ ! -f "$FILTERS_FILE" ]; then
+              echo "ERROR: test-filters-file not found: $FILTERS_FILE" >&2
+              exit 1
+            fi
+            while IFS= read -r line; do
+              case "$line" in ''|\#*) continue;; esac
+              ARGS+=(-Dtest-filter="$line")
+            done < "$FILTERS_FILE"
+          else
+            ARGS+=(-Dtest-filter="$FILTER")
+          fi
 
           # Apply target filter
           TARGET_FILTER="${{ matrix.target-filter }}"


### PR DESCRIPTION
Closes #529.

## Summary

Triage in #529 is complete — every cluster called out in the issue body has either landed a fix or been removed from the curated subset via #532. Verified on \`libc/0.16.x\` HEAD (37607621e7) — both curated subsets exit 0 across all 4 optimize modes on native \`aarch64-linux-musl\`.

This PR flips the curated functional+regression subsets from advisory to required and adds them to post-merge (aarch64-only for the first wave).

## Changes

- **Extract filter lists** into \`.github/libc-test-subsets/{functional,regression}.txt\` so \`pr-build\` and \`post-merge-libc\` share one source of truth. Lists are byte-identical to the previous inline arrays (35 functional + 36 regression entries, same order).
- **\`pr-build.yml\`**: drop \`continue-on-error: true\` from both subset steps — they now block PR merge. Subset steps read filters from the shared files. Refresh header comment.
- **\`test-libc.yml\`**: add a \`test-filters-file\` workflow input. When set, each non-blank non-comment line is appended as its own \`-Dtest-filter=<line>\`; the scalar \`test-filter\` input is ignored. \`continue-on-error\` matrix gate is extended so multi-filter calls (like \`api\`) never go advisory.
- **\`post-merge-libc.yml\`**: add two new jobs \`test-functional-aarch64\` and \`test-regression-aarch64\` that invoke \`test-libc.yml\` with the curated subsets, restricted to \`aarch64\`. The other targets in the matrix were not triaged under qemu — that's left for a follow-up. \`on-failure\` now needs all three jobs and labels the failure issue with which slice(s) regressed.

## Out of scope

- iconv (\`functional.iconv_open\`, \`regression.iconv-roundtrips\`) — removed from the curated subset by #532; tracked separately.
- TLS — tracked in #491.
- Cross-arch fan-out of functional/regression under qemu — follow-up after one clean post-merge cycle.

## Verification

Ran each subset against \`libc/0.16.x\` HEAD using the cached aarch64 stage4 — both \`EXIT=0\`:

\`\`\`
loaded 35 functional filters
... FUNC_EXIT=0
loaded 36 regression filters
... REG_EXIT=0
\`\`\`