### PR TITLE
libzigc-wasi: add __lock/__unlock stubs for stdio on WASI (fixes #622)

### DIFF
--- a/lib/c/wasi_thread_stub.zig
+++ b/lib/c/wasi_thread_stub.zig
@@ -619,6 +619,14 @@ fn thrd_sleep(req: ?*const anyopaque, rem: ?*anyopaque) callconv(.c) c_int {
     return -2;
 }
 
+fn __lock(l: *volatile c_int) callconv(.c) void {
+    _ = l;
+}
+
+fn __unlock(l: *volatile c_int) callconv(.c) void {
+    _ = l;
+}
+
 // --- Symbol exports ---
 
 comptime {
@@ -690,6 +698,8 @@ comptime {
     symbol(&pthread_tsd_run_dtors, "__pthread_tsd_run_dtors");
     symbol(&tlsNoop, "__tl_lock");
     symbol(&tlsNoop, "__tl_unlock");
+    symbol(&__lock, "__lock");
+    symbol(&__unlock, "__unlock");
     symbol(&pthread_getattr_np, "pthread_getattr_np");
     symbol(&pthread_tryjoin_np, "__pthread_tryjoin_np");
     symbol(&pthread_timedjoin_np, "__pthread_timedjoin_np");


### PR DESCRIPTION
## Summary
- Fixes #622: PR #621 switched WASI stdio to the Zig implementation, which references musl stdio lock hooks.
- Add WASI no-op exports for `__lock` and `__unlock` so `api.main.wasm` no longer imports missing `env` symbols.
- Checked `lib/c/stdio.zig` `@extern` references; the other referenced symbols already have WASI-visible exports/providers.

## Validation
- `/home/g/.local/bin/zig fmt --check lib/c/wasi_thread_stub.zig`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target wasm32-wasi-musl -lc -fno-emit-bin`
- Built `lib/c.zig` to a wasm object and parsed imports: no `env::__lock` or `env::__unlock`.

## Notes
- Local wasmtime/wasm-objdump/wasm-tools were not installed, so runtime instantiation was not run locally.