### PR TITLE
network: fix inet_ntoa returning 0.0.0.0 on big-endian (aarch64_be)

### DIFF
--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -1217,16 +1217,31 @@ fn inet_ntoa_impl(in: in_addr_t) callconv(.c) [*]u8 {
     // The C declaration `inet_ntoa(struct in_addr)` and `inet_ntoa(uint32_t)`
     // both pass the value in the low 32 bits of x0, so the C ABI is
     // unchanged.
+    // Match musl's byte-wise access through `(unsigned char *)&in`.
+    // Shifting the integer value reverses the address on big-endian targets.
+    const bytes: [4]u8 = @bitCast(in);
     var len: usize = 0;
-    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in)));
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, bytes[0]);
     inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
-    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 8)));
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, bytes[1]);
     inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
-    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 16)));
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, bytes[2]);
     inetNtopWriteByte(&inet_ntoa_buf, &len, '.');
-    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, @as(u8, @truncate(in >> 24)));
+    inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, bytes[3]);
     inet_ntoa_buf[len] = 0;
     return &inet_ntoa_buf;
+}
+
+fn expectInetNtoa(bytes: [4]u8, expected: []const u8) !void {
+    const in: in_addr_t = @bitCast(bytes);
+    try std.testing.expectEqualStrings(expected, std.mem.sliceTo(inet_ntoa_impl(in), 0));
+}
+
+test "inet_ntoa_impl formats network-order bytes" {
+    try expectInetNtoa(.{ 0, 0, 0, 0 }, "0.0.0.0");
+    try expectInetNtoa(.{ 0x7f, 0x00, 0x00, 0x01 }, "127.0.0.1");
+    try expectInetNtoa(.{ 0x0a, 0x00, 0x80, 0x1f }, "10.0.128.31");
+    try expectInetNtoa(.{ 0xff, 0xff, 0xff, 0xff }, "255.255.255.255");
 }
 
 fn inetNtopWriteByte(dst: [*]u8, pos: *usize, byte: u8) void {


### PR DESCRIPTION
Fixes #613, #618, #619, #620 (inet_pton part), and the inet_pton part of #622.

Root cause: `inet_ntoa_impl` formatted IPv4 octets by shifting/truncating the native `in_addr_t` integer. musl formats the memory-order bytes of `struct in_addr` via `(unsigned char *)&in`, which are the network-order bytes. On big-endian targets such as `aarch64_be`, shifting the integer extracts bytes in the opposite order from musl's memory-order access, causing the recurring `functional.inet_pton` failures.

Change:
- Use `@bitCast` to view the `in_addr_t` argument as `[4]u8` and format `bytes[0..4]` directly.
- Add a Zig unit test covering `0.0.0.0`, `127.0.0.1`, `10.0.128.31`, and `255.255.255.255`.
- Audited the neighboring legacy inet functions; `inet_addr`/`inet_network` already use byte-oriented parsing or endian conversion, and `inet_makeaddr`/`inet_lnaof`/`inet_netof` intentionally match musl's existing `inet_legacy.c` shift logic.

Validation:
- `/home/g/.local/bin/zig fmt --check lib/c/network.zig`
- `/home/g/.local/bin/zig test --zig-lib-dir lib lib/c.zig`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target aarch64_be-linux-musl -lc -fno-emit-bin`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target x86_64-linux-musl -lc -fno-emit-bin`

Note: the host Zig unit test is endian-native; it will catch the original byte-shift bug when run on a big-endian target. This PR also verifies the changed code compiles for `aarch64_be-linux-musl`, but does not add a new QEMU runtime CI entry.