### PR TITLE
network: work around inet_ntoa aarch64_be ABI (fixes #625)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -424,6 +424,10 @@ jobs:
             allow_failure: false
           - target: x86_64-linux-musl
             allow_failure: false
+          - target: aarch64-linux-musl
+            allow_failure: false
+          - target: aarch64_be-linux-musl
+            allow_failure: false
           - target: arm-linux-musleabi
             allow_failure: false
           - target: arm-linux-musleabihf

--- a/lib/c/network.zig
+++ b/lib/c/network.zig
@@ -1203,23 +1203,28 @@ fn inet_netof_impl(in: in_addr) callconv(.c) in_addr_t {
 var inet_ntoa_buf: [16]u8 = undefined;
 
 fn inet_ntoa_impl(in: in_addr_t) callconv(.c) [*]u8 {
+    const word: u32 = if (comptime builtin.cpu.arch == .aarch64_be) blk: {
+        const x0: u64 = asm volatile (""
+            : [ret] "={x0}" (-> u64),
+        );
+        break :blk @truncate(x0 >> 32);
+    } else in;
+
     // The previous version went through `snprintf("%d.%d.%d.%d", a[0],
     // a[1], a[2], a[3])`, but Zig does not apply C's default-argument
     // promotion to variadic args: each `u8` was passed in its natural
     // 1-byte width while libc's `snprintf` read 4 bytes per `%d`,
     // producing `0.0.0.0` for every nonzero address on aarch64.
     //
-    // Take the address as a plain `in_addr_t` (u32) rather than the
-    // `in_addr` extern struct wrapper. A struct{u32} value parameter
-    // is supposed to match the u32 ABI on aarch64, but the optimiser
-    // wasn't preserving the argument bits through the struct param
-    // (it folded `inet_ntoa_impl` to a constant `0.0.0.0` store).
-    // The C declaration `inet_ntoa(struct in_addr)` and `inet_ntoa(uint32_t)`
-    // both pass the value in the low 32 bits of x0, so the C ABI is
-    // unchanged.
-    // Match musl's byte-wise access through `(unsigned char *)&in`.
-    // Shifting the integer value reverses the address on big-endian targets.
-    const bytes: [4]u8 = @bitCast(in);
+    // C callers pass `struct in_addr` by value. AAPCS64 places small
+    // aggregates in one 64-bit register: on little-endian aarch64 the struct's
+    // bytes occupy the low 32 bits of x0, while on big-endian aarch64 they
+    // occupy the high 32 bits. Keep the Zig parameter as `in_addr_t` so the
+    // aarch64 little-endian path works around Zig 0.16.0's incorrect
+    // struct-by-value ABI for `extern struct { u32 }`; for aarch64_be, the asm
+    // above must be the first operation in this function so it can recover the
+    // original high half of x0 before anything can clobber it.
+    const bytes: [4]u8 = @bitCast(word);
     var len: usize = 0;
     inetNtopWriteUnsigned(&inet_ntoa_buf, &len, 10, bytes[0]);
     inetNtopWriteByte(&inet_ntoa_buf, &len, '.');


### PR DESCRIPTION
Fixes #625.

Root cause: `inet_ntoa` has the C prototype `inet_ntoa(struct in_addr)`. PR #623 kept the Zig implementation parameter as `in_addr_t`/`u32`, which works on aarch64 little-endian because AAPCS64 places the 4-byte struct bytes in the low 32 bits of `x0`. On AAPCS64 big-endian, the same 4-byte struct occupies the high 32 bits of `x0`; a Zig `u32` parameter reads the low 32 bits instead, so the implementation saw zero and rendered every address as `0.0.0.0`.

Why not switch back to `in_addr`? PR #626 tried that, but pr-libc-test showed it regressed aarch64 little-endian as well. That confirms Zig 0.16.0's ABI lowering for `extern struct { u32 }` by-value parameters on aarch64 does not currently match AAPCS64. Therefore this PR keeps the `u32` parameter for the LE workaround, and on `aarch64_be` performs a first-operation inline-asm read of `x0` to recover the high 32 bits used by the actual C struct argument.

Change:
- Keep `inet_ntoa_impl(in: in_addr_t)` for aarch64 LE compatibility.
- On `aarch64_be`, recover `x0 >> 32` via inline asm before any other function work.
- Format `@bitCast(word)` bytes in memory/network order.
- Restore the host unit-test helper to pass `in_addr_t`.
- Keep `aarch64-linux-musl` and `aarch64_be-linux-musl` in the pre-merge `pr-cross-compile` matrix.

Validation:
- `/home/g/.local/bin/zig fmt --check lib/c/network.zig`
- `/home/g/.local/bin/zig test --zig-lib-dir lib lib/c.zig` (`25 passed; 3 skipped; 0 failed`)
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target aarch64-linux-musl -lc -fno-emit-bin`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target aarch64_be-linux-musl -lc -fno-emit-bin`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target x86_64-linux-musl -lc -fno-emit-bin`
- `/home/g/.local/bin/zig build-obj --zig-lib-dir lib lib/c.zig -target powerpc64-linux-musl -lc -fno-emit-bin`

A simplified aarch64_be assembly probe confirmed the inline asm reads `x0` and shifts the high 32 bits. I did not extend the asm workaround to powerpc64/s390x because this branch has no runtime QEMU coverage for those ABIs and the requested powerpc64 cross-compile succeeds.